### PR TITLE
Align with Python 3.13

### DIFF
--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -6,5 +6,5 @@ def test_dockerfile_configuration():
     assert path.exists(), 'Dockerfile should exist'
     contents = path.read_text()
     lines = [line.strip() for line in contents.splitlines() if line.strip()]
-    assert lines[0] == 'FROM python:3.11-slim'
+    assert lines[0] == 'FROM python:3.13-slim'
     assert any(line.startswith('CMD ') and 'uvicorn' in line and 'app.api:app' in line for line in lines)


### PR DESCRIPTION
## Summary
- update Dockerfile test to expect Python 3.13

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_688c6b498f9c832bba0f7ecf0b25c47c