### PR TITLE
Handle overlay dict responses

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,7 +1,10 @@
 from fastapi.testclient import TestClient
 from fastapi.websockets import WebSocketDisconnect
 from unittest.mock import patch
+import json
 import pytest
+import web.router as web_router
+from web.router import _to_docx_bytes, Document
 
 from app.api import app
 
@@ -51,3 +54,32 @@ def test_export_docx_without_document(monkeypatch):
     resp = client.post("/export/docx", json={"text": "hi"})
     assert resp.status_code == 200
     assert resp.content == b"hi"
+
+
+def test_websocket_streaming_overlay_dict():
+    """Overlay mode should stringify dict results for websocket transmission."""
+    client = TestClient(app)
+    overlay_output = {"slides": []}
+    with (
+        patch("web.router.plan", return_value="p"),
+        patch("web.router.research", return_value="r"),
+        patch("web.router.draft", return_value="d"),
+        patch("web.router.review", return_value="done"),
+        patch.object(web_router.OverlayAgent, "__call__", return_value=overlay_output),
+    ):
+        with client.websocket_connect("/stream?input=x&mode=overlay") as ws:
+            assert ws.receive_text() == "p"
+            assert ws.receive_text() == "r"
+            assert ws.receive_text() == "d"
+            assert ws.receive_text() == "done"
+            assert ws.receive_text() == json.dumps(overlay_output)
+            with pytest.raises(WebSocketDisconnect):
+                ws.receive_text()
+
+
+def test_to_docx_bytes_generates_zip():
+    """Ensure generated DOCX bytes have zip file header when Document is available."""
+    if Document is None:
+        pytest.skip("python-docx not installed")
+    data = _to_docx_bytes("hi")
+    assert data.startswith(b"PK")

--- a/web/router.py
+++ b/web/router.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from io import BytesIO
 from typing import AsyncIterator, cast
+import json
 import pathlib
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Response
@@ -42,7 +43,12 @@ def _run_stream(text: str, mode: str) -> AsyncIterator[str]:
             yield result
             if "retry" not in result:
                 if overlay:
-                    text = cast(str, overlay(draft_text, result))
+                    # TODO: when overlay returns a dict, convert to JSON before yielding
+                    overlay_result = overlay(draft_text, result)
+                    if isinstance(overlay_result, dict):
+                        text = json.dumps(overlay_result)
+                    else:
+                        text = cast(str, overlay_result)
                     yield text
                 else:
                     text = result


### PR DESCRIPTION
## Summary
- support dict overlay output by stringifying JSON
- test overlay streaming behavior
- verify DOCX generation with python-docx

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r app -ll`
- `pip-audit` *(fails: certificate verify failed)*
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_688cb12a263c832b8d2c69bb5caecef0