### PR TITLE
Remove obsolete TODO

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -44,7 +44,6 @@ def test_ui_includes_cancel_and_error_handlers():
     assert "catch" in html  # fetch error handling
 
 
-# TODO: ensure /export/docx falls back to plain text if Document is missing
 def test_export_docx_without_document(monkeypatch):
     client = TestClient(app)
     monkeypatch.setattr("web.router.Document", None)


### PR DESCRIPTION
## Summary
- clean up tests/test_web by deleting a stale TODO comment

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r app -ll`
- `pip-audit` *(fails: SSL certificate verification error)*
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_688cb12236dc832b8ea76d1d32f8d9c9