### PR TITLE
Add placeholders for pedagogy and QA agents

### DIFF
--- a/app/agents.py
+++ b/app/agents.py
@@ -203,3 +203,57 @@ def review(
     result = _call_agent(prompt, agent)
     _log_metrics(result, loop)
     return result
+
+
+class PedagogyCritic:
+    """Placeholder agent that will critique generated lessons."""
+
+    def __call__(self, text: str) -> str:
+        """Return pedagogical feedback for ``text``.
+
+        Parameters
+        ----------
+        text:
+            Lesson content to evaluate.
+
+        Returns
+        -------
+        str
+            TODO: provide structured pedagogical critique.
+
+        Raises
+        ------
+        NotImplementedError
+            This placeholder has no behaviour yet.
+        """
+
+        # TODO: implement pedagogy critique logic using ChatAgent.
+        # TODO: update ``app/graph.py`` to include this agent in the LangGraph flow.
+        raise NotImplementedError("PedagogyCritic is not yet implemented")
+
+
+class QAReviewer:
+    """Placeholder agent that will perform quality assurance review."""
+
+    def __call__(self, text: str) -> str:
+        """Return QA notes for ``text``.
+
+        Parameters
+        ----------
+        text:
+            Draft content to review.
+
+        Returns
+        -------
+        str
+            TODO: return quality assurance findings.
+
+        Raises
+        ------
+        NotImplementedError
+            This placeholder has no behaviour yet.
+        """
+
+        # TODO: implement QA review logic using ChatAgent.
+        # TODO: update ``app/graph.py`` to include this agent in the LangGraph flow.
+        raise NotImplementedError("QAReviewer is not yet implemented")

--- a/app/graph.py
+++ b/app/graph.py
@@ -63,7 +63,7 @@ def build_graph(
     overlay:
         Optional :class:`OverlayAgent` for the final merge step.
     mode:
-        Conversation variant. When set to ``"overlay"`` a new
+    Conversation variant. When set to ``"overlay"`` a new
         :class:`OverlayAgent` should be created if ``overlay`` is not
         provided.
     skip_plan:
@@ -71,7 +71,7 @@ def build_graph(
         generating a plan first. This is useful when an outline is already
         available.
     """
-
+    # TODO: include PedagogyCritic and QAReviewer in the LangGraph flow.
     if overlay is None and mode == "overlay":
         overlay = OverlayAgent()
 

--- a/tests/test_placeholder_agents.py
+++ b/tests/test_placeholder_agents.py
@@ -1,0 +1,14 @@
+import pytest
+from app.agents import PedagogyCritic, QAReviewer
+
+
+@pytest.mark.xfail(reason="PedagogyCritic not implemented")
+def test_pedagogy_critic_placeholder():
+    critic = PedagogyCritic()
+    critic("test input")
+
+
+@pytest.mark.xfail(reason="QAReviewer not implemented")
+def test_qa_reviewer_placeholder():
+    reviewer = QAReviewer()
+    reviewer("draft text")


### PR DESCRIPTION
## Summary
- stub PedagogyCritic and QAReviewer agents with TODOs
- note future graph integration
- add xfailed tests for the new agents

## Testing
- `pip install -e .[test]`
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r app -ll`
- `pip-audit` *(fails: SSLCertVerificationError)*
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_688d7c84b054832b82dcc4c623f1dd2b