### PR TITLE
Add python-dotenv dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ python-docx = "*"
 weasyprint = "*"
 fastapi = "*"
 uvicorn = "*"
+python-dotenv = "*"
 
 [tool.poetry.group.dev.dependencies]
 black = ">=24.3"


### PR DESCRIPTION
## Summary
- include python-dotenv in core dependencies

## Testing
- `poetry update python-dotenv` *(fails: All attempts to connect to pypi.org failed: SSLCertVerificationError)*
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: SSLCertVerificationError connecting to pypi.org)*
- `pytest --cov` *(fails: KeyError: '__start__')*

------
https://chatgpt.com/codex/tasks/task_e_688e0e4e2924832ba3d62cb85d2e1dfa