### PR TITLE
Refactor graph to use langgraph

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -13,5 +13,5 @@ flow = build_graph()
 @app.post("/chat")
 async def chat(input: str) -> dict:
     """Handle chat requests returning the final response."""
-    result = flow.run(input)
+    result = await flow.arun(input)
     return {"response": result["output"]}

--- a/app/graph.py
+++ b/app/graph.py
@@ -1,36 +1,120 @@
-"""Conversation flow implementation."""
+"""Conversation flow implemented with langgraph."""
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
-from typing import Callable, Dict, List, Optional
+from typing import Dict, List, Optional, TypedDict
+
+from langgraph.graph import StateGraph, END, START
 
 from .agents import plan, research, draft, review
 from .overlay_agent import OverlayAgent
 
 
+class GraphState(TypedDict):
+    """State shared across graph nodes."""
+
+    text: str
+    draft: str
+    approved: bool
+    history: List[str]
+
+
 @dataclass
 class ConversationGraph:
-    """Simple sequential graph executing callables."""
+    """Wrapper around a compiled langgraph."""
 
-    nodes: List[Callable[[str], str]]
+    graph: StateGraph
+
+    async def arun(self, input: str) -> Dict[str, str]:
+        """Execute the graph asynchronously."""
+        state: GraphState = {
+            "text": input,
+            "draft": "",
+            "approved": False,
+            "history": [],
+        }
+        result: GraphState = await self.graph.ainvoke(state)
+        return {"messages": result["history"], "output": result["text"]}
 
     def run(self, input: str) -> Dict[str, str]:
-        """Run the graph on the given input."""
-        state = input
-        history: List[str] = []
-        for node in self.nodes:
-            state = node(state)
-            history.append(state)
-        return {"messages": history, "output": state}
+        """Execute the graph synchronously."""
+        return asyncio.run(self.arun(input))
 
 
 def build_graph(overlay: Optional[OverlayAgent] = None) -> ConversationGraph:
-    """Create the default conversation graph."""
+    """Create the conversation graph using langgraph."""
 
-    def review_node(text: str) -> str:
-        result = review(text)
-        return overlay(text, result) if overlay else result
+    async def plan_node(state: GraphState) -> GraphState:
+        text = plan(state["text"])
+        return {
+            "text": text,
+            "draft": state["draft"],
+            "approved": False,
+            "history": state["history"] + [text],
+        }
 
-    nodes = [plan, research, draft, review_node]
-    return ConversationGraph(nodes=nodes)
+    async def research_node(state: GraphState) -> GraphState:
+        text = research(state["text"])
+        return {
+            "text": text,
+            "draft": state["draft"],
+            "approved": False,
+            "history": state["history"] + [text],
+        }
+
+    async def draft_node(state: GraphState) -> GraphState:
+        text = draft(state["text"])
+        return {
+            "text": text,
+            "draft": text,
+            "approved": False,
+            "history": state["history"] + [text],
+        }
+
+    async def review_node(state: GraphState) -> GraphState:
+        result = review(state["text"])
+        approved = "retry" not in result
+        return {
+            "text": result,
+            "draft": state["draft"],
+            "approved": approved,
+            "history": state["history"] + [result],
+        }
+
+    async def overlay_node(state: GraphState) -> GraphState:
+        assert overlay is not None
+        result = overlay(state["draft"], state["text"])
+        return {
+            "text": result,
+            "draft": state["draft"],
+            "approved": True,
+            "history": state["history"] + [result],
+        }
+
+    builder: StateGraph = StateGraph(GraphState)
+    builder.add_node("plan", plan_node)
+    builder.add_node("research", research_node)
+    builder.add_node("draft", draft_node)
+    builder.add_node("review", review_node)
+    if overlay:
+        builder.add_node("overlay", overlay_node)
+
+    builder.add_edge(START, "plan")
+    builder.add_edge("plan", "research")
+    builder.add_edge("research", "draft")
+    builder.add_edge("draft", "review")
+
+    def after_review(state: GraphState):
+        if state["approved"]:
+            return "overlay" if overlay else END
+        return "draft"
+
+    builder.add_conditional_edges("review", after_review)
+
+    if overlay:
+        builder.add_edge("overlay", END)
+
+    graph = builder.compile()
+    return ConversationGraph(graph=graph)


### PR DESCRIPTION
## Summary
- use `langgraph` to orchestrate the conversation flow
- add async `arun` method and update API usage
- adjust tests for looping and overlay behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c7238e258832bb6873c01f44cb139