### PR TITLE
feat: add Perplexity client with offline cache

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,9 @@ readme = "README.md"
 requires-python = ">= 3.11,<4"
 dependencies = [
     "python-dotenv (>=1.1.1,<2.0.0)",
-    "pydantic (>=2.11.7,<3.0.0)"
+    "pydantic (>=2.11.7,<3.0.0)",
+    "aiosqlite (>=0.19,<1.0)",
+    "httpx (>=0.26,<1.0)"
 ]
 
 [build-system]
@@ -25,3 +27,11 @@ ruff = ">=0.4"
 mypy = ">=1.8"
 bandit = ">=1.7"
 pip-audit = ">=2.7"
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-cov",
+    "httpx",
+    "aiosqlite",
+]

--- a/src/agents/copyright_filter.py
+++ b/src/agents/copyright_filter.py
@@ -1,0 +1,28 @@
+"""Allowlist filtering for citation drafts."""
+
+from __future__ import annotations
+
+from typing import List
+from urllib.parse import urlparse
+
+from config import Settings
+
+from .researcher_web import CitationDraft
+
+
+def filter_allowlist(
+    results: List[CitationDraft],
+) -> tuple[List[CitationDraft], List[CitationDraft]]:
+    """Split drafts into kept and dropped based on an allowlist."""
+
+    settings = Settings()
+    patterns = [p.lower() for p in settings.allowlist_domains]
+    kept: List[CitationDraft] = []
+    dropped: List[CitationDraft] = []
+    for draft in results:
+        domain = urlparse(draft.url).netloc.lower()
+        if any(pattern in domain for pattern in patterns):
+            kept.append(draft)
+        else:
+            dropped.append(draft)
+    return kept, dropped

--- a/src/agents/offline_cache.py
+++ b/src/agents/offline_cache.py
@@ -1,0 +1,40 @@
+"""Offline search result caching utilities."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict
+from pathlib import Path
+from typing import TYPE_CHECKING, List, Optional
+
+# Directory for cached search results
+CACHE_DIR = Path("workspace/cache")
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type hints only
+    from .researcher_web import RawSearchResult
+
+
+def _cache_file(query: str) -> Path:
+    """Return filesystem path for ``query``'s cached results."""
+    sanitized = re.sub(r"[^A-Za-z0-9_-]", "_", query)
+    return CACHE_DIR / f"{sanitized}.json"
+
+
+def load_cached_results(query: str) -> Optional[List["RawSearchResult"]]:
+    """Load cached search results for ``query`` if available."""
+    from .researcher_web import RawSearchResult
+
+    path = _cache_file(query)
+    if not path.exists():
+        return None
+    data = json.loads(path.read_text())
+    return [RawSearchResult(**item) for item in data]
+
+
+def save_cached_results(query: str, results: List["RawSearchResult"]) -> None:
+    """Persist ``results`` for ``query`` to the cache directory."""
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    path = _cache_file(query)
+    data = [asdict(result) for result in results]
+    path.write_text(json.dumps(data))

