### PR TITLE
Add async graph dictionary test

### DIFF
--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,5 +1,8 @@
 from unittest.mock import patch
 
+import asyncio
+import pytest
+
 from app.agents import ChatAgent
 
 from app import graph
@@ -33,4 +36,24 @@ def test_graph_with_overlay():
         flow = build_graph(overlay)
         result = flow.run("topic")
         assert result["output"] == "ov"
+        ov_mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_graph_async_overlay_dict():
+    """Graph run should return a dict with slides or ai_overlay when overlay outputs one."""
+    from app.overlay_agent import OverlayAgent
+
+    overlay = OverlayAgent(ChatAgent())
+    with (
+        patch.object(OverlayAgent, "__call__", return_value={"slides": []}) as ov_mock,
+        patch.object(graph, "plan", return_value="plan"),
+        patch.object(graph, "research", return_value="research"),
+        patch.object(graph, "draft", return_value="draft"),
+        patch.object(graph, "review", return_value="review"),
+    ):
+        flow = build_graph(overlay)
+        result = await asyncio.to_thread(flow.run, "topic")
+        assert isinstance(result["output"], dict)
+        assert "slides" in result["output"] or "ai_overlay" in result["output"]
         ov_mock.assert_called_once()


### PR DESCRIPTION
## Summary
- exercise `build_graph` asynchronously
- check overlay output when it returns a dictionary

## Testing
- `PYTHONPATH=$(pwd) pytest -q`
- `PYTHONPATH=$(pwd) pytest --cov=app -q`

------
https://chatgpt.com/codex/tasks/task_e_688c67b68aec832bbadce3c30aa9d4b5