### PR TITLE
Cache chat model initialization

### DIFF
--- a/src/agents/agent_wrapper.py
+++ b/src/agents/agent_wrapper.py
@@ -6,6 +6,19 @@ from typing import Any, Dict, Optional
 
 from agentic_demo import config
 
+# Cache of initialized chat models keyed by model name.
+_MODEL_CACHE: Dict[str, Any] = {}
+
+
+def clear_model_cache() -> None:
+    """Clear cached chat model instances.
+
+    Primarily intended for use in unit tests to ensure a clean slate between
+    test cases.
+    """
+
+    _MODEL_CACHE.clear()
+
 
 def get_llm_params(**overrides: Any) -> Dict[str, Any]:
     """Return default parameters for LangChain LLM calls.
@@ -20,12 +33,12 @@ def get_llm_params(**overrides: Any) -> Dict[str, Any]:
 
 
 def init_chat_model(**overrides: Any) -> Optional[Any]:
-    """Instantiate a chat model using a unified factory.
+    """Instantiate or retrieve a cached chat model instance.
 
     The function inspects the configured model name (or an override) and
-    returns an appropriate LangChain chat model instance.  Currently supports
-    OpenAI and Perplexity Sonar models.  If the required dependency is not
-    available, ``None`` is returned.
+    returns an appropriate LangChain chat model instance. Instances are cached
+    by model name to avoid repeated construction. If the required dependency is
+    not available, ``None`` is returned.
 
     Parameters
     ----------
@@ -41,6 +54,9 @@ def init_chat_model(**overrides: Any) -> Optional[Any]:
     params = get_llm_params(**overrides)
     model_name = params.pop("model", "")
 
+    if model_name in _MODEL_CACHE:
+        return _MODEL_CACHE[model_name]
+
     try:
         if model_name.startswith("sonar"):
             from langchain_perplexity import ChatPerplexity  # type: ignore
@@ -48,13 +64,18 @@ def init_chat_model(**overrides: Any) -> Optional[Any]:
             pplx_api_key = params.pop(
                 "pplx_api_key", config.settings.perplexity_api_key
             )
-            return ChatPerplexity(model=model_name, pplx_api_key=pplx_api_key, **params)
+            model = ChatPerplexity(
+                model=model_name, pplx_api_key=pplx_api_key, **params
+            )
+        else:
+            from langchain_openai import ChatOpenAI  # type: ignore
 
-        from langchain_openai import ChatOpenAI  # type: ignore
+            model = ChatOpenAI(model=model_name, **params)
 
-        return ChatOpenAI(model=model_name, **params)
+        _MODEL_CACHE[model_name] = model
+        return model
     except Exception:  # pragma: no cover - optional dependencies
         return None
 
 
-__all__ = ["get_llm_params", "init_chat_model"]
+__all__ = ["get_llm_params", "init_chat_model", "clear_model_cache"]

--- a/tests/agents/test_agent_wrapper.py
+++ b/tests/agents/test_agent_wrapper.py
@@ -1,0 +1,75 @@
+"""Tests for caching behavior in ``init_chat_model``."""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+
+import pytest
+
+# Ensure required environment variables so ``config`` loads during import.
+os.environ.setdefault("OPENAI_API_KEY", "test-openai")
+os.environ.setdefault("PERPLEXITY_API_KEY", "test-perplexity")
+os.environ.setdefault("DATA_DIR", "/tmp")
+
+import config
+
+# Provide a minimal ``agentic_demo`` package for modules expecting it.
+pkg = types.ModuleType("agentic_demo")
+pkg.config = config
+sys.modules["agentic_demo"] = pkg
+sys.modules["agentic_demo.config"] = config
+
+from agents import agent_wrapper as aw  # noqa: E402
+
+
+def _stub_langchain(monkeypatch: pytest.MonkeyPatch, factory: object) -> None:
+    """Provide a fake ``langchain_openai`` module with ``ChatOpenAI``."""
+
+    module = types.SimpleNamespace(ChatOpenAI=factory)
+    monkeypatch.setitem(sys.modules, "langchain_openai", module)
+
+
+def test_init_chat_model_caches_instance(monkeypatch, tmp_path):
+    """Repeated calls with same model name reuse the instance."""
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk")
+    monkeypatch.setenv("PERPLEXITY_API_KEY", "pk")
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+
+    class FakeModel:
+        pass
+
+    def factory(**_kwargs):
+        return FakeModel()
+
+    _stub_langchain(monkeypatch, factory)
+
+    aw.clear_model_cache()
+
+    first = aw.init_chat_model()
+    second = aw.init_chat_model()
+    assert first is second
+
+
+def test_clear_model_cache(monkeypatch, tmp_path):
+    """Clearing the cache forces new model instantiation."""
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk")
+    monkeypatch.setenv("PERPLEXITY_API_KEY", "pk")
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+
+    class FakeModel:
+        pass
+
+    def factory(**_kwargs):
+        return FakeModel()
+
+    _stub_langchain(monkeypatch, factory)
+
+    aw.clear_model_cache()
+    first = aw.init_chat_model()
+    aw.clear_model_cache()
+    second = aw.init_chat_model()
+    assert first is not second


### PR DESCRIPTION
## Summary
- cache chat model instances by model name
- expose `clear_model_cache` for tests
- add tests covering cache reuse and clearing

## Testing
- `ruff check src/agents/agent_wrapper.py tests/agents/test_agent_wrapper.py`
- `mypy src/agents/agent_wrapper.py tests/agents/test_agent_wrapper.py` *(fails: Cannot find implementation or library stub for module named "agentic_demo", "config", "agents")*
- `bandit -r src -ll`
- `pip-audit` *(fails: SSLCertVerificationError: certificate verify failed)*
- `pytest tests/agents/test_agent_wrapper.py`


------
https://chatgpt.com/codex/tasks/task_e_68907a54cd04832ba5f3e0fc04c4f51b