### PR TITLE
Improve CI quality checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,15 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install pytest pytest-asyncio pytest-cov
+          pip install -e '.[dev,test]'
+      - name: Check formatting
+        run: black --check .
+      - name: Lint
+        run: ruff .
+      - name: Type check
+        run: mypy .
+      - name: Security scan
+        run: bandit -q -r app openai_stub scripts web
       - name: Run tests
         run: |
           export PYTHONPATH=$PWD

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,12 +8,18 @@ This repository uses automated code quality tooling for all Python sources.
 ## Linting
 - Execute `ruff .` to check style and catch common bugs.
 
+## Security
+- Run `bandit -q -r app openai_stub scripts web` to scan for vulnerabilities.
+
 ## Static Analysis
 - Run `mypy .` to perform type checking.
 
 ## Testing
-- Install dependencies with `pip install -e .[test]`.
+- Install dependencies with `pip install -e '.[dev,test]'`.
 - Run the full suite with `pytest --cov`.
+
+The CI workflow mirrors these commands and also verifies formatting, linting,
+type checking and security scanning. Run them locally before committing to avoid failures.
 
 ### Development Process
 - Follow Test Driven Development.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ Open `http://localhost:8000/ui` for the web interface or send requests to
 Install the development dependencies and run the test suite using `pytest`:
 
 ```bash
-pip install -r requirements-dev.txt
+pip install -e '.[dev,test]'
 pytest
 ```
+
+## Code Quality
+
+Ensure consistent formatting, linting and static analysis by running:
+
+```bash
+black .
+ruff .
+mypy .
+bandit -q -r app openai_stub scripts web
+```
+
+The CI workflow runs these same commands and a security scan along with the test suite.

--- a/app/overlay_agent.py
+++ b/app/overlay_agent.py
@@ -26,5 +26,6 @@ class OverlayAgent:
             f"Addition:\n{addition}"
         )
         messages: list[Dict[str, str]] = [{"role": "user", "content": prompt}]
-        assert self.agent is not None
+        if self.agent is None:
+            raise AssertionError("agent not configured")
         return self.agent(messages)

--- a/app/utils.py
+++ b/app/utils.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import pathlib
+
 try:
-    import yaml
+    import yaml  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
     yaml = None
 
@@ -49,5 +50,6 @@ def _safe_load(text: str) -> dict:
     value = rest.strip()
     if value == "|":
         from textwrap import dedent
+
         value = dedent("\n".join(lines[1:])).lstrip()
     return {key.strip(): value}

--- a/openai_stub/__init__.py
+++ b/openai_stub/__init__.py
@@ -1,3 +1,6 @@
+from typing import Any, Dict
+
+
 class ChatCompletion:
     """Simplistic stub for openai.ChatCompletion.
 
@@ -6,5 +9,5 @@ class ChatCompletion:
     """
 
     @staticmethod
