### PR TITLE
Use async httpx for licence and source checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "sse-starlette (>=3.0.2,<4.0.0)",
     "pyarrow (>=21.0.0,<22.0.0)",
     "alembic (>=1.16.4,<2.0.0)",
-    "sqlalchemy (>=2.0.42,<3.0.0)"
+    "sqlalchemy (>=2.0.42,<3.0.0)",
     "weasyprint (>=66,<67)",
     "fastapi (>=0.111,<1.0)"
 ]

--- a/tests/test_researcher_pipeline.py
+++ b/tests/test_researcher_pipeline.py
@@ -2,6 +2,7 @@ import asyncio
 from contextlib import asynccontextmanager
 
 import aiosqlite
+import httpx
 
 from agents.researcher_pipeline import researcher_pipeline
 from agents.researcher_web import CitationDraft
@@ -58,9 +59,14 @@ def test_researcher_pipeline_persists(monkeypatch, tmp_path):
         class DummyResponse:
             headers = {"License": "CC0"}
 
+        async def fake_head(self, url, timeout=5.0):  # noqa: ARG001
+            return DummyResponse()
+
         monkeypatch.setattr(
-            "agents.researcher_pipeline.httpx.head",
-            lambda url, timeout=5.0: DummyResponse(),
+            httpx.AsyncClient,
+            "head",
+            fake_head,
+            raising=False,
         )
 
         state = State(prompt="")


### PR DESCRIPTION
## Summary
- use `httpx.AsyncClient.head` for licence lookups and source verification
- issue licence checks and source verification concurrently via `asyncio.gather`
- test async implementations by patching `AsyncClient.head`

## Testing
- `black .`
- `ruff check .`
- `mypy .` *(fails: Missing stubs and modules)*
- `bandit -r src -ll`
- `pip-audit` *(fails: SSL: CERTIFICATE_VERIFY_FAILED)*
- `pytest` *(fails: 32 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68906e545db8832bb02caa31934c9e89