### PR TITLE
Add env config loader and dependencies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,4 @@
-# Rename this file to `.env` and set your API keys.
-
-# Required OpenAI API key for the demo.
-OPENAI_API_KEY=
-
-# Optional Tavily API key used for search functionality.
-# TAVILY_API_KEY=
+OPENAI_API_KEY=your-openai-key
+PERPLEXITY_API_KEY=your-perplexity-key
+MODEL_NAME=your-model
+DATA_DIR=/path/to/data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,14 @@ python = ">=3.13,<4.0"
 pytest = {version = ">=7.4", optional = true}
 pytest-cov = {version = ">=4.1", optional = true}
 pytest-asyncio = {version = ">=0.23", optional = true}
+langgraph = "*"
+openai = "*"
+perplexity-api = "*"
+pysqlite3-binary = "*" # provides sqlite3
+python-docx = "*"
+weasyprint = "*"
+fastapi = "*"
+uvicorn = "*"
 
 [tool.poetry.group.dev.dependencies]
 black = ">=24.3"

--- a/src/agentic_demo/__init__.py
+++ b/src/agentic_demo/__init__.py
@@ -5,4 +5,6 @@ Provides foundational modules for demonstration purposes.
 
 from typing import List
 
-__all__: List[str] = []
+from .config import EnvConfig, load_env
+
+__all__: List[str] = ["EnvConfig", "load_env"]

--- a/src/agentic_demo/config.py
+++ b/src/agentic_demo/config.py
@@ -1,0 +1,79 @@
+"""Environment configuration utilities."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict
+
+
+@dataclass
+class EnvConfig:
+    """Application environment settings."""
+
+    openai_api_key: str
+    perplexity_api_key: str
+    model_name: str
+    data_dir: str
+
+
+def load_env(path: str | Path = ".env") -> EnvConfig:
+    """Load environment settings from *path*.
+
+    Args:
+        path: Location of a ``.env`` file.
+
+    Returns:
+        Loaded :class:`EnvConfig` instance.
+
+    Raises:
+        FileNotFoundError: If ``path`` does not exist.
+        KeyError: If a required key is missing.
+    """
+
+    raw = _parse_env(path)
+    for key in _REQUIRED_KEYS:
+        if key in os.environ:
+            raw[key] = os.environ[key]
+    missing = [key for key in _REQUIRED_KEYS if key not in raw]
+    if missing:
+        raise KeyError(f"Missing keys: {', '.join(missing)}")
+    return EnvConfig(
+        openai_api_key=raw["OPENAI_API_KEY"],
+        perplexity_api_key=raw["PERPLEXITY_API_KEY"],
+        model_name=raw["MODEL_NAME"],
+        data_dir=raw["DATA_DIR"],
+    )
+
+
+_REQUIRED_KEYS = {
+    "OPENAI_API_KEY",
+    "PERPLEXITY_API_KEY",
+    "MODEL_NAME",
+    "DATA_DIR",
+}
+
+
+def _parse_env(path: str | Path) -> Dict[str, str]:
+    """Parse key-value pairs from *path*.
+
+    Args:
+        path: Location of a ``.env`` file.
+
+    Returns:
+        Mapping of keys to values.
+
+    Raises:
+        FileNotFoundError: If ``path`` does not exist.
+    """
+
+    data: Dict[str, str] = {}
+    with open(path) as fh:
+        for raw_line in fh:
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            key, _, value = line.partition("=")
+            data[key.strip()] = value.strip()
+    return data

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,47 @@
+"""Tests for the :mod:`agentic_demo.config` module."""
+
+from pathlib import Path
+
+import pytest
+
+from agentic_demo.config import load_env
+
+
+@pytest.fixture
+def env_file(tmp_path: Path) -> Path:
+    """Create a temporary `.env` file with valid keys."""
+    content = (
+        "OPENAI_API_KEY=sk-123\n"
+        "PERPLEXITY_API_KEY=pp-456\n"
+        "MODEL_NAME=gpt-4o\n"
+        "DATA_DIR=/data\n"
+    )
+    file = tmp_path / ".env"
+    file.write_text(content)
+    return file
+
+
+def test_load_env_returns_config(env_file: Path) -> None:
+    """``load_env`` parses values from the `.env` file."""
+    config = load_env(env_file)
+    assert config.openai_api_key == "sk-123"
+    assert config.perplexity_api_key == "pp-456"
+    assert config.model_name == "gpt-4o"
+    assert config.data_dir == "/data"
+
+
+def test_load_env_missing_key_raises(tmp_path: Path) -> None:
+    """``load_env`` validates required keys."""
+    file = tmp_path / ".env"
+    file.write_text("OPENAI_API_KEY=sk-123\n")
+    with pytest.raises(KeyError):
+        load_env(file)
+
+
+def test_environment_overrides_file(
+    env_file: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Environment variables override `.env` values."""
+    monkeypatch.setenv("MODEL_NAME", "override-model")
+    config = load_env(env_file)
+    assert config.model_name == "override-model"


### PR DESCRIPTION
## Summary
- add core runtime deps for LLM and web framework tools
- expose EnvConfig and load_env for .env based configuration
- provide example env file and tests

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: [SSL: CERTIFICATE_VERIFY_FAILED])* 
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_688e01deb1c8832b82eeb7f2dd9391db