### PR TITLE
feat: persist chat steps and expose versions

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -7,17 +7,48 @@ from web.router import router as web_router
 
 from .graph import build_graph
 from .mcp import MCP
+from .persistence import (
+    add_log,
+    get_connection,
+    init_db,
+    read_versions,
+    save_checkpoint,
+)
 
 app = FastAPI()
 flow = build_graph()
 app.include_router(web_router)
 mcp = MCP()
 
+# Database setup
+conn = get_connection()
+init_db(conn)
+
+# TODO(#test_chat_persists_steps): rollback gracefully if persisting a
+# checkpoint fails mid-conversation.
+
 
 @app.post("/chat")
-async def chat(input: str) -> dict:
-    """Handle chat requests returning the final response."""
+async def chat(input: str, run: str) -> dict:
+    """Handle chat requests returning the final response.
+
+    Parameters
+    ----------
+    input:
+        Prompt provided by the user.
+    run:
+        Identifier grouping checkpoints and logs for this conversation.
+
+    Returns
+    -------
+    dict
+        Mapping containing the final ``response`` string.
+    """
+
     result = await flow.arun(input)
+    for step in result["messages"]:
+        save_checkpoint(conn, run, step)
+        add_log(conn, run, "INFO", step)
     return {"response": result["output"]}
 
 
@@ -27,3 +58,26 @@ async def mcp_edit(payload: dict) -> dict:
     addition = payload.get("addition", "")
     text = mcp.edit(addition)
     return {"text": text}
+
+
+# TODO(#test_versions_endpoint_returns_saved_versions): add authentication and
+# pagination for version history responses.
+@app.get("/versions")
+async def versions(run: str) -> dict:
+    """Return stored checkpoints for ``run``.
+
+    Parameters
+    ----------
+    run:
+        Identifier used when saving checkpoints via :func:`chat`.
+
+    Returns
+    -------
+    dict
+        Dictionary with a ``versions`` key mapping to an ordered list of
+        version records.
+    """
+
+    rows = read_versions(conn, run)
+    data = [{"version": int(row["version"]), "data": row["data"]} for row in rows]
+    return {"versions": data}

--- a/app/persistence.py
+++ b/app/persistence.py
@@ -45,7 +45,7 @@ def get_connection(path: str = ":memory:") -> sqlite3.Connection:
         and write-ahead logging (WAL) enabled.
     """
 
-    conn = sqlite3.connect(path)
+    conn = sqlite3.connect(path, check_same_thread=False)
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA journal_mode=WAL;")
     conn.execute("PRAGMA foreign_keys=ON;")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,11 +7,16 @@ from app.agents import ChatAgent
 
 def test_chat_endpoint():
     client = TestClient(app)
+
+    async def fake_arun(_: str) -> dict:
+        return {"messages": [], "output": "ok"}
+
     with (
         patch.object(ChatAgent, "__call__", return_value="ok"),
         patch("app.agents.perplexity.search", return_value="r"),
+        patch("app.api.flow.arun", fake_arun),
     ):
-        response = client.post("/chat", params={"input": "topic"})
+        response = client.post("/chat", params={"input": "topic", "run": "r"})
     assert response.status_code == 200
     data = response.json()
     assert data == {"response": "ok"}
@@ -24,3 +29,64 @@ def test_mcp_endpoint():
     assert resp.status_code == 200
     assert resp.json() == {"text": "doc"}
     edit.assert_called_once_with("add")
+
+
+def test_chat_persists_steps(monkeypatch):
+    """Each agent step is persisted and logged."""
+    steps = ["a", "b"]
+
+    async def fake_arun(_: str) -> dict:
+        return {"messages": steps, "output": "b"}
+
+    records: list[tuple[str, str]] = []
+
+    def fake_save(conn, run, data, citations=None):  # type: ignore[unused-arg]
+        records.append(("save", data))
+
+    def fake_log(conn, run, level, message):  # type: ignore[unused-arg]
+        records.append(("log", message))
+
+    import app.api as api
+
+    monkeypatch.setattr(api.flow, "arun", fake_arun)
+    monkeypatch.setattr(api, "save_checkpoint", fake_save)
+    monkeypatch.setattr(api, "add_log", fake_log)
+
+    client = TestClient(app)
+    resp = client.post("/chat", params={"input": "i", "run": "r"})
+    assert resp.status_code == 200
+    assert records == [
+        ("save", "a"),
+        ("log", "a"),
+        ("save", "b"),
+        ("log", "b"),
+    ]
+
+
+def test_versions_endpoint_returns_saved_versions(monkeypatch):
+    """``GET /versions`` exposes stored checkpoints."""
+
+    async def fake_arun(_: str) -> dict:
+        return {"messages": ["s1", "s2"], "output": "s2"}
+
+    # fresh database for the test
+    from app.persistence import get_connection, init_db
+    import app.api as api
+
+    conn = get_connection()
+    init_db(conn)
+    monkeypatch.setattr(api, "conn", conn)
+    monkeypatch.setattr(api.flow, "arun", fake_arun)
+
+    client = TestClient(app)
+    resp = client.post("/chat", params={"input": "i", "run": "run"})
+    assert resp.status_code == 200
+
+    resp = client.get("/versions", params={"run": "run"})
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "versions": [
+            {"version": 1, "data": "s1"},
+            {"version": 2, "data": "s2"},
+        ]
+    }


### PR DESCRIPTION
## Summary
- persist each chat step to SQLite and log progress
- expose versions endpoint to retrieve run checkpoints
- add tests for step persistence and version history

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r app -ll`
- `pip-audit` *(failed: SSL certificate verify failed)*
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_688d8a546aa8832b93cc5725dafdf649