### PR TITLE
Add schema validation utilities and weave result model

### DIFF
--- a/src/agents/content_weaver.py
+++ b/src/agents/content_weaver.py
@@ -2,16 +2,48 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
+from pathlib import Path
+from typing import List
 
-from core.state import Outline, State
+from jsonschema import Draft202012Validator
+
+from core.state import State
+from .models import WeaveResult
+
+_schema_cache: dict | None = None
+
+
+def load_schema() -> dict:
+    """Load the lecture schema from disk once."""
+    global _schema_cache
+    if _schema_cache is None:
+        schema_path = (
+            Path(__file__).resolve().parents[1] / "schemas" / "lecture_schema.json"
+        )
+        with schema_path.open("r", encoding="utf-8") as f:
+            _schema_cache = json.load(f)
+    return _schema_cache
 
 
 @dataclass(slots=True)
-class WeaveResult:
-    """LLM weaving result placeholder."""
+class ValidationResult:
+    """Outcome of schema validation."""
 
-    outline: Outline | None = None
+    valid: bool
+    errors: List[str]
+
+
+def validate_against_schema(payload: dict) -> ValidationResult:
+    """Validate payload using the lecture schema."""
+    schema = load_schema()
+    validator = Draft202012Validator(schema)
+    errors = [
+        f"{'/'.join(str(p) for p in err.path)}: {err.message}"
+        for err in validator.iter_errors(payload)
+    ]
+    return ValidationResult(valid=not errors, errors=errors)
 
 
 async def run_content_weaver(state: State) -> WeaveResult:
