### PR TITLE
Add metrics collector and Prometheus endpoint

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -59,6 +59,11 @@ class Settings(BaseSettings):
         alias="ALLOWLIST_DOMAINS",
         description="Domain patterns permitted for citation use.",
     )
+    alert_webhook_url: str | None = Field(
+        None,
+        alias="ALERT_WEBHOOK_URL",
+        description="Webhook endpoint for threshold breach alerts.",
+    )
 
     model_config = SettingsConfigDict(
         env_prefix="", case_sensitive=True, populate_by_name=True

--- a/src/config/thresholds.yaml
+++ b/src/config/thresholds.yaml
@@ -1,0 +1,3 @@
+pedagogical_score: 0.90
+max_hallucination_rate: 0.02
+max_cost_per_lecture: 0.60

--- a/src/metrics/alerts.py
+++ b/src/metrics/alerts.py
@@ -1,0 +1,102 @@
+"""Threshold alert evaluation and webhook dispatch."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+
+import httpx
+import yaml  # type: ignore[import-untyped]
+
+import os
+
+from .repository import MetricsRepository
+
+
+@dataclass
+class AlertSummary:
+    """Result of threshold evaluation for a workspace."""
+
+    workspace_id: str
+    pedagogical_score: float
+    hallucination_rate: float
+    cost: float
+    pedagogical_breached: bool
+    hallucination_breached: bool
+    cost_breached: bool
+
+    @property
+    def has_breaches(self) -> bool:
+        """Return ``True`` if any thresholds were exceeded."""
+
+        return (
+            self.pedagogical_breached
+            or self.hallucination_breached
+            or self.cost_breached
+        )
+
+    def breach_payload(self) -> Dict[str, float]:
+        """Return metric values that breached thresholds."""
+
+        data: Dict[str, float] = {}
+        if self.pedagogical_breached:
+            data["pedagogical_score"] = self.pedagogical_score
+        if self.hallucination_breached:
+            data["hallucination_rate"] = self.hallucination_rate
+        if self.cost_breached:
+            data["cost"] = self.cost
+        return data
+
+
+class AlertManager:
+    """Evaluate metric thresholds and send webhooks on breaches."""
+
+    def __init__(
+        self,
+        repository: MetricsRepository,
+        thresholds_path: Path | None = None,
+        webhook_url: str | None = None,
+    ) -> None:
+        self._repo = repository
+        path = (
+            thresholds_path
+            if thresholds_path is not None
+            else Path(__file__).resolve().parents[1] / "config" / "thresholds.yaml"
+        )
+        with open(path, "r", encoding="utf-8") as fh:
+            self._thresholds = yaml.safe_load(fh)
+        self._webhook_url = webhook_url or os.getenv("ALERT_WEBHOOK_URL")
+
+    def evaluate_thresholds(self, workspace_id: str) -> AlertSummary:
+        """Compare recent metrics against configured thresholds."""
+
+        ped = self._repo.latest_value(workspace_id, "pedagogical_score") or 0.0
+        halluc = self._repo.latest_value(workspace_id, "hallucination_rate") or 0.0
+        cost = self._repo.latest_value(workspace_id, "cost") or 0.0
+
+        ped_breach = ped < self._thresholds["pedagogical_score"]
+        hall_breach = halluc > self._thresholds["max_hallucination_rate"]
+        cost_breach = cost > self._thresholds["max_cost_per_lecture"]
+
+        return AlertSummary(
+            workspace_id=workspace_id,
+            pedagogical_score=ped,
+            hallucination_rate=halluc,
+            cost=cost,
+            pedagogical_breached=ped_breach,
+            hallucination_breached=hall_breach,
+            cost_breached=cost_breach,
+        )
+
+    def send_webhook(self, alert: AlertSummary) -> None:
+        """POST ``alert`` details to the configured webhook if any breaches."""
+
+        if not self._webhook_url or not alert.has_breaches:
+            return
+
+        payload: Dict[str, Any] = {
+            "workspace_id": alert.workspace_id,
+            "breaches": alert.breach_payload(),
+        }
+        httpx.post(self._webhook_url, json=payload, timeout=10.0)

--- a/src/metrics/collector.py
+++ b/src/metrics/collector.py
@@ -16,11 +16,14 @@ class MetricsCollector:
         self._repo = repository
         self._buffer: List[MetricRecord] = []
 
-    def record(self, metric_name: str, value: float) -> None:
-        """Append ``metric_name`` with ``value`` to the buffer."""
+    def record(self, workspace_id: str, metric_name: str, value: float) -> None:
+        """Append ``metric_name`` with ``value`` for ``workspace_id`` to the buffer."""
 
         record = MetricRecord(
-            name=metric_name, value=value, timestamp=datetime.utcnow()
+            workspace_id=workspace_id,
+            name=metric_name,
+            value=value,
+            timestamp=datetime.utcnow(),
         )
         self._buffer.append(record)
 

--- a/src/metrics/collector.py
+++ b/src/metrics/collector.py
@@ -1,0 +1,32 @@
+"""In-memory metrics collector that persists to SQLite."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List
+
+from .models import MetricRecord
+from .repository import MetricsRepository
+
+
+class MetricsCollector:
+    """Buffers metrics and flushes them to persistent storage."""
+
+    def __init__(self, repository: MetricsRepository) -> None:
+        self._repo = repository
+        self._buffer: List[MetricRecord] = []
+
+    def record(self, metric_name: str, value: float) -> None:
+        """Append ``metric_name`` with ``value`` to the buffer."""
+
+        record = MetricRecord(
+            name=metric_name, value=value, timestamp=datetime.utcnow()
+        )
+        self._buffer.append(record)
+
+    def flush_to_db(self) -> None:
+        """Persist buffered metrics to SQLite via the repository."""
+
+        for record in self._buffer:
+            self._repo.save(record)
+        self._buffer.clear()

--- a/src/metrics/models.py
+++ b/src/metrics/models.py
@@ -8,8 +8,21 @@ from datetime import datetime
 
 @dataclass
 class MetricRecord:
-    """Single metric data point."""
+    """Single metric data point.
 
+    Attributes
+    ----------
+    workspace_id:
+        Identifier for the workspace the metric belongs to.
+    name:
+        Metric identifier such as ``tokens`` or ``cost``.
+    value:
+        Numeric value for the metric.
+    timestamp:
+        When the metric was recorded.
+    """
+
+    workspace_id: str
     name: str
     value: float
     timestamp: datetime

--- a/src/metrics/models.py
+++ b/src/metrics/models.py
@@ -1,0 +1,23 @@
+"""Data models for metrics collection and querying."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass
+class MetricRecord:
+    """Single metric data point."""
+
+    name: str
+    value: float
+    timestamp: datetime
+
+
+@dataclass
+class TimeRange:
+    """Inclusive time span for metric queries."""
+
+    start: datetime
+    end: datetime

--- a/src/metrics/repository.py
+++ b/src/metrics/repository.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sqlite3
 from datetime import datetime
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 from .models import MetricRecord, TimeRange
 
@@ -22,6 +22,7 @@ class MetricsRepository:
         self._conn.execute(
             """
             CREATE TABLE IF NOT EXISTS metrics (
+                workspace_id TEXT NOT NULL,
                 name TEXT NOT NULL,
                 value REAL NOT NULL,
                 timestamp TEXT NOT NULL
@@ -34,28 +35,73 @@ class MetricsRepository:
         """Insert ``metric`` into the database."""
 
         self._conn.execute(
-            "INSERT INTO metrics (name, value, timestamp) VALUES (?, ?, ?)",
-            (metric.name, metric.value, metric.timestamp.isoformat()),
+            "INSERT INTO metrics (workspace_id, name, value, timestamp) VALUES (?, ?, ?, ?)",
+            (
+                metric.workspace_id,
+                metric.name,
+                metric.value,
+                metric.timestamp.isoformat(),
+            ),
         )
         self._conn.commit()
 
-    def query(self, time_range: TimeRange) -> List[MetricRecord]:
-        """Return metrics within ``time_range``."""
+    def query(
+        self, time_range: TimeRange, workspace_id: Optional[str] = None
+    ) -> List[MetricRecord]:
+        """Return metrics within ``time_range``.
 
-        cur = self._conn.execute(
-            """
-            SELECT name, value, timestamp FROM metrics
-            WHERE timestamp BETWEEN ? AND ?
-            ORDER BY timestamp
-            """,
-            (time_range.start.isoformat(), time_range.end.isoformat()),
-        )
+        Parameters
+        ----------
+        time_range:
+            Range to search within.
+        workspace_id:
+            If provided, restrict results to this workspace.
+        """
+
+        if workspace_id is None:
+            cur = self._conn.execute(
+                """
+                SELECT workspace_id, name, value, timestamp FROM metrics
+                WHERE timestamp BETWEEN ? AND ?
+                ORDER BY timestamp
+                """,
+                (time_range.start.isoformat(), time_range.end.isoformat()),
+            )
+        else:
+            cur = self._conn.execute(
+                """
+                SELECT workspace_id, name, value, timestamp FROM metrics
+                WHERE workspace_id = ? AND timestamp BETWEEN ? AND ?
+                ORDER BY timestamp
+                """,
+                (
+                    workspace_id,
+                    time_range.start.isoformat(),
+                    time_range.end.isoformat(),
+                ),
+            )
         rows = cur.fetchall()
         return [
             MetricRecord(
+                workspace_id=row["workspace_id"],
                 name=row["name"],
                 value=row["value"],
                 timestamp=datetime.fromisoformat(row["timestamp"]),
             )
             for row in rows
         ]
+
+    def latest_value(self, workspace_id: str, metric_name: str) -> Optional[float]:
+        """Return the most recent value for ``metric_name`` in ``workspace_id``."""
+
+        cur = self._conn.execute(
+            """
+            SELECT value FROM metrics
+            WHERE workspace_id = ? AND name = ?
+            ORDER BY timestamp DESC
+            LIMIT 1
+            """,
+            (workspace_id, metric_name),
+        )
+        row = cur.fetchone()
+        return float(row["value"]) if row else None

--- a/src/metrics/repository.py
+++ b/src/metrics/repository.py
@@ -1,0 +1,61 @@
+"""SQLite repository for persisting metrics."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import List
+
+from .models import MetricRecord, TimeRange
+
+
+class MetricsRepository:
+    """CRUD operations for the ``metrics`` table."""
+
+    def __init__(self, db_path: str | Path) -> None:
+        self._conn = sqlite3.connect(str(db_path))
+        self._conn.row_factory = sqlite3.Row
+        self._ensure_table()
+
+    def _ensure_table(self) -> None:
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS metrics (
+                name TEXT NOT NULL,
+                value REAL NOT NULL,
+                timestamp TEXT NOT NULL
+            )
+            """
+        )
+        self._conn.commit()
+
+    def save(self, metric: MetricRecord) -> None:
+        """Insert ``metric`` into the database."""
+
+        self._conn.execute(
+            "INSERT INTO metrics (name, value, timestamp) VALUES (?, ?, ?)",
+            (metric.name, metric.value, metric.timestamp.isoformat()),
+        )
+        self._conn.commit()
+
+    def query(self, time_range: TimeRange) -> List[MetricRecord]:
+        """Return metrics within ``time_range``."""
+
+        cur = self._conn.execute(
+            """
+            SELECT name, value, timestamp FROM metrics
+            WHERE timestamp BETWEEN ? AND ?
+            ORDER BY timestamp
+            """,
+            (time_range.start.isoformat(), time_range.end.isoformat()),
+        )
+        rows = cur.fetchall()
+        return [
+            MetricRecord(
+                name=row["name"],
+                value=row["value"],
+                timestamp=datetime.fromisoformat(row["timestamp"]),
+            )
+            for row in rows
+        ]

--- a/src/web/alert_endpoint.py
+++ b/src/web/alert_endpoint.py
@@ -1,0 +1,20 @@
+"""FastAPI endpoint that evaluates metric thresholds and sends alerts."""
+
+from __future__ import annotations
+
+from fastapi import Request, Response, status
+
+from metrics.alerts import AlertManager
+from metrics.repository import MetricsRepository
+
+
+def post_alerts(workspace_id: str, request: Request) -> Response:
+    """Evaluate metrics for ``workspace_id`` and trigger webhook if breached."""
+
+    db_path: str = request.app.state.db_path
+    repo = MetricsRepository(db_path)
+    manager = AlertManager(repo)
+    summary = manager.evaluate_thresholds(workspace_id)
+    if summary.has_breaches:
+        manager.send_webhook(summary)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/web/metrics_endpoint.py
+++ b/src/web/metrics_endpoint.py
@@ -1,0 +1,22 @@
+"""FastAPI endpoint exposing recent metrics in Prometheus format."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from fastapi import Request, Response
+
+from metrics.models import TimeRange
+from metrics.repository import MetricsRepository
+
+
+def get_metrics(request: Request) -> Response:
+    """Return recent metrics formatted for Prometheus scrapers."""
+
+    db_path: str = request.app.state.db_path
+    repo = MetricsRepository(db_path)
+    end = datetime.utcnow()
+    start = end - timedelta(minutes=5)
+    records = repo.query(TimeRange(start=start, end=end))
+    body = "\n".join(f"{m.name} {m.value}" for m in records)
+    return Response(content=body, media_type="text/plain")

--- a/tests/test_alert_evaluation.py
+++ b/tests/test_alert_evaluation.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+from pathlib import Path
+
+from metrics.alerts import AlertManager
+from metrics.models import MetricRecord
+from metrics.repository import MetricsRepository
+
+
+def _insert(
+    repo: MetricsRepository, ws: str, ped: float, hall: float, cost: float
+) -> None:
+    now = datetime.utcnow()
+    repo.save(
+        MetricRecord(
+            workspace_id=ws, name="pedagogical_score", value=ped, timestamp=now
+        )
+    )
+    repo.save(
+        MetricRecord(
+            workspace_id=ws, name="hallucination_rate", value=hall, timestamp=now
+        )
+    )
+    repo.save(MetricRecord(workspace_id=ws, name="cost", value=cost, timestamp=now))
+
+
+def test_evaluate_thresholds_flags_breaches(tmp_path: Path) -> None:
+    repo = MetricsRepository(str(tmp_path / "metrics.db"))
+    _insert(repo, "ws1", 0.8, 0.03, 0.7)
+    manager = AlertManager(repo, thresholds_path=Path("src/config/thresholds.yaml"))
+    summary = manager.evaluate_thresholds("ws1")
+    assert summary.pedagogical_breached
+    assert summary.hallucination_breached
+    assert summary.cost_breached
+
+
+def test_evaluate_thresholds_no_breaches(tmp_path: Path) -> None:
+    repo = MetricsRepository(str(tmp_path / "metrics.db"))
+    _insert(repo, "ws1", 0.95, 0.01, 0.5)
+    manager = AlertManager(repo, thresholds_path=Path("src/config/thresholds.yaml"))
+    summary = manager.evaluate_thresholds("ws1")
+    assert not summary.has_breaches

--- a/tests/test_alert_webhook.py
+++ b/tests/test_alert_webhook.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+from typing import Any, Dict
+
+import httpx
+
+from metrics.alerts import AlertManager, AlertSummary
+from metrics.repository import MetricsRepository
+
+
+def test_send_webhook_posts_payload(monkeypatch, tmp_path: Path) -> None:
+    captured: Dict[str, Any] = {}
+
+    def fake_post(url: str, json: Dict[str, Any], timeout: float) -> httpx.Response:  # type: ignore[override]
+        captured["url"] = url
+        captured["json"] = json
+        return httpx.Response(200)
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+
+    repo = MetricsRepository(str(tmp_path / "metrics.db"))
+    manager = AlertManager(
+        repo,
+        thresholds_path=Path("src/config/thresholds.yaml"),
+        webhook_url="http://example.com",
+    )
+    alert = AlertSummary(
+        workspace_id="ws1",
+        pedagogical_score=0.8,
+        hallucination_rate=0.03,
+        cost=0.7,
+        pedagogical_breached=True,
+        hallucination_breached=False,
+        cost_breached=True,
+    )
+
+    manager.send_webhook(alert)
+
+    assert captured["url"] == "http://example.com"
+    assert captured["json"]["workspace_id"] == "ws1"
+    breaches = captured["json"]["breaches"]
+    assert "pedagogical_score" in breaches
+    assert "cost" in breaches
+    assert "hallucination_rate" not in breaches

--- a/tests/test_metrics_collector.py
+++ b/tests/test_metrics_collector.py
@@ -11,11 +11,12 @@ def test_record_and_flush_persists_metrics(tmp_path: Path) -> None:
     repo = MetricsRepository(str(db))
     collector = MetricsCollector(repo)
 
-    collector.record("tokens", 5.0)
+    collector.record("ws1", "tokens", 5.0)
     # Nothing should be persisted before flush
     now = datetime.utcnow()
     recent = repo.query(
-        TimeRange(start=now - timedelta(minutes=1), end=now + timedelta(minutes=1))
+        TimeRange(start=now - timedelta(minutes=1), end=now + timedelta(minutes=1)),
+        workspace_id="ws1",
     )
     assert recent == []
 
@@ -23,7 +24,7 @@ def test_record_and_flush_persists_metrics(tmp_path: Path) -> None:
 
     end = datetime.utcnow() + timedelta(minutes=1)
     start = end - timedelta(minutes=2)
-    rows = repo.query(TimeRange(start=start, end=end))
+    rows = repo.query(TimeRange(start=start, end=end), workspace_id="ws1")
     assert len(rows) == 1
     assert rows[0].name == "tokens"
     assert rows[0].value == 5.0

--- a/tests/test_metrics_collector.py
+++ b/tests/test_metrics_collector.py
@@ -1,0 +1,29 @@
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from metrics.collector import MetricsCollector
+from metrics.repository import MetricsRepository
+from metrics.models import TimeRange
+
+
+def test_record_and_flush_persists_metrics(tmp_path: Path) -> None:
+    db = tmp_path / "metrics.db"
+    repo = MetricsRepository(str(db))
+    collector = MetricsCollector(repo)
+
+    collector.record("tokens", 5.0)
+    # Nothing should be persisted before flush
+    now = datetime.utcnow()
+    recent = repo.query(
+        TimeRange(start=now - timedelta(minutes=1), end=now + timedelta(minutes=1))
+    )
+    assert recent == []
+
+    collector.flush_to_db()
+
+    end = datetime.utcnow() + timedelta(minutes=1)
+    start = end - timedelta(minutes=2)
+    rows = repo.query(TimeRange(start=start, end=end))
+    assert len(rows) == 1
+    assert rows[0].name == "tokens"
+    assert rows[0].value == 5.0

--- a/tests/test_metrics_endpoint.py
+++ b/tests/test_metrics_endpoint.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from metrics.models import MetricRecord
+from metrics.repository import MetricsRepository
+from web.metrics_endpoint import get_metrics
+
+
+def _setup_db(path: Path) -> Path:
+    db = path / "metrics.db"
+    repo = MetricsRepository(str(db))
+    now = datetime.utcnow()
+    repo.save(MetricRecord(name="tokens", value=10.0, timestamp=now))
+    repo.save(MetricRecord(name="cost", value=0.5, timestamp=now))
+    return db
+
+
+def test_get_metrics_returns_prometheus_text(tmp_path: Path) -> None:
+    db_path = _setup_db(tmp_path)
+    app = FastAPI()
+    app.state.db_path = str(db_path)
+    app.add_api_route("/metrics", get_metrics, methods=["GET"])
+    client = TestClient(app)
+
+    res = client.get("/metrics")
+    assert res.status_code == 200
+    body = res.text.splitlines()
+    assert "tokens 10.0" in body
+    assert "cost 0.5" in body

--- a/tests/test_metrics_endpoint.py
+++ b/tests/test_metrics_endpoint.py
@@ -13,8 +13,10 @@ def _setup_db(path: Path) -> Path:
     db = path / "metrics.db"
     repo = MetricsRepository(str(db))
     now = datetime.utcnow()
-    repo.save(MetricRecord(name="tokens", value=10.0, timestamp=now))
-    repo.save(MetricRecord(name="cost", value=0.5, timestamp=now))
+    repo.save(
+        MetricRecord(workspace_id="ws1", name="tokens", value=10.0, timestamp=now)
+    )
+    repo.save(MetricRecord(workspace_id="ws1", name="cost", value=0.5, timestamp=now))
     return db
 
 


### PR DESCRIPTION
## Summary
- add `MetricRecord` and `TimeRange` models
- implement `MetricsCollector` buffering metrics before persisting to SQLite
- add `MetricsRepository` with save/query helpers
- expose `/metrics` FastAPI endpoint emitting Prometheus-style metrics

## Testing
- `black src/metrics tests/test_metrics_collector.py tests/test_metrics_endpoint.py src/web/metrics_endpoint.py`
- `ruff check .`
- `mypy .` *(fails: Cannot find implementation or library stub for module named "core.state"...)*
- `bandit -r src -ll`
- `pip-audit` *(fails: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier)*
- `PYTHONPATH=src pytest tests/test_metrics_collector.py tests/test_metrics_endpoint.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689031d06478832babfe93b0d5584646