### PR TITLE
Serialize overlay dict

### DIFF
--- a/app/graph.py
+++ b/app/graph.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass
 from typing import Dict, List, Optional, TypedDict, cast
+import json
 
 from langgraph.graph import StateGraph, END, START
 from typing import Any
@@ -97,13 +98,18 @@ def build_graph(
         }
 
     async def overlay_node(state: GraphState) -> GraphState:
+        """Merge the draft with review notes and log the action."""
+        # TODO: append JSON string when overlay output is a dictionary
         assert overlay is not None
         result = overlay(state["draft"], cast(str, state["text"]))
+        history_entry = (
+            json.dumps(result) if isinstance(result, dict) else cast(str, result)
+        )
         return {
             "text": result,
             "draft": state["draft"],
             "approved": True,
-            "history": state["history"] + [cast(str, result)],
+            "history": state["history"] + [history_entry],
         }
 
     builder: StateGraph = StateGraph(GraphState)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -78,3 +78,21 @@ def test_build_graph_skip_plan():
         research_mock.assert_called_once()
         draft_mock.assert_called_once()
         review_mock.assert_called_once()
+
+
+def test_overlay_history_serialized_when_dict():
+    """Overlay node should append JSON when result is a dict."""
+    from app.overlay_agent import OverlayAgent
+    import json
+
+    overlay = OverlayAgent(ChatAgent())
+    with (
+        patch.object(OverlayAgent, "__call__", return_value={"slides": []}),
+        patch.object(graph, "plan", return_value="plan"),
+        patch.object(graph, "research", return_value="research"),
+        patch.object(graph, "draft", return_value="draft"),
+        patch.object(graph, "review", return_value="review"),
+    ):
+        flow = build_graph(overlay)
+        result = flow.run("topic")
+        assert result["messages"][-1] == json.dumps({"slides": []})


### PR DESCRIPTION
## Summary
- ensure overlay results that are dictionaries are serialized into the graph history
- test history serialization for overlay dict results

## Testing
- `pytest --cov`
- `ruff check .`
- `mypy .`
- `bandit -r app -ll`
- `pip-audit` *(fails: SSLError)*

------
https://chatgpt.com/codex/tasks/task_e_688cb28a9dcc832b9d17262e585a7ceb