### PR TITLE
Improve error handling in demo UI

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -31,3 +31,14 @@ def test_export_docx():
     mock_fn.assert_called_once_with("hi")
     assert resp.headers["Content-Disposition"].startswith("attachment")
     assert resp.content == b"doc"
+
+
+def test_ui_includes_cancel_and_error_handlers():
+    """UI should contain cancel button and websocket error handling."""
+    client = TestClient(app)
+    resp = client.get("/ui")
+    assert resp.status_code == 200
+    html = resp.text
+    assert 'id="cancel"' in html  # cancel button
+    assert ".onerror" in html  # websocket error handler
+    assert "catch" in html  # fetch error handling

--- a/web/templates/ui.html
+++ b/web/templates/ui.html
@@ -18,6 +18,7 @@ textarea { width: 100%; box-sizing: border-box; resize: none; }
   <option value="overlay">overlay</option>
 </select>
 <button id="run">Run</button>
+<button id="cancel">Cancel</button>
 <div id="output"></div>
 <button id="save-md">Download Markdown</button>
 <button id="save-docx">Download DOCX</button>
@@ -26,6 +27,7 @@ textarea { width: 100%; box-sizing: border-box; resize: none; }
 (function() {
   let finalText = "";
   const out = document.getElementById('output');
+  let ws = null;
 
   function resize(e) {
     const el = e.target;
@@ -41,22 +43,36 @@ textarea { width: 100%; box-sizing: border-box; resize: none; }
     finalText = "";
     const text = textEl.value;
     const mode = document.getElementById('mode').value;
-    const ws = new WebSocket(`ws://${location.host}/stream?input=${encodeURIComponent(text)}&mode=${mode}`);
+    ws = new WebSocket(`ws://${location.host}/stream?input=${encodeURIComponent(text)}&mode=${mode}`);
     ws.onmessage = ev => {
       finalText += ev.data + "\n";
       out.innerHTML = marked.parse(finalText);
     };
-    ws.onclose = () => { window.demoOutput = finalText; };
+    ws.onerror = () => { out.textContent = 'WebSocket error'; };
+    ws.onclose = ev => {
+      if (!ev.wasClean) {
+        out.textContent += '\n[connection closed]';
+      }
+      window.demoOutput = finalText;
+    };
   };
   document.getElementById('save-md').onclick = function() {
     const blob = new Blob([window.demoOutput || ""], {type: 'text/markdown'});
     const a = document.createElement('a');
     a.href = URL.createObjectURL(blob); a.download = 'output.md'; a.click();
   };
-  document.getElementById('save-docx').onclick = function() {
-    fetch('/export/docx', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({text: window.demoOutput || ''})})
-      .then(r => r.blob())
-      .then(b => { const a = document.createElement('a'); a.href = URL.createObjectURL(b); a.download = 'output.docx'; a.click(); });
+  document.getElementById('cancel').onclick = function() {
+    if (ws) { ws.close(); }
+  };
+  document.getElementById('save-docx').onclick = async function() {
+    try {
+      const r = await fetch('/export/docx', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({text: window.demoOutput || ''})});
+      const b = await r.blob();
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(b); a.download = 'output.docx'; a.click();
+    } catch (err) {
+      alert('Failed to download DOCX');
+    }
   };
 })();
 </script>


### PR DESCRIPTION
## Summary
- handle websocket errors and unexpected close events in `ui.html`
- allow cancelling the live stream from the UI
- fail gracefully when DOCX download fails
- check HTML page for new error-handling code

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r app -ll`
- `pip-audit` *(fails: certificate verify failed)*
- `pytest --cov=./`

------
https://chatgpt.com/codex/tasks/task_e_688ca871886c832bb69f0bd8c3b8e761