### PR TITLE
Move openai stub and update imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ This project is released under the [Unlicense](LICENSE).
    ```bash
    pip install -r requirements.txt
    ```
+   The optional `openai` dependency enables real API calls. Without it,
+   the bundled `openai_stub` module provides placeholder responses.
 3. **Start the API server**:
    ```bash
    uvicorn app.api:app --reload

--- a/app/agents.py
+++ b/app/agents.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-import openai
+try:  # attempt to use the real client if available
+    import openai  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback for testing
+    import openai_stub as openai  # type: ignore
 from typing import Dict, Any
 
 FALLBACK_MESSAGE = "OpenAI API unavailable"

--- a/openai/__init__.py
+++ b/openai/__init__.py
@@ -1,5 +1,0 @@
-class ChatCompletion:
-    """Simplistic stub for openai.ChatCompletion."""
-    @staticmethod
-    def create(*args, **kwargs):
-        raise NotImplementedError("openai package not installed")

--- a/openai_stub/__init__.py
+++ b/openai_stub/__init__.py
@@ -1,0 +1,10 @@
+class ChatCompletion:
+    """Simplistic stub for openai.ChatCompletion.
+
+    Returns a placeholder response when the real ``openai`` package is
+    unavailable.
+    """
+
+    @staticmethod
+    def create(*args, **kwargs):
+        return {"choices": [{"message": {"content": "stub response"}}]}

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 def test_chat_agent_calls_openai():
     agent = ChatAgent()
     messages = [{"role": "user", "content": "hi"}]
-    with patch("openai.ChatCompletion.create") as mock_create:
+    with patch("app.agents.openai.ChatCompletion.create") as mock_create:
         mock_create.return_value = {
             "choices": [{"message": {"content": "hello"}}]
         }
@@ -26,11 +26,11 @@ def test_plan_research_draft_review_calls_agent():
 def test_chat_agent_falls_back_when_openai_unavailable():
     agent = ChatAgent()
     messages = [{"role": "user", "content": "hi"}]
-    with patch("openai.ChatCompletion.create", side_effect=NotImplementedError):
+    with patch("app.agents.openai.ChatCompletion.create", side_effect=NotImplementedError):
         assert agent(messages) == "OpenAI API unavailable"
 
 
 def test_chat_agent_custom_fallback_message():
     agent = ChatAgent(fallback="oops")
-    with patch("openai.ChatCompletion.create", side_effect=NotImplementedError):
+    with patch("app.agents.openai.ChatCompletion.create", side_effect=NotImplementedError):
         assert agent([{"role": "user", "content": "ignored"}]) == "oops"


### PR DESCRIPTION
## Summary
- move stub module to `openai_stub` package
- fallback to the real `openai` package if installed
- patch tests to use the new module
- document optional openai dependency in README

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c7956d8a4832b81e00764441272dc