### PR TITLE
Standardize Python version and dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.13'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository demonstrates two main workflows for generating course content us
 
 ## Setup
 
-1. **Python**: Use Python 3.10 or newer.
+1. **Python**: Use Python 3.13 or newer.
 2. **Install dependencies**:
    ```bash
    pip install -r requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "agentic-demo"
+version = "0.1.0"
+requires-python = ">=3.13"
+dependencies = [
+    "openai>=1.98.0",
+    "tavily-python>=0.7.10",
+    "python-dotenv>=1.1.1",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+openai>=1.98.0
+python-dotenv>=1.1.1
+tavily-python>=0.7.10


### PR DESCRIPTION
## Summary
- document Python 3.13 in README
- add `pyproject.toml` with Python requirement and dependencies
- create `requirements.txt` with pinned latest library versions
- update GitHub Actions workflow to use Python 3.13

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c64f401b4832baf5e6c5e16e05310