@@ -19,5 +51,4 @@ async def run_content_weaver(state: State) -> WeaveResult:
 
     TODO: Integrate actual LLM calls and streaming mechanisms.
     """
-
-    return WeaveResult(outline=state.outline)
+    return WeaveResult(learning_objectives=[], activities=[], duration_min=0)

--- a/src/agents/content_weaver.py
+++ b/src/agents/content_weaver.py
@@ -24,9 +24,14 @@ class RetryableError(RuntimeError):
 
 
 def stream_messages(token: str) -> None:
-    """Placeholder streamer forwarding ``token`` to an observer."""
+    """Forward ``token`` over the LangGraph "messages" channel."""
 
-    print(token, end="", flush=True)
+    try:
+        from langgraph_sdk import stream  # type: ignore
+
+        stream("messages", token)
+    except Exception:  # pragma: no cover - optional dependency
+        print(token, end="", flush=True)
 
 
 _schema_cache: dict | None = None

--- a/src/agents/content_weaver.py
+++ b/src/agents/content_weaver.py
@@ -10,7 +10,13 @@ from typing import AsyncGenerator, List
 from jsonschema import Draft202012Validator
 
 from core.state import State
-from .models import Activity, SlideBullet, WeaveResult
+from .models import (
+    Activity,
+    SlideBullet,
+    AssessmentItem,
+    Citation,
+    WeaveResult,
+)
 
 
 class RetryableError(RuntimeError):
@@ -123,12 +129,31 @@ async def content_weaver(state: State) -> WeaveResult:
         if payload.get("slide_bullets")
         else None
     )
+    assessment = (
+        [AssessmentItem(**a) for a in payload.get("assessment", [])]
+        if payload.get("assessment")
+        else None
+    )
+    references = (
+        [Citation(**c) for c in payload.get("references", [])]
+        if payload.get("references")
+        else None
+    )
     return WeaveResult(
+        title=payload.get("title", ""),
         learning_objectives=payload.get("learning_objectives", []),
         activities=activities,
         duration_min=payload.get("duration_min", 0),
+        author=payload.get("author"),
+        date=payload.get("date"),
+        version=payload.get("version"),
+        summary=payload.get("summary"),
+        tags=payload.get("tags"),
+        prerequisites=payload.get("prerequisites"),
         slide_bullets=slide_bullets,
         speaker_notes=payload.get("speaker_notes"),
+        assessment=assessment,
+        references=references,
     )
 
 

--- a/src/agents/models.py
+++ b/src/agents/models.py
@@ -1,0 +1,35 @@
+"""Domain models for agent interactions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass(slots=True)
+class Activity:
+    """Learning activity performed during the lecture."""
+
+    type: str
+    description: str
+    duration_min: int
+    learning_objectives: List[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class SlideBullet:
+    """Bullet points associated with a slide."""
+
+    slide_number: int
+    bullets: List[str]
+
+
+@dataclass(slots=True)
+class WeaveResult:
+    """Typed container mirroring the weave schema output."""
+
+    learning_objectives: List[str]
+    activities: List[Activity]
+    duration_min: int
+    slide_bullets: Optional[List[SlideBullet]] = None
+    speaker_notes: Optional[str] = None

--- a/src/agents/models.py
+++ b/src/agents/models.py
@@ -25,11 +25,39 @@ class SlideBullet:
 
 
 @dataclass(slots=True)
+class AssessmentItem:
+    """Assessment or quiz used to evaluate understanding."""
+
+    type: str
+    description: str
+    max_score: Optional[float] = None
+
+
+@dataclass(slots=True)
+class Citation:
+    """Reference to an external source."""
+
+    url: str
+    title: str
+    retrieved_at: str
+    licence: Optional[str] = None
+
+
+@dataclass(slots=True)
 class WeaveResult:
     """Typed container mirroring the weave schema output."""
 
+    title: str
     learning_objectives: List[str]
     activities: List[Activity]
     duration_min: int
+    author: Optional[str] = None
+    date: Optional[str] = None
+    version: Optional[str] = None
+    summary: Optional[str] = None
+    tags: Optional[List[str]] = None
+    prerequisites: Optional[List[str]] = None
     slide_bullets: Optional[List[SlideBullet]] = None
     speaker_notes: Optional[str] = None
+    assessment: Optional[List[AssessmentItem]] = None
+    references: Optional[List[Citation]] = None

--- a/src/export/markdown.py
+++ b/src/export/markdown.py
@@ -1,0 +1,172 @@
+"""Markdown export utilities.
+
+This module converts :class:`~agents.models.WeaveResult` instances into a
+Markdown document.  It is intentionally lightweight so that callers can
+persist or display lecture plans without needing a full Markdown
+framework.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Union
+
+from agents.models import (
+    Activity,
+    AssessmentItem,
+    Citation,
+    SlideBullet,
+    WeaveResult,
+)
+
+
+def render_section(title: str, content: Union[str, Iterable[str], None]) -> str:
+    """Render a heading followed by bullet points or text.
+
+    Parameters
+    ----------
+    title:
+        Heading title for the section.
+    content:
+        Either a string which will be placed under the heading, an iterable of
+        strings to be rendered as bullet points, or ``None`` to omit the
+        section entirely.
+
+    Returns
+    -------
+    str
+        Formatted Markdown section or an empty string if ``content`` is empty.
+    """
+
+    if not content:
+        return ""
+
+    lines: List[str] = [f"## {title}"]
+    if isinstance(content, str):
+        lines.append(content)
+    else:
+        for item in content:
+            lines.append(f"- {item}")
+
+    return "\n".join(lines) + "\n\n"
+
+
+def embed_citations(md: str, citations: List[Citation]) -> str:
+    """Append citation footnotes to Markdown text.
+
+    Each citation is referenced sequentially using the ``[^n]`` Markdown
+    footnote syntax.  Callers are expected to insert ``[^n]`` markers in the
+    document body in the same order.
+    """
+
+    if not citations:
+        return md
+
+    footnotes: List[str] = []
+    for idx, cite in enumerate(citations, start=1):
+        note = f"[^{idx}]: {cite.title} - {cite.url} (retrieved {cite.retrieved_at})"
+        if cite.licence:
+            note += f" — {cite.licence}"
+        footnotes.append(note)
+
+    return md + "\n" + "\n".join(footnotes) + "\n"
+
+
+def _render_activities(activities: List[Activity]) -> List[str]:
+    """Format activity entries for the Markdown exporter."""
+
+    lines: List[str] = []
+    for activity in activities:
+        desc = f"{activity.type} ({activity.duration_min} min): {activity.description}"
+        if activity.learning_objectives:
+            desc += f" — objectives: {', '.join(activity.learning_objectives)}"
+        lines.append(desc)
+    return lines
+
+
+def _render_assessment(items: List[AssessmentItem]) -> List[str]:
+    """Format assessment items for Markdown output."""
+
+    lines: List[str] = []
+    for item in items:
+        desc = f"{item.type}: {item.description}"
+        if item.max_score is not None:
+            desc += f" (max {item.max_score})"
+        lines.append(desc)
+    return lines
+
+
+def _render_slides(slides: List[SlideBullet]) -> str:
+    """Render slide bullets as individual sections."""
+
+    sections: List[str] = []
+    for slide in slides:
+        sections.append(render_section(f"Slide {slide.slide_number}", slide.bullets))
+    return "".join(sections)
+
+
+def from_weave_result(weave: WeaveResult, citations: List[Citation]) -> str:
+    """Convert a :class:`WeaveResult` and citations into Markdown.
+
+    Parameters
+    ----------
+    weave:
+        Structured output from the content weaver agent.
+    citations:
+        Citations referenced by the document.  Footnote markers ``[^n]`` are
+        inserted into the "References" section following the order provided.
+
+    Returns
+    -------
+    str
+        A full Markdown document including YAML front-matter and citation
+        footnotes.
+    """
+
+    # YAML front matter
+    front_matter_lines = ["---", f"title: {weave.title}"]
+    if weave.author:
+        front_matter_lines.append(f"author: {weave.author}")
+    if weave.date:
+        front_matter_lines.append(f"date: {weave.date}")
+    if weave.version:
+        front_matter_lines.append(f"version: {weave.version}")
+    if weave.tags:
+        tags = ", ".join(weave.tags)
+        front_matter_lines.append(f"tags: [{tags}]")
+    front_matter_lines.append("---\n")
+
+    doc_parts: List[str] = ["\n".join(front_matter_lines)]
+
+    if weave.summary:
+        doc_parts.append(render_section("Summary", weave.summary))
+
+    doc_parts.append(render_section("Learning Objectives", weave.learning_objectives))
+
+    if weave.prerequisites:
+        doc_parts.append(render_section("Prerequisites", weave.prerequisites))
+
+    if weave.activities:
+        doc_parts.append(
+            render_section("Activities", _render_activities(weave.activities))
+        )
+
+    if weave.slide_bullets:
+        doc_parts.append(_render_slides(weave.slide_bullets))
+
+    if weave.speaker_notes:
+        doc_parts.append(render_section("Speaker Notes", weave.speaker_notes))
+
+    if weave.assessment:
+        doc_parts.append(
+            render_section("Assessment", _render_assessment(weave.assessment))
+        )
+
+    if citations:
+        refs = [f"[{c.title}]({c.url})[^%d]" % (i) for i, c in enumerate(citations, 1)]
+        doc_parts.append(render_section("References", refs))
+    elif weave.references:
+        refs = [f"[{c.title}]({c.url})" for c in weave.references]
+        doc_parts.append(render_section("References", refs))
+
+    markdown = "".join(doc_parts).rstrip() + "\n"
+    return embed_citations(markdown, citations)

--- a/tests/export/test_markdown.py
+++ b/tests/export/test_markdown.py
@@ -1,0 +1,74 @@
+from agents.models import (
+    Activity,
+    AssessmentItem,
+    Citation,
+    SlideBullet,
+    WeaveResult,
+)
+from export import markdown
+
+
+def _sample_weave() -> WeaveResult:
+    return WeaveResult(
+        title="Sample Lecture",
+        learning_objectives=["Objective"],
+        activities=[
+            Activity(
+                type="Lecture",
+                description="Intro",
+                duration_min=5,
+                learning_objectives=[],
+            )
+        ],
+        duration_min=5,
+        summary="Summary text",
+        prerequisites=["Prereq"],
+        slide_bullets=[SlideBullet(slide_number=1, bullets=["Point"])],
+        speaker_notes="Notes",
+        assessment=[AssessmentItem(type="Quiz", description="Q1")],
+        references=[
+            Citation(
+                url="http://example.com/ref",
+                title="Ref",
+                retrieved_at="2024-01-01T00:00:00Z",
+            )
+        ],
+    )
+
+
+def test_from_weave_result_includes_all_sections():
+    weave = _sample_weave()
+    citations = [
+        Citation(
+            url="http://example.com/cite",
+            title="Cite",
+            retrieved_at="2024-01-01T00:00:00Z",
+        )
+    ]
+    md = markdown.from_weave_result(weave, citations)
+    assert "title: Sample Lecture" in md
+    assert "## Summary" in md
+    assert "## Learning Objectives" in md
+    assert "## Prerequisites" in md
+    assert "## Activities" in md
+    assert "## Slide 1" in md
+    assert "## Speaker Notes" in md
+    assert "## Assessment" in md
+    assert "## References" in md
+    assert "[^1]: Cite - http://example.com/cite" in md
+
+
+def test_embed_citations_generates_footnotes():
+    md = "Body text\n"
+    citations = [
+        Citation(url="http://a", title="A", retrieved_at="2024-01-01T00:00:00Z"),
+        Citation(
+            url="http://b",
+            title="B",
+            retrieved_at="2024-01-02T00:00:00Z",
+            licence="CC-BY",
+        ),
+    ]
+    result = markdown.embed_citations(md, citations)
+    assert "[^1]: A - http://a (retrieved 2024-01-01T00:00:00Z)" in result
+    assert "[^2]: B - http://b (retrieved 2024-01-02T00:00:00Z) — CC-BY" in result


### PR DESCRIPTION
## Summary
- add cached schema loader and payload validator using jsonschema
- introduce Activity, SlideBullet, and WeaveResult domain dataclasses

## Testing
- `black .`
- `ruff check .`
- `mypy .` *(fails: Cannot find implementation or library stubs for multiple modules)*
- `bandit -r src -ll`
- `pip-audit` *(fails: certificate verify failed)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_688f53c44704832ba125d1326dc65890