### PR TITLE
feat: add langsmith tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ cp .env.example .env
 # PERPLEXITY_API_KEY=...
 # MODEL_NAME=o4-mini
 # DATA_DIR=./workspace
+# LANGCHAIN_API_KEY=...
+# LANGCHAIN_ENDPOINT=https://api.smith.langchain.com
 ```
 
 ### Running Locally
@@ -190,6 +192,8 @@ cp .env.example .env
 | `MODEL_NAME`         | Model to use (`o4-mini` or `o3`)         | `o4-mini`  |
 | `DATA_DIR`           | Path for SQLite DB, cache, logs          | (required) |
 | `DATABASE_URL`       | Postgres connection string (optional)    |            |
+| `LANGCHAIN_API_KEY`  | API key for LangSmith tracing            |            |
+| `LANGCHAIN_ENDPOINT` | LangSmith API endpoint                   | `https://api.smith.langchain.com` |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ dependencies = [
     "alembic (>=1.16.4,<2.0.0)",
     "sqlalchemy (>=2.0.42,<3.0.0)",
     "weasyprint (>=66,<67)",
-    "fastapi (>=0.111,<1.0)"
+    "fastapi (>=0.111,<1.0)",
+    "langsmith (>=0.4,<0.5)"
 ]
 
 [build-system]

--- a/tests/core/test_langsmith_client.py
+++ b/tests/core/test_langsmith_client.py
@@ -1,0 +1,144 @@
+import sys
+import types
+from contextlib import asynccontextmanager
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_wrap_traces_with_langsmith_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dummy_settings = types.SimpleNamespace(model_name="m", data_dir=Path("./workspace"))
+    agentic_demo_config = types.SimpleNamespace(MODEL_NAME="m", settings=dummy_settings)
+    sys.modules["agentic_demo"] = types.SimpleNamespace(config=agentic_demo_config)
+    sys.modules["agentic_demo.config"] = types.SimpleNamespace(
+        Settings=lambda: dummy_settings, settings=dummy_settings
+    )
+    sys.modules["persistence"] = types.SimpleNamespace(get_db_session=None)
+    sys.modules["persistence.logs"] = types.SimpleNamespace(
+        compute_hash=lambda _: "h", log_action=lambda *a, **k: None
+    )
+    sys.modules["agents.planner"] = types.SimpleNamespace(PlanResult=object)
+
+    class DummyCheckpoint:
+        def __init__(self, *args, **kwargs) -> None:  # noqa: ANN001
+            pass
+
+        async def save_checkpoint(self, state) -> None:  # noqa: ANN001
+            pass
+
+    sys.modules["core.checkpoint"] = types.SimpleNamespace(
+        SqliteCheckpointManager=DummyCheckpoint
+    )
+
+    class DummyStateModule:
+        class State:  # noqa: D401
+            """Minimal State stub."""
+
+            def __init__(self, prompt: str = "p") -> None:
+                self.prompt = prompt
+
+            def to_dict(self) -> dict:
+                return {"prompt": self.prompt}
+
+    sys.modules["core.state"] = DummyStateModule
+
+    class DummyEncoding:
+        def encode(self, text: str) -> bytes:  # noqa: ANN001
+            return text.encode()
+
+    class DummyTiktoken:
+        def encoding_for_model(self, model: str):  # noqa: ANN001
+            raise KeyError
+
+        def get_encoding(self, name: str) -> DummyEncoding:  # noqa: ANN001
+            return DummyEncoding()
+
+    sys.modules["tiktoken"] = DummyTiktoken()
+
+    class DummyCompiled:
+        def get_graph(self):  # noqa: ANN001
+            return types.SimpleNamespace(nodes={}, edges=[])
+
+    class DummyStateGraph:
+        def __init__(self, state_cls) -> None:  # noqa: ANN001
+            self.nodes = {}
+            self.edges = []
+
+        def add_node(self, *args, **kwargs) -> None:  # noqa: ANN001, ANN002
+            pass
+
+        def add_edge(self, *args, **kwargs) -> None:  # noqa: ANN001, ANN002
+            pass
+
+        def add_conditional_edges(self, *a, **k) -> None:  # noqa: ANN001, ANN002
+            pass
+
+        def compile(self) -> DummyCompiled:
+            return DummyCompiled()
+
+    sys.modules["langgraph.graph"] = types.SimpleNamespace(
+        END="__end__",
+        START="__start__",
+        StateGraph=DummyStateGraph,
+    )
+    sys.modules["langgraph.graph.state"] = types.SimpleNamespace(
+        CompiledStateGraph=DummyCompiled
+    )
+
+    real_open = Path.open
+
+    def fake_open(self, *args, **kwargs):  # noqa: ANN001
+        if self.name.endswith("langgraph.json"):
+            return StringIO('{"nodes": [], "edges": []}')
+        return real_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", fake_open)
+
+    from core.orchestrator import GraphOrchestrator
+
+    calls: list[str] = []
+
+    class DummyRun:
+        def __init__(self, name: str) -> None:
+            self.name = name
+            self.outputs: object | None = None
+
+        def end(self, *, outputs: object) -> None:  # noqa: ANN001
+            self.outputs = outputs
+
+    class DummyClient:
+        def trace(self, name: str, *, inputs: object | None = None):  # noqa: ANN001
+            calls.append(name)
+
+            class Ctx:
+                def __enter__(self) -> DummyRun:  # type: ignore[override]
+                    return DummyRun(name)
+
+                def __exit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001
+                    return None
+
+            return Ctx()
+
+    async def fake_log_action(*args, **kwargs) -> None:  # noqa: ANN001, ANN002
+        return None
+
+    @asynccontextmanager
+    async def fake_session():
+        yield None
+
+    monkeypatch.setattr("core.orchestrator.log_action", fake_log_action)
+    monkeypatch.setattr("core.orchestrator.get_db_session", fake_session)
+
+    client = DummyClient()
+    orch = GraphOrchestrator(langsmith_client=client)
+
+    async def node(state: DummyStateModule.State) -> str:  # noqa: ANN001
+        return "ok"
+
+    state = DummyStateModule.State()
+    await orch._wrap("Trace", node)(state)
+    assert calls == ["Trace"]


### PR DESCRIPTION
## Summary
- add langsmith dependency
- wrap graph nodes with LangSmith tracing
- document LangSmith environment variables
- test tracing when client is enabled

## Testing
- `black src/core/orchestrator.py tests/core/test_langsmith_client.py`
- `ruff check .`
- `mypy src/core/orchestrator.py tests/core/test_langsmith_client.py` *(fails: module not found)*
- `bandit -r src -ll`
- `pip-audit` *(fails: certificate verify failed)*
- `pytest tests/core/test_langsmith_client.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689081e6bb40832b9df43d2fe5982a22