### PR TITLE
Add fallback export test

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -42,3 +42,12 @@ def test_ui_includes_cancel_and_error_handlers():
     assert 'id="cancel"' in html  # cancel button
     assert ".onerror" in html  # websocket error handler
     assert "catch" in html  # fetch error handling
+
+
+# TODO: ensure /export/docx falls back to plain text if Document is missing
+def test_export_docx_without_document(monkeypatch):
+    client = TestClient(app)
+    monkeypatch.setattr("web.router.Document", None)
+    resp = client.post("/export/docx", json={"text": "hi"})
+    assert resp.status_code == 200
+    assert resp.content == b"hi"


### PR DESCRIPTION
## Summary
- ensure `/export/docx` returns plain text when the `python-docx` dependency is missing

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r app -ll`
- `pip-audit` *(fails: certificate verify failed)*
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_688cad2e93c4832ba6752b2f7c38d35a