### PR TITLE
Track policy retries and enforce limits

### DIFF
--- a/tests/core/test_policies.py
+++ b/tests/core/test_policies.py
@@ -2,29 +2,102 @@
 
 from __future__ import annotations
 
+import os
+import sys
+import types
+from dataclasses import dataclass
+
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("PERPLEXITY_API_KEY", "test")
+os.environ.setdefault("DATA_DIR", "/tmp")
+
 import pytest
 
-from agents.critics import CritiqueReport
-from agents.planner import PlanResult
-from core.policies import (merge_research_results,
-                           policy_retry_on_critic_failure,
-                           policy_retry_on_low_confidence, retry_tracker)
-from core.state import State
-from web.researcher_web import CitationResult
+
+@dataclass
+class PlanResult:
+    """Minimal planner result used for testing."""
+
+    confidence: float
+
+
+@dataclass
+class CritiqueReport:
+    """Minimal critique report for testing."""
+
+    issues: list[str] | None = None
+
+
+class FactCheckReport(CritiqueReport):
+    """Alias for :class:`CritiqueReport` used by critic policy."""
+
+
+@dataclass
+class CitationResult:
+    """Simplified citation result for merge tests."""
+
+    url: str
+    content: str
+
+
+critics_mod = types.ModuleType("agents.critics")
+critics_mod.CritiqueReport = CritiqueReport
+critics_mod.FactCheckReport = FactCheckReport
+sys.modules["agents.critics"] = critics_mod
+
+planner_mod = types.ModuleType("agents.planner")
+planner_mod.PlanResult = PlanResult
+sys.modules["agents.planner"] = planner_mod
+
+research_mod = types.ModuleType("web.researcher_web")
+research_mod.CitationResult = CitationResult
+sys.modules["web.researcher_web"] = research_mod
+
+from core.policies import (  # noqa: E402
+    merge_research_results,
+    policy_retry_on_critic_failure,
+    policy_retry_on_low_confidence,
+    retry_tracker,
+)
+from core.state import State  # noqa: E402
 
 
 def test_policy_retry_on_low_confidence() -> None:
     """Planner with low confidence should trigger a retry."""
 
-    assert policy_retry_on_low_confidence(PlanResult(confidence=0.5))
-    assert not policy_retry_on_low_confidence(PlanResult(confidence=0.9))
+    state = State()
+    assert policy_retry_on_low_confidence(PlanResult(confidence=0.5), state)
+    assert not policy_retry_on_low_confidence(PlanResult(confidence=0.9), state)
+
+
+def test_policy_retry_on_low_confidence_limit() -> None:
+    """A fourth planner retry should raise an error."""
+
+    state = State()
+    result = PlanResult(confidence=0.1)
+    for _ in range(3):
+        assert policy_retry_on_low_confidence(result, state)
+    with pytest.raises(RuntimeError):
+        policy_retry_on_low_confidence(result, state)
 
 
 def test_policy_retry_on_critic_failure() -> None:
     """Presence of issues should trigger a content rewrite."""
 
-    assert policy_retry_on_critic_failure(CritiqueReport(issues=["gap"]))
-    assert not policy_retry_on_critic_failure(CritiqueReport())
+    state = State()
+    assert policy_retry_on_critic_failure(CritiqueReport(issues=["gap"]), state)
+    assert not policy_retry_on_critic_failure(CritiqueReport(), state)
+
+
+def test_policy_retry_on_critic_failure_limit() -> None:
+    """A fourth rewrite should raise an error."""
+
+    state = State()
+    report = CritiqueReport(issues=["gap"])
+    for _ in range(3):
+        assert policy_retry_on_critic_failure(report, state)
+    with pytest.raises(RuntimeError):
+        policy_retry_on_critic_failure(report, state)
 
 
 def test_merge_research_results_dedupes_urls() -> None:


### PR DESCRIPTION
## Summary
- track planner retries when confidence is low and limit to three attempts
- track content rewrites after critic failure and halt after three
- add tests covering retry limits for planner and critic policies

## Testing
- `ruff check .`
- `mypy src/core/policies.py tests/core/test_policies.py` *(fails: Cannot find implementation or library stub for module named "agents.critics" and others)*
- `bandit -r src -ll`
- `pip-audit` *(fails: SSL: CERTIFICATE_VERIFY_FAILED)*
- `pytest tests/core/test_policies.py`


------
https://chatgpt.com/codex/tasks/task_e_689070005034832b97455be07d8410dc