### PR TITLE
Support section-specific content weaving

### DIFF
--- a/src/core/regenerator.py
+++ b/src/core/regenerator.py
@@ -48,7 +48,11 @@ def apply_regeneration(
 ) -> None:
     """Invoke the Content Weaver node for the specified sections."""
     for section_id in sections:
-        graph.invoke("Content-Weaver", state, section_id=section_id)  # type: ignore[attr-defined]
+        try:
+            idx = int(section_id)
+        except ValueError:
+            continue
+        graph.invoke("Content-Weaver", state, section_id=idx)  # type: ignore[attr-defined]
 
 
 def orchestrate_regeneration(


### PR DESCRIPTION
## Summary
- allow content weaving functions to target a single outline section using `section_id`
- ensure regenerator invokes the content weaver with numeric section identifiers
- expand tests to cover section-specific prompts and integer conversion

## Testing
- `black .`
- `ruff check .`
- `mypy .` *(fails: Cannot find implementation or library stub for module named "core.state" and others)*
- `bandit -r src -ll`
- `pip-audit` *(fails: SSLError: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded)*
- `pytest` *(fails: Interrupted: 33 errors during collection)*
- `pytest tests/agents/test_content_weaver.py tests/core/test_regeneration.py` *(fails: ModuleNotFoundError: No module named 'agentic_demo')*


------
https://chatgpt.com/codex/tasks/task_e_6890723432e4832b95340c7757206a72