### PR TITLE
Graceful offline mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ This project is released under the [Unlicense](LICENSE).
    ```bash
    python -m agentic_demo.cli
    ```
+4. **Try the demo script**:
+   ```bash
+   python scripts/run_demo.py --topic "Quantum" 
+   ```
 
 ## Configuration
 
@@ -30,8 +34,8 @@ provided example file and editing it with your credentials:
 cp .env.example .env
 ```
 
-The `OPENAI_API_KEY` variable is required to interact with OpenAI services.
-If you have a Tavily account, you can also set `TAVILY_API_KEY` to enable
+The `OPENAI_API_KEY` variable enables real responses from OpenAI services. If it
+is unset the demo prints placeholder text. If you have a Tavily account, you can also set `TAVILY_API_KEY` to enable
 search features.
 
 ## Running Tests

--- a/scripts/run_demo.py
+++ b/scripts/run_demo.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import os
 from typing import Optional
 
 from app.graph import build_graph
@@ -57,6 +58,8 @@ async def run_demo(topic: str, mode: str) -> dict[str, str]:
 async def main(argv: Optional[list[str]] = None) -> None:
     """Entry point for the demo script."""
     args = parse_args(argv)
+    if not os.environ.get("OPENAI_API_KEY"):
+        print("OPENAI_API_KEY not set - using placeholder responses.")
     result = await run_demo(args.topic, args.mode)
     print(result["output"])
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -21,3 +21,16 @@ def test_plan_research_draft_review_calls_agent():
         assert draft("research", agent=agent) == "x"
         assert review("draft", agent=agent) == "x"
         assert mock.call_count == 4
+
+
+def test_chat_agent_falls_back_when_openai_unavailable():
+    agent = ChatAgent()
+    messages = [{"role": "user", "content": "hi"}]
+    with patch("openai.ChatCompletion.create", side_effect=NotImplementedError):
+        assert agent(messages) == "OpenAI API unavailable"
+
+
+def test_chat_agent_custom_fallback_message():
+    agent = ChatAgent(fallback="oops")
+    with patch("openai.ChatCompletion.create", side_effect=NotImplementedError):
+        assert agent([{"role": "user", "content": "ignored"}]) == "oops"

--- a/tests/test_run_demo.py
+++ b/tests/test_run_demo.py
@@ -34,3 +34,12 @@ def test_main_prints_result(capsys):
         asyncio.run(rd.main(["--topic", "abc"]))
     captured = capsys.readouterr()
     assert "printed" in captured.out
+
+
+def test_main_warns_when_missing_api_key(monkeypatch, capsys):
+    fake_graph = SimpleNamespace(run=lambda topic: {"output": "any"})
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with patch("scripts.run_demo.build_graph", return_value=fake_graph):
+        asyncio.run(rd.main(["--topic", "abc"]))
+    captured = capsys.readouterr()
+    assert "OPENAI_API_KEY not set" in captured.out


### PR DESCRIPTION
## Summary
- handle missing `openai` in `ChatAgent`
- warn when `OPENAI_API_KEY` is absent in `run_demo`
- clarify README instructions
- add tests for offline mode

## Testing
- `pytest -q`
- `pytest --cov=app --cov=scripts --cov=tests -q`

------
https://chatgpt.com/codex/tasks/task_e_688c70873ef8832b8cef966eb499d2f0