### PR TITLE
Improve outline parsing for numbered and Markdown headings

### DIFF
--- a/app/workflow.py
+++ b/app/workflow.py
@@ -16,11 +16,21 @@ class DocumentWorkflow:
 
     overlay: OverlayAgent | None = None
 
-    # TODO: allow nested numbering or markdown parsing of outlines
+    def _clean_heading(self, line: str) -> str:
+        """Remove bullet, numeric or Markdown heading prefixes from ``line``."""
+        import re
+
+        line = line.strip()
+        pattern = r"^(?:[-*]|\d+(?:\.\d+)*[.)]?|#+)\s*(.*)"
+        match = re.match(pattern, line)
+        if match:
+            return match.group(1).strip()
+        return line
+
     def parse_outline(self, outline: str) -> List[str]:
-        """Extract individual headings from a plain-text outline."""
+        """Return a list of headings parsed from ``outline``."""
         return [
-            line.lstrip("- ").strip() for line in outline.splitlines() if line.strip()
+            self._clean_heading(line) for line in outline.splitlines() if line.strip()
         ]
 
     def generate(self, topic: str) -> str:

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -9,6 +9,12 @@ def test_parse_outline_basic():
     assert wf.parse_outline(outline) == ["Intro", "Body", "Conclusion"]
 
 
+def test_parse_outline_numbers_and_markdown():
+    wf = DocumentWorkflow()
+    outline = "1. Intro\n1.1 Details\n## Conclusion"
+    assert wf.parse_outline(outline) == ["Intro", "Details", "Conclusion"]
+
+
 def test_generate_document_runs_graph_per_heading():
     wf = DocumentWorkflow()
     with (


### PR DESCRIPTION
## Summary
- extend `DocumentWorkflow.parse_outline` to strip numeric/markdown prefixes
- add a helper `_clean_heading`
- test numbered and markdown outlines

## Testing
- `pytest --cov`
- `ruff check .`
- `mypy .`
- `bandit -r app -ll`
- `pip-audit` *(fails: certificate verify failed / proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_688cb11aa5a4832ba301773db8e5a1de