### PR TITLE
refactor: use aiosqlite for checkpoints

### DIFF
--- a/src/core/checkpoint.py
+++ b/src/core/checkpoint.py
@@ -3,39 +3,47 @@
 from __future__ import annotations
 
 import json
-import sqlite3
 from pathlib import Path
+
+import aiosqlite
 
 from core.state import State, increment_version
 
 
 class SqliteCheckpointManager:
-    """Persist ``State`` snapshots to a SQLite database."""
+    """Persist ``State`` snapshots to an on-disk SQLite database.
+
+    The manager uses :mod:`aiosqlite` and opens a fresh connection for each
+    operation to avoid cross-task sharing.
+    """
 
     # TODO: Implement retention policy to prune old checkpoints.
 
     def __init__(self, db_path: str) -> None:
-        """Initialize the manager with a path to the database file."""
+        """Store the path to the backing database file."""
         self._path = Path(db_path)
-        self._conn = sqlite3.connect(self._path)
-        self._conn.execute(
-            "CREATE TABLE IF NOT EXISTS checkpoints (id INTEGER PRIMARY KEY AUTOINCREMENT, state TEXT NOT NULL)"
-        )
-        self._conn.commit()
 
-    def save_checkpoint(self, state: State) -> None:
+    async def save_checkpoint(self, state: State) -> None:
         """Serialize ``state`` into the checkpoint table."""
         increment_version(state)
         payload = json.dumps(state.to_dict())
-        self._conn.execute("INSERT INTO checkpoints (state) VALUES (?)", (payload,))
-        self._conn.commit()
+        async with aiosqlite.connect(self._path) as db:
+            await db.execute(
+                "CREATE TABLE IF NOT EXISTS checkpoints (id INTEGER PRIMARY KEY AUTOINCREMENT, state TEXT NOT NULL)"
+            )
+            await db.execute("INSERT INTO checkpoints (state) VALUES (?)", (payload,))
+            await db.commit()
 
-    def load_checkpoint(self) -> State:
+    async def load_checkpoint(self) -> State:
         """Load the most recent ``State`` snapshot."""
-        cur = self._conn.execute(
-            "SELECT state FROM checkpoints ORDER BY id DESC LIMIT 1"
-        )
-        row = cur.fetchone()
+        async with aiosqlite.connect(self._path) as db:
+            await db.execute(
+                "CREATE TABLE IF NOT EXISTS checkpoints (id INTEGER PRIMARY KEY AUTOINCREMENT, state TEXT NOT NULL)"
+            )
+            cur = await db.execute(
+                "SELECT state FROM checkpoints ORDER BY id DESC LIMIT 1"
+            )
+            row = await cur.fetchone()
         if row is None:
             raise RuntimeError("No checkpoint available")
         data = json.loads(row[0])

--- a/src/core/orchestrator.py
+++ b/src/core/orchestrator.py
@@ -92,7 +92,7 @@ class GraphOrchestrator:
             input_hash = compute_hash(input_dict)
             result = await node(state)
             if self.checkpoint_manager is not None:
-                self.checkpoint_manager.save_checkpoint(state)
+                await self.checkpoint_manager.save_checkpoint(state)
             output_hash = compute_hash(result)
             tokens = _token_count(input_dict) + _token_count(result)
             workspace_id = getattr(state, "workspace_id", "default")
@@ -160,7 +160,7 @@ class GraphOrchestrator:
             self.register_edges()
         if self.checkpoint_manager is None:
             raise RuntimeError("Checkpoint manager required to resume")
-        state = self.checkpoint_manager.load_checkpoint()
+        state = await self.checkpoint_manager.load_checkpoint()
         planner = self._wrap("Planner", _import_callable("agents.planner.run_planner"))
         return await planner(state)
 

--- a/tests/core/test_checkpoint_manager.py
+++ b/tests/core/test_checkpoint_manager.py
@@ -2,16 +2,19 @@
 
 from pathlib import Path
 
+import pytest
+
 from core.checkpoint import SqliteCheckpointManager
 from core.state import State
 
 
-def test_save_and_load_roundtrip(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_save_and_load_roundtrip(tmp_path: Path) -> None:
     """Manager should persist and restore :class:`State`."""
     db_path = tmp_path / "checkpoint.db"
     manager = SqliteCheckpointManager(str(db_path))
     state = State(prompt="hello")
-    manager.save_checkpoint(state)
+    await manager.save_checkpoint(state)
     state.prompt = "changed"
-    loaded = manager.load_checkpoint()
+    loaded = await manager.load_checkpoint()
     assert loaded.prompt == "hello"

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -1,5 +1,3 @@
-"""Tests for model configuration enforcement."""
-
 from __future__ import annotations
 
 import importlib
@@ -43,6 +41,10 @@ def test_validate_model_configuration_rejects_override(monkeypatch, tmp_path):
         """No-op stub used to satisfy imports."""
         return None
 
+    async def noop_async(*_args: object, **_kwargs: object) -> None:
+        """Async no-op used for async interfaces."""
+        return None
+
     sg = types.SimpleNamespace(add_node=noop, add_edge=noop, add_conditional_edges=noop)
     _stub_module(
         "langgraph.graph",
@@ -55,7 +57,11 @@ def test_validate_model_configuration_rejects_override(monkeypatch, tmp_path):
         SqliteCheckpointManager=type(
             "CM",
             (),
-            {"__init__": noop, "save_checkpoint": noop, "load_checkpoint": noop},
+            {
+                "__init__": noop,
+                "save_checkpoint": noop_async,
+                "load_checkpoint": noop_async,
+            },
         ),
     )
     _stub_module("agents.approver", run_approver=noop)


### PR DESCRIPTION
## Summary
- use aiosqlite for checkpoint persistence with async operations
- await checkpoint saves and loads in orchestrator
- adapt checkpoint tests for asyncio

## Testing
- `black src/core/checkpoint.py src/core/orchestrator.py tests/core/test_checkpoint_manager.py tests/test_model_config.py`
- `ruff check .`
- `mypy .` *(fails: Cannot find implementation or library stub for module named "core.state" and others)*
- `bandit -r src -ll`
- `pip-audit` *(fails: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed)*
- `pytest` *(fails: 33 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689073e20240832b94315115352eb20f