### PR TITLE
chore: add pre-commit and dev tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.1.0
+    hooks:
+      - id: flake8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ ruff = ">=0.4"
 mypy = ">=1.8"
 bandit = ">=1.7"
 pip-audit = ">=2.7"
+flake8 = ">=7.0"
+isort = ">=5.13"
+pre-commit = ">=3.7"
 
 [tool.poetry.extras]
 test = ["pytest", "pytest-cov", "pytest-asyncio"]


### PR DESCRIPTION
## Summary
- configure pre-commit with black, isort, and flake8 hooks
- declare pre-commit, isort, and flake8 as dev dependencies

## Testing
- `pre-commit run --files pyproject.toml .pre-commit-config.yaml`
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /pypi/agentic-demo/0.1.0/json (Caused by SSLError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)')))*
- `pytest --cov` *(fails: KeyError: '__start__')*


------
https://chatgpt.com/codex/tasks/task_e_688e0e4814e8832bb8bbcb330d30030a