### PR TITLE
Fix Dockerfile version check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.x'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3-slim
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This project is released under the [Unlicense](LICENSE).
 
 ## Setup
 
-1. **Python**: Use Python 3.11 or newer.
+1. **Python**: Use the latest Python 3 release.
 2. **Install dependencies**:
    ```bash
    pip install -r requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "agentic-demo"
 version = "0.1.0"
-requires-python = ">=3.11"
+requires-python = ">=3"
 dependencies = [
     "openai>=1.25.0",
     "tavily-python>=0.7.10",
@@ -34,14 +34,12 @@ packages = [
     "web",
 ]
 
+
 [tool.black]
-target-version = ['py311']
 
 [tool.ruff]
-target-version = 'py311'
 line-length = 88
 
 [tool.mypy]
-python_version = 3.11
 ignore_missing_imports = true
 disallow_untyped_defs = true

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -6,5 +6,5 @@ def test_dockerfile_configuration():
     assert path.exists(), 'Dockerfile should exist'
     contents = path.read_text()
     lines = [line.strip() for line in contents.splitlines() if line.strip()]
-    assert lines[0] == 'FROM python:3.11-slim'
+    assert lines[0] == 'FROM python:3-slim'
     assert any(line.startswith('CMD ') and 'uvicorn' in line and 'app.api:app' in line for line in lines)


### PR DESCRIPTION
## Summary
- unpin Python versions across config
- update Dockerfile and README to reference latest Python 3
- adjust CI and tests to look for `python:3-slim`

## Testing
- `ruff check .`
- `mypy .` *(fails: Function is missing a return type annotation)*
- `pytest --cov` *(fails: unrecognized arguments: --cov)*

------
https://chatgpt.com/codex/tasks/task_e_688c8bb245a8832b8f99b0b4bb339cfb