--- a/src/agents/researcher_pipeline.py
+++ b/src/agents/researcher_pipeline.py
@@ -1,0 +1,48 @@
+"""Pipeline orchestration for researcher web search."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List
+
+import httpx
+
+from core.state import State
+from persistence import Citation, CitationRepo, get_db_session
+
+from .copyright_filter import filter_allowlist
+from .researcher_web import CitationDraft, rank_by_authority
+from .researcher_web_runner import run_web_search
+
+
+def _lookup_licence(url: str) -> str:
+    """Fetch licence information via HTTP HEAD."""
+
+    try:
+        response = httpx.head(url, timeout=5.0)
+        return response.headers.get("License", "")
+    except Exception:
+        return ""
+
+
+async def researcher_pipeline(query: str, state: State) -> List[Citation]:
+    """Execute the researcher pipeline for ``query``."""
+
+    state.prompt = query
+    drafts: List[CitationDraft] = run_web_search(state)
+    ranked = rank_by_authority(drafts)
+    kept, _ = filter_allowlist(ranked)
+    citations: List[Citation] = []
+    workspace_id = getattr(state, "workspace_id", "default")
+    async with get_db_session() as conn:
+        repo = CitationRepo(conn, workspace_id)
+        for draft in kept:
+            citation = Citation(
+                url=draft.url,
+                title=draft.title,
+                retrieved_at=datetime.utcnow(),
+                licence=_lookup_licence(draft.url) or "unknown",
+            )
+            await repo.insert(citation)
+            citations.append(citation)
+    return citations

--- a/src/agents/researcher_web.py
+++ b/src/agents/researcher_web.py
@@ -1,0 +1,55 @@
+"""Client for the Perplexity search API with offline fallback."""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+from dataclasses import dataclass
+from typing import List
+
+from .offline_cache import load_cached_results, save_cached_results
+
+
+@dataclass(slots=True)
+class RawSearchResult:
+    """Minimal search result returned by Perplexity."""
+
+    url: str
+    snippet: str
+    title: str
+
+
+class PerplexityClient:
+    """Wrapper around the Perplexity search endpoint."""
+
+    endpoint = "https://api.perplexity.ai/search"
+
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
+
+    def search(self, query: str) -> List[RawSearchResult]:
+        """Call the remote API and cache results."""
+        payload = json.dumps({"q": query}).encode("utf-8")
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.api_key}",
+        }
+        request = urllib.request.Request(
+            self.endpoint, data=payload, headers=headers, method="POST"
+        )
+        with urllib.request.urlopen(request) as response:  # nosec B310
+            data = json.loads(response.read().decode("utf-8"))
+        results = [
+            RawSearchResult(
+                url=item.get("url", ""),
+                snippet=item.get("snippet", ""),
+                title=item.get("title", ""),
+            )
+            for item in data.get("search_results", [])
+        ]
+        save_cached_results(query, results)
+        return results
+
+    def fallback_search(self, query: str) -> List[RawSearchResult]:
+        """Load cached results when offline."""
+        return load_cached_results(query) or []

--- a/src/agents/researcher_web_runner.py
+++ b/src/agents/researcher_web_runner.py
@@ -2,22 +2,12 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import List
 
 from config import Settings
 from core.state import State
 
-from .researcher_web import PerplexityClient, RawSearchResult
-
-
-@dataclass(slots=True)
-class CitationDraft:
-    """Preliminary citation information from a web search."""
-
-    url: str
-    snippet: str
-    title: str
+from .researcher_web import CitationDraft, PerplexityClient, RawSearchResult
 
 
 def _to_draft(result: RawSearchResult) -> CitationDraft:

--- a/src/agents/researcher_web_runner.py
+++ b/src/agents/researcher_web_runner.py
@@ -1,0 +1,35 @@
+"""Entry point for performing a web search based on state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from config import Settings
+from core.state import State
+
+from .researcher_web import PerplexityClient, RawSearchResult
+
+
+@dataclass(slots=True)
+class CitationDraft:
+    """Preliminary citation information from a web search."""
+
+    url: str
+    snippet: str
+    title: str
+
+
+def _to_draft(result: RawSearchResult) -> CitationDraft:
+    return CitationDraft(url=result.url, snippet=result.snippet, title=result.title)
+
+
+def run_web_search(state: State) -> List[CitationDraft]:
+    """Run a Perplexity search using the state's prompt as query."""
+    settings = Settings()
+    client = PerplexityClient(settings.perplexity_api_key)
+    if settings.offline_mode:
+        results = client.fallback_search(state.prompt)
+    else:
+        results = client.search(state.prompt)
+    return [_to_draft(r) for r in results]

--- a/src/config.py
+++ b/src/config.py
@@ -6,6 +6,7 @@ Exposes configuration via a :class:`pydantic_settings.BaseSettings` subclass.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import List
 
 from dotenv import load_dotenv
 from pydantic import Field
@@ -52,6 +53,11 @@ class Settings(BaseSettings):
         False,
         alias="OFFLINE_MODE",
         description="Run application without external network calls.",
