### PR TITLE
feat: centralize chat model initialization

### DIFF
--- a/src/agents/agent_wrapper.py
+++ b/src/agents/agent_wrapper.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from agentic_demo import config
 
@@ -19,4 +19,42 @@ def get_llm_params(**overrides: Any) -> Dict[str, Any]:
     return params
 
 
-__all__ = ["get_llm_params"]
+def init_chat_model(**overrides: Any) -> Optional[Any]:
+    """Instantiate a chat model using a unified factory.
+
+    The function inspects the configured model name (or an override) and
+    returns an appropriate LangChain chat model instance.  Currently supports
+    OpenAI and Perplexity Sonar models.  If the required dependency is not
+    available, ``None`` is returned.
+
+    Parameters
+    ----------
+    **overrides:
+        Optional keyword arguments merged with the default LLM parameters.
+
+    Returns
+    -------
+    Optional[Any]
+        The instantiated chat model or ``None`` if construction failed.
+    """
+
+    params = get_llm_params(**overrides)
+    model_name = params.pop("model", "")
+
+    try:
+        if model_name.startswith("sonar"):
+            from langchain_perplexity import ChatPerplexity  # type: ignore
+
+            pplx_api_key = params.pop(
+                "pplx_api_key", config.settings.perplexity_api_key
+            )
+            return ChatPerplexity(model=model_name, pplx_api_key=pplx_api_key, **params)
+
+        from langchain_openai import ChatOpenAI  # type: ignore
+
+        return ChatOpenAI(model=model_name, **params)
+    except Exception:  # pragma: no cover - optional dependencies
+        return None
+
+
+__all__ = ["get_llm_params", "init_chat_model"]

--- a/src/agents/pedagogy_critic.py
+++ b/src/agents/pedagogy_critic.py
@@ -10,7 +10,7 @@ from collections import Counter
 from dataclasses import dataclass
 from typing import Callable, Dict, List, cast
 
-from agents.agent_wrapper import get_llm_params
+from agents.agent_wrapper import init_chat_model
 from agents.models import Activity
 from core.state import State
 from prompts import get_prompt
@@ -76,13 +76,12 @@ def classify_bloom_level(text: str) -> str:
 
     prompt = get_prompt("pedagogy_critic_classify") + "\n\n" + text
     try:  # pragma: no cover - network dependency
-        from langchain_openai import ChatOpenAI  # type: ignore
-
-        model = ChatOpenAI(**get_llm_params())
-        response = model.invoke(prompt)
-        level = (response.content or "").strip().lower()
-        if level in BLOOM_LEVELS:
-            return level
+        model = init_chat_model()
+        if model is not None:
+            response = model.invoke(prompt)
+            level = (response.content or "").strip().lower()
+            if level in BLOOM_LEVELS:
+                return level
     except Exception:
         pass
     return _keyword_classify(text)

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from core.state import Outline, State
 from prompts import get_prompt
 
-from .agent_wrapper import get_llm_params
+from .agent_wrapper import init_chat_model
 
 
 @dataclass(slots=True)
@@ -31,12 +31,13 @@ async def call_planner_llm(topic: str) -> str:
     """
 
     try:  # pragma: no cover - exercised via monkeypatch in tests
-        from langchain_openai import ChatOpenAI  # type: ignore
         from langchain_core.messages import HumanMessage, SystemMessage
     except Exception:  # dependency missing
         return ""
 
-    model = ChatOpenAI(**get_llm_params())
+    model = init_chat_model()
+    if model is None:
+        return ""
     messages = [
         SystemMessage(content=get_prompt("planner_system")),
         HumanMessage(content=topic),

--- a/src/agents/researcher_web.py
+++ b/src/agents/researcher_web.py
@@ -6,8 +6,7 @@ from dataclasses import dataclass
 from typing import Any, List, Optional, Protocol
 from urllib.parse import urlparse
 
-from langchain_perplexity import ChatPerplexity
-
+from .agent_wrapper import init_chat_model
 from .offline_cache import load_cached_results, save_cached_results
 
 
@@ -33,7 +32,10 @@ class PerplexityClient:
     """Wrapper around the Perplexity Sonar model via LangChain."""
 
     def __init__(self, api_key: str, llm: Optional[Any] = None) -> None:
-        self.llm = llm or ChatPerplexity(model="sonar", pplx_api_key=api_key)
+        model = llm or init_chat_model(model="sonar", pplx_api_key=api_key)
+        if model is None:  # pragma: no cover - dependency missing
+            raise RuntimeError("Perplexity chat model unavailable")
+        self.llm = model
 
     def search(self, query: str) -> List[RawSearchResult]:
         """Call the Sonar model and cache its cited search results."""

--- a/tests/agents/test_content_weaver.py
+++ b/tests/agents/test_content_weaver.py
@@ -10,10 +10,7 @@ def test_call_openai_function_streams_tokens(monkeypatch):
         def __init__(self, content: str):
             self.content = content
 
-    class FakeChatOpenAI:
-        def __init__(self, **_kwargs: object) -> None:
-            pass
-
+    class FakeLLM:
         async def astream(self, *args, **kwargs):
             async def gen():
                 yield FakeChunk("foo")
@@ -21,7 +18,7 @@ def test_call_openai_function_streams_tokens(monkeypatch):
 
             return gen()
 
-    monkeypatch.setattr(cw, "ChatOpenAI", FakeChatOpenAI)
+    monkeypatch.setattr(cw, "init_chat_model", lambda **_kwargs: FakeLLM())
 
     async def run_test():
         gen = await cw.call_openai_function("prompt", {})


### PR DESCRIPTION
## Summary
- add `init_chat_model` factory to manage chat model creation
- refactor agents to use centralized model initialization
- update tests for new model factory

## Testing
- `black --config /dev/null src/agents/agent_wrapper.py src/agents/content_weaver.py src/agents/pedagogy_critic.py src/agents/planner.py src/agents/researcher_web.py tests/agents/test_content_weaver.py`
- `ruff check --isolated src/agents/agent_wrapper.py src/agents/content_weaver.py src/agents/pedagogy_critic.py src/agents/planner.py src/agents/researcher_web.py tests/agents/test_content_weaver.py`
- `mypy --config-file /dev/null src/agents/agent_wrapper.py src/agents/content_weaver.py src/agents/pedagogy_critic.py src/agents/planner.py src/agents/researcher_web.py tests/agents/test_content_weaver.py` *(failed: missing dependencies)*
- `bandit -r src -ll`
- `pip-audit` *(failed: SSL certificate verify failed)*
- `pytest -c /tmp/pytest.ini` *(failed: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689063d299a0832bad175a8ab2ab19c5