### PR TITLE
Add CI workflow for pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Run tests
+        run: |
+          pytest --cov


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running on push and PR
- setup Python 3.11, install deps, run `pytest --cov`

## Testing
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_688c637d2854832ba76b43dc7aabe710