### PR TITLE
Switch to YAML-based prompts

### DIFF
--- a/app/overlay_agent.py
+++ b/app/overlay_agent.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from typing import Dict
 import json
 
+from . import utils
+
 from .agents import ChatAgent
 
 
@@ -21,12 +23,15 @@ class OverlayAgent:
 
     def __call__(self, original: str, addition: str) -> str | dict[str, object]:
         """Merge new material with existing text. JSON responses are parsed to a dictionary."""
-        prompt = (
-            "Integrate the addition below into the existing text.\n"
-            f"Existing:\n{original}\n"
-            f"Addition:\n{addition}"
-        )
-        messages: list[Dict[str, str]] = [{"role": "user", "content": prompt}]
+        # TODO: use YAML template for overlay prompt
+        template = utils.load_prompt("overlay")
+        prompt = template.format(original=original, addition=addition)
+        system = utils.load_prompt("system")
+        user = utils.load_prompt("user").format(input=prompt)
+        messages: list[Dict[str, str]] = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ]
         assert self.agent is not None
         result = self.agent(messages)
         try:

--- a/app/prompts/draft.yaml
+++ b/app/prompts/draft.yaml
@@ -1,2 +1,2 @@
 prompt: |
-  Write a short passage using: {notes}
+  Compose a brief and coherent paragraph based on these notes: {notes}

--- a/app/prompts/overlay.yaml
+++ b/app/prompts/overlay.yaml
@@ -1,6 +1,4 @@
 prompt: |
-  Integrate the addition below into the existing text.
-  Existing:
-  {original}
-  Addition:
-  {addition}
+  Seamlessly integrate the addition into the existing text.
+  Existing: {original}
+  Addition: {addition}

--- a/app/prompts/plan.yaml
+++ b/app/prompts/plan.yaml
@@ -1,2 +1,2 @@
 prompt: |
-  Create an outline for {topic}.
+  You are an expert planner. Provide a concise bullet-point outline for {topic}.

--- a/app/prompts/research.yaml
+++ b/app/prompts/research.yaml
@@ -1,2 +1,2 @@
 prompt: |
-  Provide background facts about: {outline}
+  Gather concise background facts supporting {outline}. Include credible sources when possible.

--- a/app/prompts/review.yaml
+++ b/app/prompts/review.yaml
@@ -1,3 +1,3 @@
 prompt: |
-  Improve the following text for clarity:
+  Review the text below for clarity and correct grammar. Return the improved version or 'retry' if major issues remain:
   {text}

--- a/app/prompts/system.yaml
+++ b/app/prompts/system.yaml
@@ -1,2 +1,2 @@
 content: |
-  You are a helpful assistant.
+  You are a knowledgeable and concise writing assistant.

--- a/tests/test_overlay_agent.py
+++ b/tests/test_overlay_agent.py
@@ -11,8 +11,30 @@ def test_overlay_agent_composes_prompt():
         assert out == "result"
         assert mock.call_count == 1
         called_messages = mock.call_args[0][0]
-        assert "orig" in called_messages[0]["content"]
-        assert "add" in called_messages[0]["content"]
+        assert called_messages[0]["role"] == "system"
+        assert "orig" in called_messages[1]["content"]
+        assert "add" in called_messages[1]["content"]
+
+
+def test_overlay_agent_uses_yaml_prompt():
+    """OverlayAgent should format its prompt from YAML."""
+
+    def fake_load(name):
+        return {
+            "overlay": "ov {original} {addition}",
+            "system": "sys",
+            "user": "{input}",
+        }[name]
+
+    with (
+        patch("app.utils.load_prompt", side_effect=fake_load),
+        patch.object(ChatAgent, "__call__", return_value="x") as mock,
+    ):
+        oa = OverlayAgent(ChatAgent())
+        oa("orig", "add")
+
+        called_messages = mock.call_args[0][0]
+        assert called_messages[1]["content"] == "ov orig add"
 
 
 def test_overlay_agent_returns_dict_when_json():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -32,8 +32,8 @@ def test_safe_load_without_yaml(monkeypatch):
 
 def test_repository_prompts_load(monkeypatch):
     monkeypatch.setattr(utils, "PROMPTS_PATH", pathlib.Path("app/prompts"))
-    assert utils.load_prompt("plan").startswith("Create an outline")
-    assert utils.load_prompt("research").startswith("Provide background")
-    assert utils.load_prompt("draft").startswith("Write a short passage")
-    assert utils.load_prompt("review").startswith("Improve the following")
-    assert utils.load_prompt("overlay").startswith("Integrate the addition")
+    assert utils.load_prompt("plan").startswith("You are an expert planner")
+    assert utils.load_prompt("research").startswith("Gather concise background")
+    assert utils.load_prompt("draft").startswith("Compose a brief")
+    assert utils.load_prompt("review").startswith("Review the text below")
+    assert utils.load_prompt("overlay").startswith("Seamlessly integrate")


### PR DESCRIPTION
## Summary
- load system/user prompts from YAML
- move plan/research/draft/review and overlay prompts to YAML
- improve prompt wording
- update tests to verify YAML prompt usage

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r app -ll`
- `pip-audit` *(fails: certificate verify failed)*
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_688cbd00f350832bb9dad41b7e06d103