### PR TITLE
feat: scaffold async sqlite saver with migrations

### DIFF
--- a/src/agentic_demo/persistence/__init__.py
+++ b/src/agentic_demo/persistence/__init__.py
@@ -1,0 +1,5 @@
+"""Persistence layer for the agentic demo."""
+
+from .sqlite import AsyncSqliteSaver
+
+__all__ = ["AsyncSqliteSaver"]

--- a/src/agentic_demo/persistence/sqlite.py
+++ b/src/agentic_demo/persistence/sqlite.py
@@ -1,0 +1,78 @@
+"""SQLite-based persistence utilities."""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from pathlib import Path
+
+
+class AsyncSqliteSaver:
+    """Persist workspace data asynchronously to a SQLite database.
+
+    Parameters
+    ----------
+    path:
+        Filesystem location of the SQLite database.
+    """
+
+    _MIGRATIONS: tuple[str, ...] = (
+        """
+        CREATE TABLE IF NOT EXISTS state (
+            id TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS documents (
+            id TEXT PRIMARY KEY,
+            content TEXT NOT NULL
+        );
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS citations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            document_id TEXT NOT NULL,
+            citation TEXT NOT NULL,
+            FOREIGN KEY(document_id) REFERENCES documents(id)
+        );
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS logs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            message TEXT NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+        """,
+    )
+
+    path: Path
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    async def init(self) -> None:
+        """Initialize the database and apply migrations.
+
+        Side Effects
+        ------------
+        Creates the database file and applies initial schema.
+
+        Raises
+        ------
+        sqlite3.Error
+            If applying migrations fails.
+        """
+
+        await asyncio.to_thread(self._apply_migrations)
+
+    def _apply_migrations(self) -> None:
+        """Apply schema migrations synchronously."""
+        conn = sqlite3.connect(self.path)
+        try:
+            cur = conn.cursor()
+            for statement in self._MIGRATIONS:
+                cur.executescript(statement)
+            conn.commit()
+        finally:
+            conn.close()

--- a/tests/test_persistence_sqlite.py
+++ b/tests/test_persistence_sqlite.py
@@ -1,0 +1,25 @@
+"""Tests for the SQLite persistence layer."""
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from agentic_demo.persistence import AsyncSqliteSaver
+
+
+@pytest.mark.asyncio
+async def test_init_creates_tables(tmp_path: Path) -> None:
+    """Initializing the saver applies schema migrations."""
+    db_path = tmp_path / "test.db"
+    saver = AsyncSqliteSaver(db_path)
+    await saver.init()
+    conn = sqlite3.connect(db_path)
+    try:
+        tables = {
+            row[0]
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+    finally:
+        conn.close()
+    assert {"state", "documents", "citations", "logs"} <= tables


### PR DESCRIPTION
## Summary
- add AsyncSqliteSaver with migrations for state, documents, citations, and logs tables
- expose persistence module and add tests for schema creation

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: SSL certificate verify failed)*
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_688e041bbb34832ba3813e1eace7f764