### PR TITLE
Add Dockerfile and API endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["uvicorn", "app.api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/app/api.py
+++ b/app/api.py
@@ -1,0 +1,17 @@
+"""FastAPI application for agentic demo."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from .graph import build_graph
+
+app = FastAPI()
+flow = build_graph()
+
+
+@app.post("/chat")
+async def chat(input: str) -> dict:
+    """Handle chat requests returning the final response."""
+    result = flow.run(input)
+    return {"response": result["output"]}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,14 @@
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+from app.api import app
+from app.agents import ChatAgent
+
+
+def test_chat_endpoint():
+    client = TestClient(app)
+    with patch.object(ChatAgent, "__call__", return_value="ok"):
+        response = client.post('/chat', params={'input': 'topic'})
+    assert response.status_code == 200
+    data = response.json()
+    assert data == {"response": "ok"}

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -1,0 +1,10 @@
+import pathlib
+
+
+def test_dockerfile_configuration():
+    path = pathlib.Path('Dockerfile')
+    assert path.exists(), 'Dockerfile should exist'
+    contents = path.read_text()
+    lines = [line.strip() for line in contents.splitlines() if line.strip()]
+    assert lines[0] == 'FROM python:3.11-slim'
+    assert any(line.startswith('CMD ') and 'uvicorn' in line and 'app.api:app' in line for line in lines)


### PR DESCRIPTION
## Summary
- add a Dockerfile for launching the FastAPI service with uvicorn
- implement `app.api` with a FastAPI application
- test the new API module
- test Dockerfile contents

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c67bafc7c832bb6e1ebd8f79ed114