### PR TITLE
Use conditional retry for low-confidence planning

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -231,9 +231,9 @@ Each node module defines a single `async` handler function and its input/output 
 
 **File:** `src/core/policies.py`
 
-- **Function `policy_retry_on_low_confidence(prev: PlanResult) → bool`**
+- **Function `policy_retry_on_low_confidence(prev: PlanResult) → Literal["loop", "continue"]`**
 
-- Returns `true` if Planner’s confidence \< threshold, to loop back into Researcher.
+- Returns ``"loop"`` if Planner’s confidence \< threshold and retries remain; otherwise ``"continue"`` to proceed to the Content Weaver.
 
 - **Function `policy_retry_on_critic_failure(report: CritiqueReport|FactCheckReport) → bool`**
 

--- a/src/langgraph.json
+++ b/src/langgraph.json
@@ -1,22 +1,58 @@
 {
-  "nodes": [
-    {"name": "Planner", "callable": "agents.planner.run_planner", "streams": "values"},
-    {"name": "Researcher-Web", "callable": "agents.researcher_web_node.run_researcher_web", "streams": "updates"},
-    {"name": "Content-Weaver", "callable": "agents.content_weaver.run_content_weaver", "streams": "messages"},
-    {"name": "Pedagogy-Critic", "callable": "agents.pedagogy_critic.run_pedagogy_critic", "streams": "debug"},
-    {"name": "Fact-Checker", "callable": "agents.fact_checker.run_fact_checker", "streams": "debug"},
-    {"name": "Human-In-Loop", "callable": "agents.approver.run_approver", "streams": "values"},
-    {"name": "Exporter", "callable": "agents.exporter.run_exporter"}
-  ],
-  "edges": [
-    {"source": "__start__", "target": "Planner"},
-    {"source": "Planner", "condition": "core.policies.policy_retry_on_low_confidence", "mapping": {"True": "Researcher-Web", "False": "Content-Weaver"}},
-    {"source": "Researcher-Web", "target": "Planner"},
-    {"source": "Content-Weaver", "target": "Pedagogy-Critic"},
-    {"source": "Content-Weaver", "target": "Fact-Checker"},
-    {"source": "Pedagogy-Critic", "condition": "core.policies.policy_retry_on_critic_failure", "mapping": {"True": "Content-Weaver", "False": "Human-In-Loop"}},
-    {"source": "Fact-Checker", "condition": "core.policies.policy_retry_on_critic_failure", "mapping": {"True": "Content-Weaver", "False": "Human-In-Loop"}},
-    {"source": "Human-In-Loop", "target": "Exporter"},
-    {"source": "Exporter", "target": "__end__"}
-  ]
+    "nodes": [
+        {
+            "name": "Planner",
+            "callable": "agents.planner.run_planner",
+            "streams": "values",
+        },
+        {
+            "name": "Researcher-Web",
+            "callable": "agents.researcher_web_node.run_researcher_web",
+            "streams": "updates",
+        },
+        {
+            "name": "Content-Weaver",
+            "callable": "agents.content_weaver.run_content_weaver",
+            "streams": "messages",
+        },
+        {
+            "name": "Pedagogy-Critic",
+            "callable": "agents.pedagogy_critic.run_pedagogy_critic",
+            "streams": "debug",
+        },
+        {
+            "name": "Fact-Checker",
+            "callable": "agents.fact_checker.run_fact_checker",
+            "streams": "debug",
+        },
+        {
+            "name": "Human-In-Loop",
+            "callable": "agents.approver.run_approver",
+            "streams": "values",
+        },
+        {"name": "Exporter", "callable": "agents.exporter.run_exporter"},
+    ],
+    "edges": [
+        {"source": "__start__", "target": "Planner"},
+        {
+            "source": "Planner",
+            "condition": "core.policies.policy_retry_on_low_confidence",
+            "mapping": {"loop": "Researcher-Web", "continue": "Content-Weaver"},
+        },
+        {"source": "Researcher-Web", "target": "Planner"},
+        {"source": "Content-Weaver", "target": "Pedagogy-Critic"},
+        {"source": "Content-Weaver", "target": "Fact-Checker"},
+        {
+            "source": "Pedagogy-Critic",
+            "condition": "core.policies.policy_retry_on_critic_failure",
+            "mapping": {"True": "Content-Weaver", "False": "Human-In-Loop"},
+        },
+        {
+            "source": "Fact-Checker",
+            "condition": "core.policies.policy_retry_on_critic_failure",
+            "mapping": {"True": "Content-Weaver", "False": "Human-In-Loop"},
+        },
+        {"source": "Human-In-Loop", "target": "Exporter"},
+        {"source": "Exporter", "target": "__end__"},
+    ],
 }

--- a/tests/core/test_policies.py
+++ b/tests/core/test_policies.py
@@ -66,19 +66,20 @@ def test_policy_retry_on_low_confidence() -> None:
     """Planner with low confidence should trigger a retry."""
 
     state = State()
-    assert policy_retry_on_low_confidence(PlanResult(confidence=0.5), state)
-    assert not policy_retry_on_low_confidence(PlanResult(confidence=0.9), state)
+    assert policy_retry_on_low_confidence(PlanResult(confidence=0.5), state) == "loop"
+    assert (
+        policy_retry_on_low_confidence(PlanResult(confidence=0.9), state) == "continue"
+    )
 
 
 def test_policy_retry_on_low_confidence_limit() -> None:
-    """A fourth planner retry should raise an error."""
+    """A fourth planner attempt should fall through without retry."""
 
     state = State()
     result = PlanResult(confidence=0.1)
     for _ in range(3):
-        assert policy_retry_on_low_confidence(result, state)
-    with pytest.raises(RuntimeError):
-        policy_retry_on_low_confidence(result, state)
+        assert policy_retry_on_low_confidence(result, state) == "loop"
+    assert policy_retry_on_low_confidence(result, state) == "continue"
 
 
 def test_policy_retry_on_critic_failure() -> None:


### PR DESCRIPTION
## Summary
- return explicit "loop" or "continue" decisions from the low-confidence retry policy
- map new policy outputs in `langgraph.json` for researcher loop vs content weaver continue
- document and test the new loop/continue semantics

## Testing
- `black src/core/policies.py tests/core/test_policies.py`
- `ruff check src/core/policies.py tests/core/test_policies.py`
- `mypy src/core/policies.py tests/core/test_policies.py` *(fails: Cannot find implementation or library stub for modules like `agents.critics` and `agents.planner`)*
- `bandit -r src -ll`
- `pip-audit` *(fails: certificate verify failed: Missing Authority Key Identifier)*
- `pytest tests/core/test_policies.py`


------
https://chatgpt.com/codex/tasks/task_e_6890769d3eb4832bb78bdcd61173901c