### PR TITLE
feat: enforce o4-mini model

### DIFF
--- a/src/agents/agent_wrapper.py
+++ b/src/agents/agent_wrapper.py
@@ -1,0 +1,22 @@
+"""Utility helpers for LLM interactions."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from agentic_demo import config
+
+
+def get_llm_params(**overrides: Any) -> Dict[str, Any]:
+    """Return default parameters for OpenAI calls.
+
+    Reads the configured model name and merges any ``overrides`` provided,
+    ensuring every request specifies the enforced model.
+    """
+
+    params: Dict[str, Any] = {"model": config.settings.model_name}
+    params.update(overrides)
+    return params
+
+
+__all__ = ["get_llm_params"]

--- a/src/agents/content_weaver.py
+++ b/src/agents/content_weaver.py
@@ -17,6 +17,7 @@ from .models import (
     Citation,
     WeaveResult,
 )
+from .agent_wrapper import get_llm_params
 
 
 class RetryableError(RuntimeError):
@@ -110,7 +111,7 @@ async def call_openai_function(prompt: str, schema: dict) -> AsyncGenerator[str,
 
     async def generator() -> AsyncGenerator[str, None]:
         response = await client.responses.stream(
-            model="gpt-4o-mini",
+            **get_llm_params(),
             messages=[
                 {
                     "role": "system",

--- a/src/agents/pedagogy_critic.py
+++ b/src/agents/pedagogy_critic.py
@@ -12,6 +12,7 @@ from typing import Callable, Dict, List, cast
 
 from core.state import State
 
+from agents.agent_wrapper import get_llm_params
 from agents.models import Activity
 from models import (
     ActivityDiversityReport,
@@ -83,7 +84,7 @@ def classify_bloom_level(text: str) -> str:
 
         client = OpenAI()
         response = client.responses.create(
-            model="gpt-4o-mini",
+            **get_llm_params(),
             input=[{"role": "user", "content": prompt}],
         )
         level = response.output_text.strip().lower()

--- a/src/config.py
+++ b/src/config.py
@@ -15,6 +15,9 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 # Load environment variables from a `.env` file if present.
 load_dotenv()
 
+# Default OpenAI model enforced across the application.
+MODEL_NAME: str = "o4-mini"
+
 
 class Settings(BaseSettings):
     """Strongly-typed application configuration.
@@ -44,7 +47,9 @@ class Settings(BaseSettings):
         ..., alias="PERPLEXITY_API_KEY", description="API key for Perplexity services."
     )
     model_name: str = Field(
-        ..., alias="MODEL_NAME", description="Default model identifier to use."
+        MODEL_NAME,
+        alias="MODEL_NAME",
+        description="Default model identifier to use.",
     )
     data_dir: Path = Field(
         ..., alias="DATA_DIR", description="Directory for application data."
@@ -96,4 +101,4 @@ def load_settings() -> Settings:
 # Eagerly instantiate settings for modules that import it directly.
 settings = load_settings()
 
-__all__ = ["Settings", "load_settings", "load_env", "settings"]
+__all__ = ["Settings", "load_settings", "load_env", "settings", "MODEL_NAME"]

--- a/src/core/orchestrator.py
+++ b/src/core/orchestrator.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Awaitable, Callable, Optional, TypeVar
+import logging
 
 from langgraph.graph import END, START, StateGraph
 
+from agentic_demo import config
 from agentic_demo.config import Settings
 from core.checkpoint import SqliteCheckpointManager
 from agents.approver import run_approver
@@ -20,6 +22,22 @@ from core.policies import (
     policy_retry_on_low_confidence,
 )
 from core.state import State
+
+logger = logging.getLogger(__name__)
+
+
+def validate_model_configuration() -> None:
+    """Ensure the configured model matches the enforced default."""
+    configured = config.settings.model_name
+    if configured != config.MODEL_NAME:
+        raise ValueError(
+            f"MODEL_NAME misconfigured: expected '{config.MODEL_NAME}', got '{configured}'"
+        )
+    logger.info("Using LLM engine %s", config.MODEL_NAME)
+
+
+validate_model_configuration()
+
 
 T = TypeVar("T")
 

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -1,0 +1,81 @@
+"""Tests for model configuration enforcement."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+def _stub_module(name: str, **attrs: object) -> None:
+    module = types.ModuleType(name)
+    module.__dict__.update(attrs)
+    sys.modules[name] = module
+
+
+def test_validate_model_configuration_rejects_override(monkeypatch, tmp_path):
+    """``validate_model_configuration`` errors when MODEL_NAME is overridden."""
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-openai")
+    monkeypatch.setenv("PERPLEXITY_API_KEY", "test-perplexity")
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("MODEL_NAME", "wrong-model")
+
+    import config
+
+    importlib.reload(config)
+
+    # Provide a minimal package so ``from agentic_demo import config`` succeeds.
+    pkg = types.ModuleType("agentic_demo")
+    pkg.config = config
+    sys.modules["agentic_demo"] = pkg
+    sys.modules["agentic_demo.config"] = config
+
+    def noop(*_args: object, **_kwargs: object) -> None:
+        """No-op stub used to satisfy imports."""
+        return None
+
+    sg = types.SimpleNamespace(add_node=noop, add_edge=noop, add_conditional_edges=noop)
+    _stub_module(
+        "langgraph.graph",
+        END=object(),
+        START=object(),
+        StateGraph=lambda *a, **k: sg,
+    )
+    _stub_module(
+        "core.checkpoint",
+        SqliteCheckpointManager=type(
+            "CM",
+            (),
+            {"__init__": noop, "save_checkpoint": noop, "load_checkpoint": noop},
+        ),
+    )
+    _stub_module("agents.approver", run_approver=noop)
+    _stub_module("agents.content_weaver", run_content_weaver=noop)
+    _stub_module(
+        "agents.critics",
+        run_fact_checker=noop,
+        run_pedagogy_critic=noop,
+    )
+    _stub_module("agents.exporter", run_exporter=noop)
+    _stub_module("agents.planner", PlanResult=object, run_planner=noop)
+    _stub_module("agents.researcher_web_node", run_researcher_web=noop)
+    _stub_module(
+        "core.policies",
+        policy_retry_on_critic_failure=lambda *a, **k: False,
+        policy_retry_on_low_confidence=lambda *a, **k: False,
+    )
+    _stub_module("core.state", State=object)
+
+    with pytest.raises(ValueError):
+        import core.orchestrator as orchestrator
+
+        importlib.reload(orchestrator)


### PR DESCRIPTION
## Summary
- enforce `o4-mini` as the default OpenAI model
- validate model configuration and log active engine at startup
- centralize LLM param injection for agents and add config tests

## Testing
- `black tests/test_model_config.py src/agents/agent_wrapper.py src/agents/content_weaver.py src/agents/pedagogy_critic.py src/config.py src/core/orchestrator.py`
- `ruff check tests/test_model_config.py`
- `PYTHONPATH=src pytest tests/test_model_config.py -q`
- `mypy .` *(fails: Cannot find implementation or library stub for module named "agents.researcher_web"...)*
- `bandit -r src -ll`
- `pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_689035a4a068832b99cd8d3899e128f2