### PR TITLE
Ensure app package installed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,10 @@ test = [
     "pytest-cov>=4.1",
     "pytest-asyncio>=0.23",
 ]
+
+[tool.setuptools]
+packages = [
+    "app",
+    "openai_stub",
+    "scripts",
+]

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Utility command-line interfaces for the demo project."""


### PR DESCRIPTION
## Summary
- include app, openai_stub and scripts packages in setuptools config
- package the scripts directory so command-line modules work after install

## Testing
- `pip install -e .`
- `pytest -q`
- `python -m scripts.run_demo --topic demo`

------
https://chatgpt.com/codex/tasks/task_e_688c7f8021e4832bbb681044ab37e65a