### PR TITLE
feat(orchestration): add state dataclass

### DIFF
--- a/src/agentic_demo/orchestration/__init__.py
+++ b/src/agentic_demo/orchestration/__init__.py
@@ -1,0 +1,5 @@
+"""Orchestration utilities."""
+
+from .state import State
+
+__all__ = ["State"]

--- a/src/agentic_demo/orchestration/state.py
+++ b/src/agentic_demo/orchestration/state.py
@@ -1,0 +1,25 @@
+"""State model for orchestration core."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass(slots=True)
+class State:
+    """Represents the evolving state of a LangGraph conversation.
+
+    Attributes:
+        prompt: Latest user or system prompt driving the conversation.
+        sources: Collection of source identifiers used for context.
+        outline: High level plan or outline guiding the conversation.
+        log: History of notable events or messages.
+        version: Integer representing the schema version of this state.
+    """
+
+    prompt: str = ""
+    sources: List[str] = field(default_factory=list)
+    outline: List[str] = field(default_factory=list)
+    log: List[str] = field(default_factory=list)
+    version: int = 1

--- a/tests/test_orchestration_state.py
+++ b/tests/test_orchestration_state.py
@@ -1,0 +1,29 @@
+"""Tests for orchestration state model."""
+
+from agentic_demo.orchestration.state import State
+
+
+def test_state_defaults():
+    """State should provide sensible default values."""
+    state = State()
+    assert state.prompt == ""
+    assert state.sources == []
+    assert state.outline == []
+    assert state.log == []
+    assert state.version == 1
+
+
+def test_state_custom_values():
+    """State should accept custom initialization values."""
+    state = State(
+        prompt="hi",
+        sources=["doc"],
+        outline=["step"],
+        log=["msg"],
+        version=2,
+    )
+    assert state.prompt == "hi"
+    assert state.sources == ["doc"]
+    assert state.outline == ["step"]
+    assert state.log == ["msg"]
+    assert state.version == 2


### PR DESCRIPTION
## Summary
- add State dataclass to capture orchestration prompt, sources, outline, log and version
- expose State via orchestration package
- test State defaults and custom values

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: certificate verify failed)*
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_688e0563fc14832b94fd9efa076e5c6e