### PR TITLE
Add env example and README configuration docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Rename this file to `.env` and set your API keys.
+
+# Required OpenAI API key for the demo.
+OPENAI_API_KEY=
+
+# Optional Tavily API key used for search functionality.
+# TAVILY_API_KEY=

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # agentic-demo
-An agentic demo
+
+An agentic demo.
+
+## Configuration
+
+This project uses environment variables for API keys. Start by copying the
+provided example file and editing it with your credentials:
+
+```bash
+cp .env.example .env
+```
+
+The `OPENAI_API_KEY` variable is required to interact with OpenAI services.
+If you have a Tavily account, you can also set `TAVILY_API_KEY` to enable
+search features.
+


### PR DESCRIPTION
## Summary
- add `.env.example` with OpenAI and optional Tavily keys
- document environment variable setup in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c63852664832ba502a3ec8bd3fd7d