### PR TITLE
Implement async CLI demo

### DIFF
--- a/scripts/run_demo.py
+++ b/scripts/run_demo.py
@@ -1,21 +1,65 @@
-"""Run the FastAPI demo app."""
+"""Command-line interface to run the demo graph."""
 
 from __future__ import annotations
 
-import uvicorn
-from fastapi import FastAPI
+import argparse
+import asyncio
+from typing import Optional
 
 from app.graph import build_graph
-
-app = FastAPI()
-flow = build_graph()
+from app.overlay_agent import OverlayAgent
 
 
-@app.post("/chat")
-async def chat(input: str) -> dict:
-    result = flow.run(input)
-    return {"response": result["output"]}
+# ---------------------------------------------------------------------------
+# argument parsing
+# ---------------------------------------------------------------------------
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    """Parse command line arguments.
+
+    Parameters
+    ----------
+    argv:
+        List of argument strings. If ``None`` the arguments are taken from
+        ``sys.argv``.
+
+    Returns
+    -------
+    argparse.Namespace
+        Namespace with ``topic`` and ``mode`` attributes.
+    """
+    parser = argparse.ArgumentParser(description="Run agentic demo")
+    parser.add_argument(
+        "--topic",
+        required=True,
+        help="Topic to generate material for.",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["basic", "overlay"],
+        default="basic",
+        help="Execution mode: 'basic' or 'overlay'",
+    )
+    return parser.parse_args(argv)
 
 
-if __name__ == "__main__":
-    uvicorn.run("scripts.run_demo:app", host="0.0.0.0", port=8000)
+# ---------------------------------------------------------------------------
+# core execution helpers
+# ---------------------------------------------------------------------------
+
+async def run_demo(topic: str, mode: str) -> dict[str, str]:
+    """Run the conversation flow asynchronously and return the result."""
+    overlay = OverlayAgent() if mode == "overlay" else None
+    flow = build_graph(overlay)
+    return await asyncio.to_thread(flow.run, topic)
+
+
+async def main(argv: Optional[list[str]] = None) -> None:
+    """Entry point for the demo script."""
+    args = parse_args(argv)
+    result = await run_demo(args.topic, args.mode)
+    print(result["output"])
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution only
+    asyncio.run(main())

--- a/tests/test_run_demo.py
+++ b/tests/test_run_demo.py
@@ -1,0 +1,36 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import scripts.run_demo as rd
+
+
+def test_parse_args_defaults():
+    args = rd.parse_args(["--topic", "abc"])
+    assert args.topic == "abc"
+    assert args.mode == "basic"
+
+
+def test_run_demo_basic_executes_flow():
+    fake_graph = SimpleNamespace(run=lambda topic: {"output": f"out-{topic}"})
+    with patch("scripts.run_demo.build_graph", return_value=fake_graph) as build:
+        result = asyncio.run(rd.run_demo("hello", "basic"))
+        build.assert_called_once_with(None)
+        assert result["output"] == "out-hello"
+
+
+def test_run_demo_overlay_builds_overlay():
+    fake_graph = SimpleNamespace(run=lambda topic: {"output": "done"})
+    with patch("scripts.run_demo.build_graph", return_value=fake_graph) as build:
+        result = asyncio.run(rd.run_demo("hello", "overlay"))
+        assert result["output"] == "done"
+        build.assert_called_once()
+        assert build.call_args[0][0] is not None
+
+
+def test_main_prints_result(capsys):
+    fake_graph = SimpleNamespace(run=lambda topic: {"output": "printed"})
+    with patch("scripts.run_demo.build_graph", return_value=fake_graph):
+        asyncio.run(rd.main(["--topic", "abc"]))
+    captured = capsys.readouterr()
+    assert "printed" in captured.out


### PR DESCRIPTION
## Summary
- rewrite `scripts/run_demo.py` into a CLI script
- add functions for argument parsing and async execution
- test CLI helpers

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c67a2a6e4832ba69464426080d67f