### PR TITLE
Add Docker deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ is unset the demo prints placeholder text. If you have a Tavily account, you can
 search features. Uvicorn can load this file automatically with `--env-file .env`,
 and the demo script supports `python -m dotenv run -- python scripts/run_demo.py ...`.
 
+## Docker Usage
+
+A Dockerfile is included for local development and deployment. See
+[docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for build and run instructions.
+
 ## API
 
 The FastAPI app exposes several endpoints:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,36 @@
+# Deployment
+
+This project provides a Dockerfile for running the application in a container.
+
+## Build the image
+
+```bash
+docker build -t agentic-demo .
+```
+
+## Development mode
+
+Mount the source tree and use `--reload` to automatically pick up changes:
+
+```bash
+docker run --rm -it -p 8000:8000 -v $(pwd):/app agentic-demo \
+  uvicorn app.api:app --host 0.0.0.0 --reload
+```
+
+## Production mode
+
+Run the prebuilt image without mounting local files. Pass environment variables
+such as `OPENAI_API_KEY` or load them from a file:
+
+```bash
+docker run --rm -it -p 8000:8000 --env-file .env agentic-demo
+```
+
+## Testing inside the container
+
+Install the development dependencies and execute the test suite:
+
+```bash
+docker run --rm -it -v $(pwd):/app -w /app agentic-demo \
+  /bin/bash -c "pip install -e .[test,dev] && pytest --cov"
+```


### PR DESCRIPTION
## Summary
- document Docker workflows in `docs/DEPLOYMENT.md`
- reference the new deployment guide from README

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r app -ll`
- `pip-audit` *(fails: certificate verify failed)*
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_688caa1ab904832bb88093bb73cc316d