### PR TITLE
feat: scaffold placeholder packages and docs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,14 @@ version = "0.1.0"
 description = "Demo project scaffold"
 authors = ["Agent <agent@example.com>"]
 readme = "README.md"
-packages = [{ include = "agentic_demo", from = "src" }]
+packages = [
+    { include = "agentic_demo", from = "src" },
+    { include = "core", from = "src" },
+    { include = "agents", from = "src" },
+    { include = "persistence", from = "src" },
+    { include = "web", from = "src" },
+    { include = "export", from = "src" },
+]
 
 [tool.poetry.dependencies]
 python = ">=3.13,<4.0"

--- a/src/agentic_demo/orchestration/graph.py
+++ b/src/agentic_demo/orchestration/graph.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 from dataclasses import asdict
-from typing import AsyncGenerator
+from typing import Any, AsyncGenerator
 
 from langgraph.graph import END, START, StateGraph
-from langgraph.graph.graph import CompiledGraph
 
 from .state import State
+
+# ``langgraph`` does not expose a stable ``CompiledGraph`` in all versions. For
+# type checking, we alias it to :class:`Any` to avoid hard dependency on internal
+# modules while retaining the intended semantics.
+CompiledGraph = Any
 
 
 # TODO: Implement real planner logic once available

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,0 +1,7 @@
+"""Agent implementations for the demo.
+
+This package will contain concrete agent classes and related behaviors used
+throughout the system.
+
+TODO: Implement agent classes and behaviors.
+"""

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,0 +1,7 @@
+"""Core functionality for the agentic demo.
+
+This package will house foundational utilities and base classes that are
+shared across the project.
+
+TODO: Define foundational utilities and base classes shared across modules.
+"""

--- a/src/export/__init__.py
+++ b/src/export/__init__.py
@@ -1,0 +1,7 @@
+"""Data export functionality.
+
+This package will be responsible for exporting data into various formats or
+external systems.
+
+TODO: Implement export formats and mechanisms.
+"""

--- a/src/persistence/__init__.py
+++ b/src/persistence/__init__.py
@@ -1,0 +1,7 @@
+"""Persistence interfaces and implementations.
+
+This package will offer database abstractions and models for storing and
+retrieving application data.
+
+TODO: Provide database abstractions and models.
+"""

--- a/src/web/__init__.py
+++ b/src/web/__init__.py
@@ -1,0 +1,7 @@
+"""Web-facing components for the project.
+
+This package will include API endpoints, web user interfaces, and related
+utilities.
+
+TODO: Implement web server and routing.
+"""

--- a/tests/test_package_imports.py
+++ b/tests/test_package_imports.py
@@ -1,0 +1,26 @@
+"""Tests for presence of new packages.
+
+These tests ensure that the top-level architectural packages exist and are
+importable. The packages currently act as placeholders for future
+implementation.
+"""
+
+from importlib import import_module
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "package_name",
+    ["core", "agents", "persistence", "web", "export"],
+)
+def test_package_is_importable(package_name: str) -> None:
+    """Verify that the placeholder package can be imported.
+
+    Parameters
+    ----------
+    package_name:
+        The dotted path of the package to import.
+    """
+    module = import_module(package_name)
+    assert module.__spec__ is not None


### PR DESCRIPTION
## Summary
- scaffold empty core packages for future development
- expose new packages via pyproject and docs placeholder
- ensure orchestration imports avoid missing CompiledGraph

## Testing
- `pip install -e .[test]`
- `black src/agentic_demo/orchestration/graph.py`
- `ruff check src/agentic_demo/orchestration/graph.py`
- `mypy src/agentic_demo/orchestration/graph.py`
- `bandit -r src -ll`
- `pip-audit` *(fails: SSL CERTIFICATE_VERIFY_FAILED)*
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_688e0e6ed958832b93542824065e4790