### PR TITLE
feat: add domain-based dedupe

### DIFF
--- a/src/web/researcher_web.py
+++ b/src/web/researcher_web.py
@@ -34,13 +34,19 @@ async def _fetch(url: str) -> CitationResult:
 
 
 def _normalize(url: str) -> str:
-    """Normalize a URL for similarity comparison."""
+    """Normalize ``url`` to its canonical domain.
+
+    Args:
+        url: URL string to normalize.
+
+    Returns:
+        Lower-cased domain without scheme or a leading ``www``.
+    """
     parsed = urlparse(url)
     netloc = parsed.netloc.lower()
     if netloc.startswith("www."):
         netloc = netloc[4:]
-    path = parsed.path.rstrip("/").lower()
-    return f"{netloc}{path}"
+    return netloc
 
 
 async def researcher_web(
@@ -56,6 +62,7 @@ async def researcher_web(
 
     Returns:
         Deduplicated list of :class:`CitationResult` objects preserving input order.
+        Only the first result for each domain is retained.
 
     Exceptions are suppressed; failed fetches are omitted from the results.
     """

--- a/tests/test_researcher_web.py
+++ b/tests/test_researcher_web.py
@@ -13,8 +13,8 @@ web_module = importlib.import_module("web.researcher_web")
 @pytest.mark.asyncio
 async def test_researcher_web_deduplicates_and_fetches_concurrently():
     urls = [
-        "https://Example.com/path",
-        "http://example.com/path/",
+        "https://Example.com/path1",
+        "http://example.com/path2",
         "https://another.com/article",
     ]
     call_count = 0


### PR DESCRIPTION
## Summary
- de-duplicate URL fetches by canonical domain
- clarify concurrent fetching with domain-based aggregation
- test fan-out timing and domain-based de-duplication

## Testing
- `ruff check src/web/researcher_web.py tests/test_researcher_web.py`
- `mypy src/web/researcher_web.py`
- `bandit -r src -ll`
- `pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /pypi/agentic-demo/0.1.0/json (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)')))*
- `pytest tests/test_researcher_web.py --cov=web.researcher_web -q`
- `pytest --cov` *(fails: ModuleNotFoundError: No module named 'agentic_demo.orchestration.state')*

------
https://chatgpt.com/codex/tasks/task_e_688ef75bc368832baebbba96e506fe39