### PR TITLE
Remove outdated TODO and clarify docstring

### DIFF
--- a/app/overlay_agent.py
+++ b/app/overlay_agent.py
@@ -20,8 +20,7 @@ class OverlayAgent:
             self.agent = ChatAgent()
 
     def __call__(self, original: str, addition: str) -> str | dict[str, object]:
-        """Merge new material with existing text."""
-        # TODO: return a parsed dict when the underlying agent responds with JSON
+        """Merge new material with existing text. JSON responses are parsed to a dictionary."""
         prompt = (
             "Integrate the addition below into the existing text.\n"
             f"Existing:\n{original}\n"


### PR DESCRIPTION
## Summary
- cleaned up the overlay agent docstring
- removed outdated TODO comment

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r app -ll`
- `pip-audit` *(fails: certificate verify failed)*
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_688caff3a4f0832b9772daffdeacf393