### PR TITLE
Compile and expose LangGraph graph

### DIFF
--- a/src/core/regenerator.py
+++ b/src/core/regenerator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import List
 
-from langgraph.graph import StateGraph
+from langgraph.graph.state import CompiledStateGraph
 
 from core.state import State
 from models.critique_report import CritiqueReport
@@ -44,7 +44,7 @@ def has_exceeded_max_retries(state: State, section_id: SectionIdentifier) -> boo
 
 
 def apply_regeneration(
-    graph: StateGraph, state: State, sections: List[SectionIdentifier]
+    graph: CompiledStateGraph[State], state: State, sections: List[SectionIdentifier]
 ) -> None:
     """Invoke the Content Weaver node for the specified sections."""
     for section_id in sections:
@@ -58,7 +58,7 @@ def apply_regeneration(
 def orchestrate_regeneration(
     state: State,
     report: CritiqueReport | FactCheckReport,
-    graph: StateGraph | None = None,
+    graph: CompiledStateGraph[State] | None = None,
 ) -> State:
     """Select sections for rewriting and trigger regeneration.
 

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -66,7 +66,7 @@ async def setup_database(app: FastAPI) -> None:
 
 
 def setup_graph(app: FastAPI) -> None:
-    """Initialize the LangGraph ``StateGraph`` and checkpoint saver."""
+    """Initialize the LangGraph graph and checkpoint saver."""
 
     settings: Settings = app.state.settings
     checkpoint_path = settings.data_dir / "checkpoint.db"

--- a/tests/core/test_nodes_and_orchestrator.py
+++ b/tests/core/test_nodes_and_orchestrator.py
@@ -55,9 +55,10 @@ def test_orchestrator_wires_graph() -> None:
     orchestrator = GraphOrchestrator()
     orchestrator.initialize_graph()
     orchestrator.register_edges()
-    graph = orchestrator.graph
-    assert graph is not None
-    nodes = set(graph.nodes.keys())
+    compiled = orchestrator.graph
+    assert compiled is not None
+    underlying = compiled.get_graph()
+    nodes = set(underlying.nodes.keys())
     assert {
         "Planner",
         "Researcher-Web",
@@ -67,12 +68,13 @@ def test_orchestrator_wires_graph() -> None:
         "Human-In-Loop",
         "Exporter",
     }.issubset(nodes)
-    assert (START, "Planner") in graph.edges
-    assert ("Planner", "Researcher-Web") in graph.edges
-    assert ("Planner", "Content-Weaver") in graph.edges
-    assert ("Researcher-Web", "Planner") in graph.edges
-    assert ("Human-In-Loop", "Exporter") in graph.edges
-    assert ("Exporter", END) in graph.edges
+    edges = {(e.source, e.target) for e in underlying.edges}
+    assert (START, "Planner") in edges
+    assert ("Planner", "Researcher-Web") in edges
+    assert ("Planner", "Content-Weaver") in edges
+    assert ("Researcher-Web", "Planner") in edges
+    assert ("Human-In-Loop", "Exporter") in edges
+    assert ("Exporter", END) in edges
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- compile StateGraph after edge registration and expose compiled graph from orchestrator
- adjust regenerator and web setup to use compiled LangGraph graph
- update orchestrator tests to inspect compiled graph structure

## Testing
- `black .`
- `ruff check .`
- `mypy .` *(fails: Cannot find implementation or library stub for module named "agentic_demo" and others)*
- `bandit -r src -ll`
- `pip-audit` *(fails: HTTPSConnectionPool host='pypi.org' SSL: CERTIFICATE_VERIFY_FAILED)*
- `OPENAI_API_KEY=x PERPLEXITY_API_KEY=y MODEL_NAME=m DATA_DIR=/tmp pytest tests/core/test_nodes_and_orchestrator.py` *(fails: ModuleNotFoundError: No module named 'agentic_demo')*

------
https://chatgpt.com/codex/tasks/task_e_68907ed41e70832bac236b36d03691d2