### PR TITLE
Add lecture JSON schema

### DIFF
--- a/src/schemas/lecture_schema.json
+++ b/src/schemas/lecture_schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "learning_objectives": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "activities": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {"type": "string"},
+          "description": {"type": "string"},
+          "duration_min": {"type": "integer", "minimum": 0}
+        },
+        "required": ["type", "description", "duration_min"],
+        "additionalProperties": true
+      }
+    },
+    "duration_min": {
+      "type": "integer",
+      "minimum": 0
+    }
+  },
+  "required": ["learning_objectives", "activities", "duration_min"],
+  "additionalProperties": true
+}


### PR DESCRIPTION
## Summary
- define JSON schema for generated lecture outputs

## Testing
- `black .`
- `ruff check .`
- `mypy .` *(fails: Cannot find implementation or library stub for module named "agents.researcher_web" and others)*
- `bandit -r src -ll`
- `pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443)... certificate verify failed)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_688f50f93b00832b963aa10c193287c2