-    def create(*args, **kwargs):
+    def create(*args: Any, **kwargs: Any) -> Dict[str, list[Dict[str, Dict[str, str]]]]:
         return {"choices": [{"message": {"content": "stub response"}}]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dev = [
     "black>=24.3",
     "ruff>=0.4",
     "mypy>=1.8",
+    "bandit>=1.7",
 ]
 
 [tool.setuptools]
@@ -43,3 +44,4 @@ line-length = 88
 [tool.mypy]
 ignore_missing_imports = true
 disallow_untyped_defs = true
+exclude = ["tests/"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ pytest-asyncio>=0.23
 black>=24.3
 ruff>=0.4
 mypy>=1.8
+bandit>=1.7

--- a/scripts/run_demo.py
+++ b/scripts/run_demo.py
@@ -15,6 +15,7 @@ from app.overlay_agent import OverlayAgent
 # argument parsing
 # ---------------------------------------------------------------------------
 
+
 def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     """Parse command line arguments.
 
@@ -48,7 +49,8 @@ def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
 # core execution helpers
 # ---------------------------------------------------------------------------
 
-async def run_demo(topic: str, mode: str) -> dict[str, str]:
+
+async def run_demo(topic: str, mode: str) -> dict[str, list[str] | str]:
     """Run the conversation flow asynchronously and return the result."""
     overlay = OverlayAgent() if mode == "overlay" else None
     flow = build_graph(overlay)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -6,9 +6,7 @@ def test_chat_agent_calls_openai():
     agent = ChatAgent()
     messages = [{"role": "user", "content": "hi"}]
     with patch("app.agents.openai.ChatCompletion.create") as mock_create:
-        mock_create.return_value = {
-            "choices": [{"message": {"content": "hello"}}]
-        }
+        mock_create.return_value = {"choices": [{"message": {"content": "hello"}}]}
         assert agent(messages) == "hello"
         mock_create.assert_called_once_with(model=agent.model, messages=messages)
 
@@ -26,11 +24,15 @@ def test_plan_research_draft_review_calls_agent():
 def test_chat_agent_falls_back_when_openai_unavailable():
     agent = ChatAgent()
     messages = [{"role": "user", "content": "hi"}]
-    with patch("app.agents.openai.ChatCompletion.create", side_effect=NotImplementedError):
+    with patch(
+        "app.agents.openai.ChatCompletion.create", side_effect=NotImplementedError
+    ):
         assert agent(messages) == "OpenAI API unavailable"
 
 
 def test_chat_agent_custom_fallback_message():
     agent = ChatAgent(fallback="oops")
-    with patch("app.agents.openai.ChatCompletion.create", side_effect=NotImplementedError):
+    with patch(
+        "app.agents.openai.ChatCompletion.create", side_effect=NotImplementedError
+    ):
         assert agent([{"role": "user", "content": "ignored"}]) == "oops"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,7 +8,7 @@ from app.agents import ChatAgent
 def test_chat_endpoint():
     client = TestClient(app)
     with patch.object(ChatAgent, "__call__", return_value="ok"):
-        response = client.post('/chat', params={'input': 'topic'})
+        response = client.post("/chat", params={"input": "topic"})
     assert response.status_code == 200
     data = response.json()
     assert data == {"response": "ok"}

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -2,9 +2,12 @@ import pathlib
 
 
 def test_dockerfile_configuration():
-    path = pathlib.Path('Dockerfile')
-    assert path.exists(), 'Dockerfile should exist'
+    path = pathlib.Path("Dockerfile")
+    assert path.exists(), "Dockerfile should exist"
     contents = path.read_text()
     lines = [line.strip() for line in contents.splitlines() if line.strip()]
-    assert lines[0] == 'FROM python:3-slim'
-    assert any(line.startswith('CMD ') and 'uvicorn' in line and 'app.api:app' in line for line in lines)
+    assert lines[0] == "FROM python:3-slim"
+    assert any(
+        line.startswith("CMD ") and "uvicorn" in line and "app.api:app" in line
+        for line in lines
+    )

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -9,7 +9,6 @@ from app import graph
 from app.graph import build_graph
 
 
-
 def test_graph_cycles_until_review_passes():
     """Flow should repeat draft-review until review approves."""
     with (
@@ -24,6 +23,7 @@ def test_graph_cycles_until_review_passes():
         assert plan_mock.called and research_mock.called
         assert draft_mock.call_count == 2
         assert review_mock.call_count == 2
+
 
 def test_graph_with_overlay():
     """Overlay node should merge draft with review output when provided."""

--- a/web/router.py
+++ b/web/router.py
@@ -24,9 +24,11 @@ router = APIRouter()
 # helpers
 # ---------------------------------------------------------------------------
 
+
 def _run_stream(text: str, mode: str) -> AsyncIterator[str]:
     """Run the conversation flow yielding intermediate results."""
     overlay = OverlayAgent() if mode == "overlay" else None
+
     async def _inner() -> AsyncIterator[str]:
         nonlocal text
         while True:
@@ -46,6 +48,7 @@ def _run_stream(text: str, mode: str) -> AsyncIterator[str]:
                     text = result
                 break
             text = result
+
     return _inner()
 
 
@@ -64,6 +67,7 @@ def _to_docx_bytes(text: str) -> bytes:
 # ---------------------------------------------------------------------------
 # routes
 # ---------------------------------------------------------------------------
+
 
 @router.get("/ui")
 async def ui() -> HTMLResponse:
@@ -89,4 +93,8 @@ async def export_docx(payload: dict) -> Response:
     text = payload.get("text", "")
     data = _to_docx_bytes(text)
     headers = {"Content-Disposition": "attachment; filename=output.docx"}
-    return Response(content=data, media_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document", headers=headers)
+    return Response(
+        content=data,
+        media_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        headers=headers,
+    )


### PR DESCRIPTION
## Summary
- ensure CI installs dev and test extras
- run black, ruff and mypy during GitHub Actions
- add bandit security scanning step
- document code quality workflow in README and AGENTS
- use explicit errors instead of asserts for Bandit compliance

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -q -r app openai_stub scripts web`
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_688c97af6d50832bb657757928770606