### PR TITLE
Add multi-stage conversation flow with overlay agent

### DIFF
--- a/app/agents.py
+++ b/app/agents.py
@@ -16,3 +16,29 @@ class ChatAgent:
         """Call the chat completion API with the provided messages."""
         response = openai.ChatCompletion.create(model=self.model, messages=messages)
         return response["choices"][0]["message"]["content"].strip()
+
+
+def _call_agent(prompt: str, agent: ChatAgent | None) -> str:
+    use_agent = agent or ChatAgent()
+    messages = [{"role": "user", "content": prompt}]
+    return use_agent(messages)
+
+
+def plan(topic: str, *, agent: ChatAgent | None = None) -> str:
+    """Generate a short plan for the given topic."""
+    return _call_agent(f"Create an outline for {topic}.", agent)
+
+
+def research(outline: str, *, agent: ChatAgent | None = None) -> str:
+    """Return research notes for the outline."""
+    return _call_agent(f"Provide background facts about: {outline}", agent)
+
+
+def draft(notes: str, *, agent: ChatAgent | None = None) -> str:
+    """Draft content from notes."""
+    return _call_agent(f"Write a short passage using: {notes}", agent)
+
+
+def review(text: str, *, agent: ChatAgent | None = None) -> str:
+    """Review and polish the text."""
+    return _call_agent(f"Improve the following text for clarity:\n{text}", agent)

--- a/app/overlay_agent.py
+++ b/app/overlay_agent.py
@@ -1,0 +1,30 @@
+"""Agent for overlaying additional material onto existing text."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Dict
+
+from .agents import ChatAgent
+
+
+@dataclass
+class OverlayAgent:
+    """Compose new material with existing content using a chat model."""
+
+    agent: ChatAgent | None = None
+
+    def __post_init__(self) -> None:
+        if self.agent is None:
+            self.agent = ChatAgent()
+
+    def __call__(self, original: str, addition: str) -> str:
+        """Merge new material with existing text."""
+        prompt = (
+            "Integrate the addition below into the existing text.\n"
+            f"Existing:\n{original}\n"
+            f"Addition:\n{addition}"
+        )
+        messages: list[Dict[str, str]] = [{"role": "user", "content": prompt}]
+        assert self.agent is not None
+        return self.agent(messages)

--- a/openai/__init__.py
+++ b/openai/__init__.py
@@ -1,0 +1,5 @@
+class ChatCompletion:
+    """Simplistic stub for openai.ChatCompletion."""
+    @staticmethod
+    def create(*args, **kwargs):
+        raise NotImplementedError("openai package not installed")

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,4 +1,4 @@
-from app.agents import ChatAgent
+from app.agents import ChatAgent, plan, research, draft, review
 from unittest.mock import patch
 
 
@@ -11,3 +11,13 @@ def test_chat_agent_calls_openai():
         }
         assert agent(messages) == "hello"
         mock_create.assert_called_once_with(model=agent.model, messages=messages)
+
+
+def test_plan_research_draft_review_calls_agent():
+    with patch.object(ChatAgent, "__call__", return_value="x") as mock:
+        agent = ChatAgent()
+        assert plan("topic", agent=agent) == "x"
+        assert research("plan", agent=agent) == "x"
+        assert draft("research", agent=agent) == "x"
+        assert review("draft", agent=agent) == "x"
+        assert mock.call_count == 4

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,13 +1,36 @@
 from unittest.mock import patch
 
-from app.graph import build_graph
 from app.agents import ChatAgent
+
+from app import graph
+from app.graph import build_graph
+
 
 
 def test_graph_flow():
-    with patch.object(ChatAgent, "__call__", return_value="done") as mock_call:
-        graph = build_graph()
-        result = graph.run("hello")
-        mock_call.assert_called_once()
-        assert result["output"] == "done"
-        assert result["messages"][-1]["content"] == "done"
+    with (
+        patch.object(graph, "plan", return_value="plan") as plan_mock,
+        patch.object(graph, "research", return_value="research") as research_mock,
+        patch.object(graph, "draft", return_value="draft") as draft_mock,
+        patch.object(graph, "review", return_value="review") as review_mock,
+    ):
+        flow = build_graph()
+        result = flow.run("topic")
+        assert result["output"] == "review"
+        assert plan_mock.called and research_mock.called
+        assert draft_mock.called and review_mock.called
+
+def test_graph_with_overlay():
+    from app.overlay_agent import OverlayAgent
+    overlay = OverlayAgent(ChatAgent())
+    with (
+        patch.object(OverlayAgent, "__call__", return_value="ov") as ov_mock,
+        patch.object(graph, "plan", return_value="plan"),
+        patch.object(graph, "research", return_value="research"),
+        patch.object(graph, "draft", return_value="draft"),
+        patch.object(graph, "review", return_value="review"),
+    ):
+        flow = build_graph(overlay)
+        result = flow.run("topic")
+        assert result["output"] == "ov"
+        ov_mock.assert_called_once()

--- a/tests/test_overlay_agent.py
+++ b/tests/test_overlay_agent.py
@@ -1,0 +1,15 @@
+from app.overlay_agent import OverlayAgent
+from app.agents import ChatAgent
+from unittest.mock import patch
+
+
+def test_overlay_agent_composes_prompt():
+    with patch.object(ChatAgent, "__call__", return_value="result") as mock:
+        agent = ChatAgent()
+        oa = OverlayAgent(agent)
+        out = oa("orig", "add")
+        assert out == "result"
+        assert mock.call_count == 1
+        called_messages = mock.call_args[0][0]
+        assert "orig" in called_messages[0]["content"]
+        assert "add" in called_messages[0]["content"]


### PR DESCRIPTION
## Summary
- expand `app.agents` with planning/research/drafting/review callbacks
- implement sequential graph factory supporting an optional overlay agent
- provide `OverlayAgent` for curriculum enrichment
- create a small `openai` stub for offline tests
- add comprehensive tests for new agents, graph logic and overlay agent

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c6575f058832ba155ff64ba973e29