+    )
+    allowlist_domains: List[str] = Field(
+        default_factory=lambda: ["wikipedia.org", ".edu", ".gov"],
+        alias="ALLOWLIST_DOMAINS",
+        description="Domain patterns permitted for citation use.",
     )
 
     model_config = SettingsConfigDict(

--- a/src/core/nodes/researcher_web.py
+++ b/src/core/nodes/researcher_web.py
@@ -1,18 +1,17 @@
-"""Researcher node invoking the web helper."""
+"""Researcher node delegating to the researcher pipeline."""
 
 from __future__ import annotations
 
 from typing import List
 
-from core.state import State
-from web.researcher_web import CitationResult, researcher_web
+from agents.researcher_pipeline import researcher_pipeline
+from core.state import Citation as StateCitation, State
 
 
-async def run_researcher_web(state: State) -> List[CitationResult]:
-    """Fire off web searches and return ranked snippets + metadata.
+async def run_researcher_web(state: State) -> List[StateCitation]:
+    """Execute the web research pipeline and update state sources."""
 
-    TODO: Enhance with query generation and ranking algorithms.
-    """
-
-    urls = [c.url for c in state.sources]
-    return await researcher_web(urls)
+    citations = await researcher_pipeline(state.prompt, state)
+    new_sources = [StateCitation(url=c.url) for c in citations]
+    state.sources.extend(new_sources)
+    return new_sources

--- a/src/persistence/__init__.py
+++ b/src/persistence/__init__.py
@@ -1,5 +1,13 @@
 """Persistence layer for the agentic demo."""
 
 from .sqlite import AsyncSqliteSaver
+from .models import Citation
+from .db import get_db_session
+from .repositories.citation_repo import CitationRepo
 
-__all__ = ["AsyncSqliteSaver"]
+__all__ = [
+    "AsyncSqliteSaver",
+    "Citation",
+    "CitationRepo",
+    "get_db_session",
+]

--- a/src/persistence/db.py
+++ b/src/persistence/db.py
@@ -1,0 +1,24 @@
+"""Database connection helpers."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator
+
+import aiosqlite
+
+from config import Settings
+
+
+@asynccontextmanager
+async def get_db_session() -> AsyncGenerator[aiosqlite.Connection, None]:
+    """Yield a connection to the application's SQLite database."""
+
+    settings = Settings()
+    db_path = settings.data_dir / "citations.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = await aiosqlite.connect(db_path)
+    try:
+        yield conn
+    finally:
+        await conn.close()

--- a/src/persistence/migrations/0001_create_citations_table.py
+++ b/src/persistence/migrations/0001_create_citations_table.py
@@ -1,0 +1,31 @@
+"""Create citations table."""
+
+from __future__ import annotations
+
+from alembic import op  # type: ignore[import]
+import sqlalchemy as sa  # type: ignore[import]
+
+revision = "0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Apply the migration."""
+
+    op.create_table(
+        "citations",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("workspace_id", sa.String, nullable=False),
+        sa.Column("url", sa.String, nullable=False, unique=True),
+        sa.Column("title", sa.String, nullable=False),
+        sa.Column("retrieved_at", sa.DateTime, nullable=False),
+        sa.Column("licence", sa.String, nullable=False),
+    )
+
+
+def downgrade() -> None:
+    """Revert the migration."""
+
+    op.drop_table("citations")

--- a/src/persistence/models.py
+++ b/src/persistence/models.py
@@ -1,0 +1,15 @@
+"""Persistence data models."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pydantic import BaseModel, HttpUrl
+
+
+class Citation(BaseModel):
+    """Stored reference to an external source."""
+
+    url: HttpUrl
+    title: str
+    retrieved_at: datetime
+    licence: str

--- a/src/persistence/repositories/citation_repo.py
+++ b/src/persistence/repositories/citation_repo.py
@@ -1,0 +1,79 @@
+"""Repository for managing citations."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+import aiosqlite
+
+from ..models import Citation
+
+
+class CitationRepo:
+    """Provide CRUD operations for :class:`Citation` records."""
+
+    def __init__(self, conn: aiosqlite.Connection, workspace_id: str) -> None:
+        self._conn = conn
+        self._workspace_id = workspace_id
+
+    async def insert(self, citation: Citation) -> None:
+        """Insert or replace a citation record."""
+
+        await self._conn.execute(
+            """
+            INSERT OR REPLACE INTO citations (workspace_id, url, title, retrieved_at, licence)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                self._workspace_id,
+                str(citation.url),
+                citation.title,
+                citation.retrieved_at.isoformat(),
+                citation.licence,
+            ),
+        )
+        await self._conn.commit()
+
+    async def get_by_url(self, url: str) -> Optional[Citation]:
+        """Return a citation matching ``url`` if present."""
+
+        cur = await self._conn.execute(
+            """
+            SELECT url, title, retrieved_at, licence FROM citations
+            WHERE workspace_id = ? AND url = ?
+            """,
+            (self._workspace_id, url),
+        )
+        row = await cur.fetchone()
+        await cur.close()
+        if row is None:
+            return None
+        return Citation(
+            url=row[0],
+            title=row[1],
+            retrieved_at=datetime.fromisoformat(row[2]),
+            licence=row[3],
+        )
+
+    async def list_by_workspace(self, workspace_id: str) -> List[Citation]:
+        """List all citations for ``workspace_id``."""
+
+        cur = await self._conn.execute(
+            """
+            SELECT url, title, retrieved_at, licence FROM citations
+            WHERE workspace_id = ?
+            """,
+            (workspace_id,),
+        )
+        rows = await cur.fetchall()
+        await cur.close()
+        return [
+            Citation(
+                url=row[0],
+                title=row[1],
+                retrieved_at=datetime.fromisoformat(row[2]),
+                licence=row[3],
+            )
+            for row in rows
+        ]

--- a/tests/test_authority_and_filter.py
+++ b/tests/test_authority_and_filter.py
@@ -1,0 +1,30 @@
+from agents.researcher_web import CitationDraft, rank_by_authority
+from agents.copyright_filter import filter_allowlist
+
+
+def _set_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk")
+    monkeypatch.setenv("PERPLEXITY_API_KEY", "pk")
+    monkeypatch.setenv("MODEL_NAME", "gpt")
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+
+
+def test_rank_by_authority_sorts(monkeypatch, tmp_path):
+    _set_env(monkeypatch, tmp_path)
+    low = CitationDraft(url="http://blog.com", snippet="", title="")
+    high = CitationDraft(url="http://uni.edu", snippet="", title="")
+    ranked = rank_by_authority([low, high])
+    assert ranked[0] == high
+
+
+def test_filter_allowlist(monkeypatch, tmp_path):
+    _set_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("ALLOWLIST_DOMAINS", '["example.com", ".edu"]')
+    drafts = [
+        CitationDraft(url="http://example.com/a", snippet="", title=""),
+        CitationDraft(url="http://other.net", snippet="", title=""),
+        CitationDraft(url="http://site.edu/info", snippet="", title=""),
+    ]
+    kept, dropped = filter_allowlist(drafts)
+    assert [d.url for d in kept] == ["http://example.com/a", "http://site.edu/info"]
+    assert [d.url for d in dropped] == ["http://other.net"]

--- a/tests/test_citation_repo.py
+++ b/tests/test_citation_repo.py
@@ -1,0 +1,77 @@
+"""Tests for the citation repository."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from persistence import Citation, CitationRepo, get_db_session
+
+
+CREATE_TABLE_SQL = """
+CREATE TABLE citations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    workspace_id TEXT NOT NULL,
+    url TEXT UNIQUE NOT NULL,
+    title TEXT NOT NULL,
+    retrieved_at TEXT NOT NULL,
+    licence TEXT NOT NULL
+)
+"""
+
+
+@pytest.mark.asyncio
+async def test_insert_and_get_by_url(tmp_path, monkeypatch):
+    """Inserting then fetching a citation returns the same record."""
+
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setenv("PERPLEXITY_API_KEY", "x")
+    monkeypatch.setenv("MODEL_NAME", "model")
+    async with get_db_session() as conn:
+        await conn.execute(CREATE_TABLE_SQL)
+        await conn.commit()
+        repo = CitationRepo(conn, "ws1")
+        citation = Citation(
+            url="https://example.com",
+            title="Example",
+            retrieved_at=datetime.utcnow(),
+            licence="CC0",
+        )
+        await repo.insert(citation)
+        fetched = await repo.get_by_url(str(citation.url))
+        assert fetched == citation
+
+
+@pytest.mark.asyncio
+async def test_list_by_workspace(tmp_path, monkeypatch):
+    """Listing citations returns only those for the requested workspace."""
+
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setenv("PERPLEXITY_API_KEY", "x")
+    monkeypatch.setenv("MODEL_NAME", "model")
+    async with get_db_session() as conn:
+        await conn.execute(CREATE_TABLE_SQL)
+        await conn.commit()
+        repo1 = CitationRepo(conn, "ws1")
+        repo2 = CitationRepo(conn, "ws2")
+        citation1 = Citation(
+            url="https://a.example.com",
+            title="A",
+            retrieved_at=datetime.utcnow(),
+            licence="L1",
+        )
+        citation2 = Citation(
+            url="https://b.example.com",
+            title="B",
+            retrieved_at=datetime.utcnow(),
+            licence="L2",
+        )
+        await repo1.insert(citation1)
+        await repo2.insert(citation2)
+        ws1 = await repo1.list_by_workspace("ws1")
+        ws2 = await repo2.list_by_workspace("ws2")
+        assert ws1 == [citation1]
+        assert ws2 == [citation2]

--- a/tests/test_perplexity_client.py
+++ b/tests/test_perplexity_client.py
@@ -1,0 +1,45 @@
+import json
+import urllib.request
+
+from agents import offline_cache
+from agents.researcher_web import PerplexityClient, RawSearchResult
+
+
+def test_search_hits_api_and_caches_results(monkeypatch, tmp_path):
+    monkeypatch.setattr(offline_cache, "CACHE_DIR", tmp_path)
+
+    payload = {
+        "search_results": [
+            {"url": "http://example.com", "snippet": "snippet", "title": "title"}
+        ]
+    }
+
+    class DummyResponse:
+        def read(self):
+            return json.dumps(payload).encode("utf-8")
+
+        def __enter__(self):  # pragma: no cover - trivial
+            return self
+
+        def __exit__(self, *exc):  # pragma: no cover - trivial
+            return None
+
+    monkeypatch.setattr(urllib.request, "urlopen", lambda req: DummyResponse())
+
+    client = PerplexityClient(api_key="token")
+    results = client.search("hello world")
+
+    assert results == [
+        RawSearchResult(url="http://example.com", snippet="snippet", title="title")
+    ]
+    assert (tmp_path / "hello_world.json").exists()
+
+
+def test_fallback_search_returns_cached(monkeypatch, tmp_path):
+    monkeypatch.setattr(offline_cache, "CACHE_DIR", tmp_path)
+    expected = [RawSearchResult(url="http://a", snippet="b", title="c")]
+    offline_cache.save_cached_results("query", expected)
+
+    client = PerplexityClient(api_key="token")
+    results = client.fallback_search("query")
+    assert results == expected

--- a/tests/test_researcher_pipeline.py
+++ b/tests/test_researcher_pipeline.py
@@ -1,0 +1,76 @@
+import aiosqlite
+import asyncio
+from contextlib import asynccontextmanager
+
+from agents.researcher_pipeline import researcher_pipeline
+from agents.researcher_web import CitationDraft
+from core.state import State
+
+CREATE_TABLE_SQL = """
+CREATE TABLE citations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    workspace_id TEXT NOT NULL,
+    url TEXT UNIQUE NOT NULL,
+    title TEXT NOT NULL,
+    retrieved_at TEXT NOT NULL,
+    licence TEXT NOT NULL
+)
+"""
+
+
+def test_researcher_pipeline_persists(monkeypatch, tmp_path):
+    async def run() -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "sk")
+        monkeypatch.setenv("PERPLEXITY_API_KEY", "pk")
+        monkeypatch.setenv("MODEL_NAME", "gpt")
+        monkeypatch.setenv("DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("ALLOWLIST_DOMAINS", '["example.com"]')
+
+        db_file = tmp_path / "citations.db"
+
+        @asynccontextmanager
+        async def fake_get_db_session():
+            conn = await aiosqlite.connect(db_file)
+            await conn.execute(CREATE_TABLE_SQL)
+            await conn.commit()
+            try:
+                yield conn
+            finally:
+                await conn.close()
+
+        monkeypatch.setattr(
+            "agents.researcher_pipeline.get_db_session", fake_get_db_session
+        )
+
+        drafts = [
+            CitationDraft(url="http://example.com/a", snippet="", title="A"),
+            CitationDraft(url="http://other.com/b", snippet="", title="B"),
+        ]
+
+        def fake_run_web_search(state):
+            return drafts
+
+        monkeypatch.setattr(
+            "agents.researcher_pipeline.run_web_search", fake_run_web_search
+        )
+
+        class DummyResponse:
+            headers = {"License": "CC0"}
+
+        monkeypatch.setattr(
+            "agents.researcher_pipeline.httpx.head",
+            lambda url, timeout=5.0: DummyResponse(),
+        )
+
+        state = State(prompt="")
+        results = await researcher_pipeline("query", state)
+        assert len(results) == 1
+        assert str(results[0].url) == "http://example.com/a"
+
+        async with aiosqlite.connect(db_file) as check:
+            cur = await check.execute("SELECT url FROM citations")
+            rows = await cur.fetchall()
+            assert rows == [("http://example.com/a",)]
+            await cur.close()
+
+    asyncio.run(run())

--- a/tests/test_researcher_web_runner.py
+++ b/tests/test_researcher_web_runner.py
@@ -1,5 +1,5 @@
-from agents.researcher_web import RawSearchResult
-from agents.researcher_web_runner import CitationDraft, run_web_search
+from agents.researcher_web import CitationDraft, RawSearchResult
+from agents.researcher_web_runner import run_web_search
 from core.state import State
 
 

--- a/tests/test_researcher_web_runner.py
+++ b/tests/test_researcher_web_runner.py
@@ -1,0 +1,71 @@
+from agents.researcher_web import RawSearchResult
+from agents.researcher_web_runner import CitationDraft, run_web_search
+from core.state import State
+
+
+def _set_env(monkeypatch, offline: bool) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk")
+    monkeypatch.setenv("PERPLEXITY_API_KEY", "pp")
+    monkeypatch.setenv("MODEL_NAME", "gpt")
+    monkeypatch.setenv("DATA_DIR", "/tmp")
+    monkeypatch.setenv("OFFLINE_MODE", "1" if offline else "0")
+
+
+def test_run_web_search_online(monkeypatch):
+    _set_env(monkeypatch, offline=False)
+
+    state = State(prompt="cats")
+    called = {"search": False, "fallback": False}
+    results = [RawSearchResult(url="u", snippet="s", title="t")]
+
+    def fake_search(self, query):
+        called["search"] = True
+        return results
+
+    def fake_fallback(self, query):
+        called["fallback"] = True
+        return []
+
+    monkeypatch.setattr(
+        "agents.researcher_web.PerplexityClient.search", fake_search, raising=False
+    )
+    monkeypatch.setattr(
+        "agents.researcher_web.PerplexityClient.fallback_search",
+        fake_fallback,
+        raising=False,
+    )
+
+    citations = run_web_search(state)
+    assert called["search"] is True
+    assert called["fallback"] is False
+    assert citations == [CitationDraft(url="u", snippet="s", title="t")]
+
+
+def test_run_web_search_offline(monkeypatch):
+    _set_env(monkeypatch, offline=True)
+
+    state = State(prompt="dogs")
+    called = {"search": False, "fallback": False}
+    results = [RawSearchResult(url="u2", snippet="s2", title="t2")]
+
+    def fake_search(self, query):
+        called["search"] = True
+        return []
+
+    def fake_fallback(self, query):
+        called["fallback"] = True
+        return results
+
+    monkeypatch.setattr(
+        "agents.researcher_web.PerplexityClient.search", fake_search, raising=False
+    )
+    monkeypatch.setattr(
+        "agents.researcher_web.PerplexityClient.fallback_search",
+        fake_fallback,
+        raising=False,
+    )
+
+    citations = run_web_search(state)
+    assert called["search"] is False
+    assert called["fallback"] is True
+    assert citations == [CitationDraft(url="u2", snippet="s2", title="t2")]


### PR DESCRIPTION
## Summary
- implement Perplexity API client with caching and offline fallback
- add offline cache utilities
- wire up web search runner returning citation drafts

## Testing
- `pip install -e .[test]` (failed: ModuleOrPackageNotFoundError)
- `black .`
- `ruff check .`
- `mypy src/agents tests/test_perplexity_client.py tests/test_researcher_web_runner.py --ignore-missing-imports`
- `bandit -r src -ll`
- `pip-audit` (failed: CERTIFICATE_VERIFY_FAILED)
- `PYTHONPATH=src pytest tests/test_perplexity_client.py tests/test_researcher_web_runner.py -q`
- `PYTHONPATH=src pytest --cov` (failed: errors during collection)


------
https://chatgpt.com/codex/tasks/task_e_688f477ec960832bb76d2b37359f2e26