### PR TITLE
ci: upgrade poetry version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,24 +9,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install Poetry
+        run: pipx install poetry==2.1.3
       - uses: actions/setup-python@v5
         with:
           python-version: '3.13'
-      - uses: abatilo/actions-poetry@v4
-        with:
-          poetry-version: '1.8.3'
-      - run: poetry install --no-interaction --no-ansi
+          cache: 'poetry'
+          cache-dependency-path: poetry.lock
+      - run: poetry install --with dev --extras test --no-interaction --no-ansi
       - run: poetry run pre-commit run --all-files
 
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install Poetry
+        run: pipx install poetry==2.1.3
       - uses: actions/setup-python@v5
         with:
           python-version: '3.13'
-      - uses: abatilo/actions-poetry@v4
-        with:
-          poetry-version: '1.8.3'
-      - run: poetry install --no-interaction --no-ansi
+          cache: 'poetry'
+          cache-dependency-path: poetry.lock
+      - run: poetry install --with dev --extras test --no-interaction --no-ansi
       - run: poetry run pytest --maxfail=1 --disable-warnings -q


### PR DESCRIPTION
## Summary
- use Poetry 2.1.3 in CI workflow
- install dev dependency group and test extras during CI setup
- cache Poetry dependencies to speed up CI jobs
- pre-install Poetry so actions/setup-python can restore cache without errors

## Testing
- `poetry run black .`
- `poetry run ruff check .`
- `poetry run mypy .` *(fails: import-not-found)
- `poetry run bandit -r src -ll` *(fails: Command not found: bandit)*
- `poetry run pip-audit` *(fails: Command not found: pip-audit)*
- `poetry run pytest --maxfail=1 --disable-warnings -q` *(fails: ModuleNotFoundError: No module named 'core')*


------
https://chatgpt.com/codex/tasks/task_e_688f5fc49b78832bb8125d8022b971c8