### PR TITLE
Bump langgraph dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "openai>=1.25.0",
     "tavily-python>=0.7.10",
     "python-dotenv>=1.1.1",
+    "langgraph>=0.9.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 openai>=1.25.0
 python-dotenv>=1.1.1
 tavily-python>=0.7.10
-langgraph>=0.6.0
+langgraph>=0.9.0
 tiktoken
 httpx
 langsmith


### PR DESCRIPTION
## Summary
- bump langgraph to 0.9.0 in requirements
- add langgraph to project dependencies

## Testing
- `pip install langgraph>=0.9.0`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c810ab71c832bb59ac4688fc3b676