### PR TITLE
Add FastAPI web UI with websocket streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,11 @@ and the demo script supports `python -m dotenv run -- python scripts/run_demo.py
 
 ## API
 
-The FastAPI app exposes a single endpoint:
+The FastAPI app exposes several endpoints:
 
 - `POST /chat?input=TEXT` – runs the conversation flow and returns
   `{"response": "..."}`.
+- `GET /ui` – serves a simple browser UI for interactive use.
 
 Start the server using the command shown in the setup section and send requests
 to `http://localhost:8000/chat`.

--- a/app/api.py
+++ b/app/api.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from fastapi import FastAPI
+from web.router import router as web_router
 
 from .graph import build_graph
 
 app = FastAPI()
 flow = build_graph()
+app.include_router(web_router)
 
 
 @app.post("/chat")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "tavily-python>=0.7.10",
     "python-dotenv>=1.1.1",
     "langgraph>=0.9.0",
+    "python-docx",
 ]
 
 [project.optional-dependencies]
@@ -25,4 +26,5 @@ packages = [
     "app",
     "openai_stub",
     "scripts",
+    "web",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ httpx
 langsmith
 fastapi
 uvicorn[standard]
+python-docx

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,32 @@
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+import pytest
+
+from app.api import app
+
+
+def test_websocket_streaming_basic():
+    client = TestClient(app)
+    with (
+        patch("web.router.plan", return_value="p"),
+        patch("web.router.research", return_value="r"),
+        patch("web.router.draft", return_value="d"),
+        patch("web.router.review", return_value="done"),
+    ):
+        with client.websocket_connect("/stream?input=x&mode=basic") as ws:
+            assert ws.receive_text() == "p"
+            assert ws.receive_text() == "r"
+            assert ws.receive_text() == "d"
+            assert ws.receive_text() == "done"
+            with pytest.raises(RuntimeError):
+                ws.receive_text()
+
+
+def test_export_docx():
+    client = TestClient(app)
+    with patch("web.router._to_docx_bytes", return_value=b"doc") as mock_fn:
+        resp = client.post("/export/docx", json={"text": "hi"})
+    assert resp.status_code == 200
+    mock_fn.assert_called_once_with("hi")
+    assert resp.headers["Content-Disposition"].startswith("attachment")
+    assert resp.content == b"doc"

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -1,0 +1,1 @@
+"""Web UI package for the agentic demo."""

--- a/web/router.py
+++ b/web/router.py
@@ -1,0 +1,92 @@
+"""Web UI routes and websocket streaming for agentic demo."""
+
+from __future__ import annotations
+
+from io import BytesIO
+from typing import AsyncIterator
+import pathlib
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Response
+from fastapi.responses import HTMLResponse
+
+from app.graph import plan, research, draft, review
+from app.overlay_agent import OverlayAgent
+
+try:
+    from docx import Document
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    Document = None  # type: ignore
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _run_stream(text: str, mode: str) -> AsyncIterator[str]:
+    """Run the conversation flow yielding intermediate results."""
+    overlay = OverlayAgent() if mode == "overlay" else None
+    async def _inner() -> AsyncIterator[str]:
+        nonlocal text
+        while True:
+            text = plan(text)
+            yield text
+            text = research(text)
+            yield text
+            draft_text = draft(text)
+            yield draft_text
+            result = review(draft_text)
+            yield result
+            if "retry" not in result:
+                if overlay:
+                    text = overlay(draft_text, result)
+                    yield text
+                else:
+                    text = result
+                break
+            text = result
+    return _inner()
+
+
+def _to_docx_bytes(text: str) -> bytes:
+    """Convert plain text to a DOCX binary."""
+    if Document is None:  # pragma: no cover - dependency optional
+        return text.encode()
+    doc = Document()
+    for line in text.splitlines():
+        doc.add_paragraph(line)
+    buffer = BytesIO()
+    doc.save(buffer)
+    return buffer.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# routes
+# ---------------------------------------------------------------------------
+
+@router.get("/ui")
+async def ui() -> HTMLResponse:
+    """Serve the demo HTML page."""
+    html = (pathlib.Path(__file__).with_name("templates") / "ui.html").read_text()
+    return HTMLResponse(html)
+
+
+@router.websocket("/stream")
+async def stream(websocket: WebSocket, input: str, mode: str = "basic") -> None:
+    """Stream conversation results over a websocket."""
+    await websocket.accept()
+    try:
+        async for msg in _run_stream(input, mode):
+            await websocket.send_text(msg)
+    except WebSocketDisconnect:  # pragma: no cover - client closed early
+        pass
+
+
+@router.post("/export/docx")
+async def export_docx(payload: dict) -> Response:
+    """Return DOCX file for provided text."""
+    text = payload.get("text", "")
+    data = _to_docx_bytes(text)
+    headers = {"Content-Disposition": "attachment; filename=output.docx"}
+    return Response(content=data, media_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document", headers=headers)

--- a/web/templates/ui.html
+++ b/web/templates/ui.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>Agentic Demo</title>
+<style>
+body { font-family: sans-serif; margin: 2em; }
+textarea { width: 100%; box-sizing: border-box; }
+#output { border: 1px solid #ccc; padding: 0.5em; white-space: pre-wrap; min-height: 6em; margin-top: 1em; }
+</style>
+</head>
+<body>
+<h1>Agentic Demo</h1>
+<textarea id="text" rows="4" placeholder="Enter topic"></textarea>
+<select id="mode">
+  <option value="basic">basic</option>
+  <option value="overlay">overlay</option>
+</select>
+<button id="run">Run</button>
+<div id="output"></div>
+<button id="save-md">Download Markdown</button>
+<button id="save-docx">Download DOCX</button>
+<script>
+(function() {
+  let finalText = "";
+  const out = document.getElementById('output');
+  document.getElementById('run').onclick = function() {
+    out.textContent = "";
+    finalText = "";
+    const text = document.getElementById('text').value;
+    const mode = document.getElementById('mode').value;
+    const ws = new WebSocket(`ws://${location.host}/stream?input=${encodeURIComponent(text)}&mode=${mode}`);
+    ws.onmessage = ev => { finalText += ev.data + "\n"; out.textContent = finalText; };
+    ws.onclose = () => { window.demoOutput = finalText; };
+  };
+  document.getElementById('save-md').onclick = function() {
+    const blob = new Blob([window.demoOutput || ""], {type: 'text/markdown'});
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob); a.download = 'output.md'; a.click();
+  };
+  document.getElementById('save-docx').onclick = function() {
+    fetch('/export/docx', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({text: window.demoOutput || ''})})
+      .then(r => r.blob())
+      .then(b => { const a = document.createElement('a'); a.href = URL.createObjectURL(b); a.download = 'output.docx'; a.click(); });
+  };
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `web` module with html UI and websocket route
- expose `/ui`, `/stream` and `/export/docx` via router
- integrate router into FastAPI app
- document new endpoint
- test websocket streaming and docx export

## Testing
- `pytest -q tests/test_web.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688c85c5942c832b8ca5e62af1244274