### PR TITLE
Improve docs for agent workflow and SSE streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ Start the server using the command shown in the setup section.
 Open `http://localhost:8000/ui` for the web interface or send requests to
 `http://localhost:8000/chat`.
 
+The service streams OpenAI responses using **Server-Sent Events (SSE)**. Tokens
+are forwarded directly from FastAPI to the browser so no WebSocket is required.
+
 ## Running Tests
 
 Install the development dependencies and run the test suite using `pytest`:
@@ -90,15 +93,21 @@ pip install -r requirements-dev.txt
 pytest
 ```
 
+## Architecture
+
+See [`docs/architecture.md`](docs/architecture.md) for a full overview of the
+system diagram. The FastAPI service orchestrates five cooperating agents through
+LangGraph and persists all runs to SQLite for deterministic versioning.
+
 ## Agentic Workflow
 
-The application orchestrates content creation through a sequence of prompts and agents. Each topic is processed section by section, allowing refinements at every stage.
+The application orchestrates content creation through five specialised agents. Each topic is processed section by section so every phase can refine the output.
 
-1. **Research** – gather background notes for each subheading.
-2. **Draft** – generate initial text from the notes.
-3. **Edit** – review and adjust the draft for clarity and coherence.
-4. **Rewrite** – produce an improved revision using feedback from the edit step.
-5. **Final edit and polish** – complete a last pass to ensure consistent style and structure across all sections.
+1. **Planner** – break the request into an outline of subtopics.
+2. **Researcher** – gather background notes for each subheading.
+3. **Synthesiser** – draft a coherent section from the notes.
+4. **Pedagogy-Critic** – review the draft for clarity and instructional value.
+5. **QA-Reviewer** – perform a final pass to confirm style and structure.
 
 The conversation graph in ``app.graph`` repeats steps 2–4 until the review approves the content. Once all subsections are finalized, the final edit produces the polished document.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,7 +17,7 @@ Each node wraps a small agent function decorated with `@langsmith.traceable` so 
 
 ## OpenAI Responses SSE streaming
 
-The browser UI receives OpenAI responses as a continuous stream of events. Nodes yield tokens as soon as they arrive, providing near real-time feedback.
+The browser UI receives OpenAI responses as a continuous stream of events. Nodes yield tokens as soon as they arrive, providing near real-time feedback. The FastAPI service forwards these SSE events directly to the browser, so no WebSocket is required.
 
 ## LangGraph coordination
 


### PR DESCRIPTION
## Summary
- clarify API docs with SSE streaming behavior
- add architecture overview and reference
- revamp Agentic Workflow steps with new agent names
- note FastAPI SSE forwarding in architecture document

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r app -ll`
- `pip-audit` *(fails: SSLError)*
- `pytest --cov` *(46 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688d5a776d58832b9fc1f1cbb57650fb