### PR TITLE
Update architecture doc

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,22 +1,32 @@
 # System Architecture
 
-This project orchestrates several agents via a langgraph flow exposed through a
-FastAPI application. The web UI streams node outputs back to the browser so
-users can observe each step in real time.
+This project orchestrates a sequence of five agents using LangGraph. The FastAPI application streams Server-Sent Events (SSE) back to the browser so users can watch each step in real time.
 
 ```mermaid
 graph TD
     A[Web UI / API] -->|input| B(build_graph)
-    B --> C[plan node]
-    C --> D[research node]
-    D --> E[draft node]
-    E --> F[review node]
-    F -->|approved| G[overlay node]
-    F -->|retry| E
+    B --> C[planner]
+    C --> D[researcher]
+    D --> E[synthesiser]
+    E --> F[pedagogy-critic]
+    F --> G[qa-reviewer]
     G --> H[(output)]
 ```
 
-Each node wraps a small agent function decorated with `@langsmith.traceable` so
-token metrics and events are recorded when LangSmith environment variables are
-configured.
+Each node wraps a small agent function decorated with `@langsmith.traceable` so token metrics and events are captured when LangSmith variables are configured.
 
+## OpenAI Responses SSE streaming
+
+The browser UI receives OpenAI responses as a continuous stream of events. Nodes yield tokens as soon as they arrive, providing near real-time feedback.
+
+## LangGraph coordination
+
+LangGraph manages the flow from planner through QA-reviewer. Edges between nodes define the order of execution and allow retries or branching if desired.
+
+## SQLite persistence
+
+Runs, versions, citations and log entries are stored in an SQLite database. The connection uses Write-Ahead Logging (WAL) so the graph can resume or replay deterministically.
+
+## Deterministic replay
+
+LangGraph checkpoints combined with WAL-enabled SQLite make it possible to replay any run exactly as it happened. This aids debugging and auditing.


### PR DESCRIPTION
## Summary
- refresh architecture docs
- note streaming responses and sqlite persistence

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r app -ll`
- `pip-audit` *(failed: SSLError)*
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_688d57a9d950832bac0f381b17a9419e