### PR TITLE
ci: upgrade poetry version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.13'
+          cache: 'poetry'
+          cache-dependency-path: poetry.lock
       - uses: abatilo/actions-poetry@v4
         with:
           poetry-version: '2.1.3'
@@ -25,6 +27,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.13'
+          cache: 'poetry'
+          cache-dependency-path: poetry.lock
       - uses: abatilo/actions-poetry@v4
         with:
           poetry-version: '2.1.3'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
           python-version: '3.13'
       - uses: abatilo/actions-poetry@v4
         with:
-          poetry-version: '1.8.3'
-      - run: poetry install --no-interaction --no-ansi
+          poetry-version: '2.1.3'
+      - run: poetry install --with dev,test --no-interaction --no-ansi
       - run: poetry run pre-commit run --all-files
 
   test:
@@ -27,6 +27,6 @@ jobs:
           python-version: '3.13'
       - uses: abatilo/actions-poetry@v4
         with:
-          poetry-version: '1.8.3'
-      - run: poetry install --no-interaction --no-ansi
+          poetry-version: '2.1.3'
+      - run: poetry install --with dev,test --no-interaction --no-ansi
       - run: poetry run pytest --maxfail=1 --disable-warnings -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: abatilo/actions-poetry@v4
         with:
           poetry-version: '2.1.3'
-      - run: poetry install --with dev,test --no-interaction --no-ansi
+      - run: poetry install --no-interaction --no-ansi --no-root --with dev --extras test
       - run: poetry run pre-commit run --all-files
 
   test:
@@ -32,5 +32,5 @@ jobs:
       - uses: abatilo/actions-poetry@v4
         with:
           poetry-version: '2.1.3'
-      - run: poetry install --with dev,test --no-interaction --no-ansi
+      - run: poetry install --no-interaction --no-ansi --no-root --with dev --extras test
       - run: poetry run pytest --maxfail=1 --disable-warnings -q


### PR DESCRIPTION
## Summary
- use Poetry 2.1.3 in CI workflow
- install dev and test dependency groups during CI setup

## Testing
- `poetry run black .`
- `poetry run ruff check .`
- `poetry run mypy .` *(fails: Cannot find implementation or library stub for modules)*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSL: CERTIFICATE_VERIFY_FAILED)*
- `poetry run pytest --maxfail=1 --disable-warnings -q` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_688f5fc49b78832bb8125d8022b971c8