### PR TITLE
Add prompt templates and fallback YAML loader

### DIFF
--- a/app/prompts/draft.yaml
+++ b/app/prompts/draft.yaml
@@ -1,0 +1,2 @@
+prompt: |
+  Write a short passage using: {notes}

--- a/app/prompts/overlay.yaml
+++ b/app/prompts/overlay.yaml
@@ -1,0 +1,6 @@
+prompt: |
+  Integrate the addition below into the existing text.
+  Existing:
+  {original}
+  Addition:
+  {addition}

--- a/app/prompts/plan.yaml
+++ b/app/prompts/plan.yaml
@@ -1,0 +1,2 @@
+prompt: |
+  Create an outline for {topic}.

--- a/app/prompts/research.yaml
+++ b/app/prompts/research.yaml
@@ -1,0 +1,2 @@
+prompt: |
+  Provide background facts about: {outline}

--- a/app/prompts/review.yaml
+++ b/app/prompts/review.yaml
@@ -1,0 +1,3 @@
+prompt: |
+  Improve the following text for clarity:
+  {text}

--- a/app/utils.py
+++ b/app/utils.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import pathlib
-import yaml
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    yaml = None
 
 PROMPTS_PATH = pathlib.Path(__file__).parent / "prompts"
 
@@ -29,5 +32,22 @@ def load_prompt(name: str) -> str:
     path = PROMPTS_PATH / f"{name}.yaml"
     if not path.exists():
         raise FileNotFoundError(path)
-    data = yaml.safe_load(path.read_text())
-    return data["content"]
+    text = path.read_text()
+    data = _safe_load(text)
+    return data.get("content") or data["prompt"]
+
+
+def _safe_load(text: str) -> dict:
+    """Load YAML text with a minimal fallback parser."""
+    if yaml is not None:
+        return yaml.safe_load(text)
+
+    lines = text.splitlines()
+    if not lines:
+        return {}
+    key, _, rest = lines[0].partition(":")
+    value = rest.strip()
+    if value == "|":
+        from textwrap import dedent
+        value = dedent("\n".join(lines[1:])).lstrip()
+    return {key.strip(): value}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import pytest
+import pathlib
 
 from app import utils
 
@@ -12,3 +13,27 @@ def test_load_prompt(tmp_path, monkeypatch):
 
     with pytest.raises(FileNotFoundError):
         utils.load_prompt("missing")
+
+
+def test_load_prompt_with_prompt_key(tmp_path, monkeypatch):
+    prom_dir = tmp_path / "prompts"
+    prom_dir.mkdir()
+    (prom_dir / "new.yaml").write_text("prompt: hi")
+    monkeypatch.setattr(utils, "PROMPTS_PATH", prom_dir)
+    assert utils.load_prompt("new") == "hi"
+
+
+def test_safe_load_without_yaml(monkeypatch):
+    text = "prompt: |\n  hello\n  there"
+    monkeypatch.setattr(utils, "yaml", None)
+    data = utils._safe_load(text)
+    assert data == {"prompt": "hello\nthere"}
+
+
+def test_repository_prompts_load(monkeypatch):
+    monkeypatch.setattr(utils, "PROMPTS_PATH", pathlib.Path("app/prompts"))
+    assert utils.load_prompt("plan").startswith("Create an outline")
+    assert utils.load_prompt("research").startswith("Provide background")
+    assert utils.load_prompt("draft").startswith("Write a short passage")
+    assert utils.load_prompt("review").startswith("Improve the following")
+    assert utils.load_prompt("overlay").startswith("Integrate the addition")


### PR DESCRIPTION
## Summary
- add conversation prompt templates for plan, research, draft, review and overlay
- improve `load_prompt` to support optional PyYAML dependency
- provide fallback YAML parser
- extend tests for prompt loading

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c67930f20832ba51bba69efb1f4c0