### PR TITLE
feat(stream): add helper and emit events

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ The system comprises:
 4. **Storage Layer**: SQLite for state, logs, citations; optional Postgres via repository abstraction.
 5. **Export Pipeline**: Pandoc-ready Markdown, python-docx, WeasyPrint PDF.
 
+### Stream Channels
+
+Agents emit events over several LangGraph channels that the frontend can
+subscribe to:
+
+- `messages` – token-level content such as LLM outputs.
+- `debug` – diagnostic information and warnings.
+- `values` – structured state snapshots.
+- `updates` – citation and progress updates.
+
 ---
 
 ## Getting Started

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -9,6 +9,7 @@ from core.state import Outline, State
 from prompts import get_prompt
 
 from .agent_wrapper import init_chat_model
+from .streaming import stream_debug, stream_messages
 
 
 @dataclass(slots=True)
@@ -64,10 +65,13 @@ async def run_planner(state: State) -> PlanResult:
     """Analyze ``state.prompt`` and draft an outline."""
 
     raw = await call_planner_llm(state.prompt)
+    stream_messages(raw)
     outline = extract_outline(raw)
     confidence = 0.0
     if outline.steps:
         confidence = min(1.0, round(0.5 + 0.1 * len(outline.steps), 2))
+    else:
+        stream_debug("planner produced empty outline")
     return PlanResult(outline=outline, confidence=confidence)
 
 

--- a/src/agents/streaming.py
+++ b/src/agents/streaming.py
@@ -1,0 +1,38 @@
+"""Utilities for emitting LangGraph stream events with safe fallbacks."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def stream(channel: str, payload: Any) -> None:
+    """Send ``payload`` to ``channel`` if ``langgraph_sdk`` is installed.
+
+    Falls back to printing when the optional dependency is missing or raises
+    an exception.
+    """
+
+    try:
+        from langgraph_sdk import stream as _stream  # type: ignore
+
+        _stream(channel, payload)
+    except Exception:  # pragma: no cover - optional dependency
+        if channel == "messages":
+            print(payload, end="", flush=True)
+        else:
+            print(payload, flush=True)
+
+
+def stream_messages(token: str) -> None:
+    """Forward ``token`` over the ``messages`` channel."""
+
+    stream("messages", token)
+
+
+def stream_debug(message: str) -> None:
+    """Forward ``message`` over the ``debug`` channel."""
+
+    stream("debug", message)
+
+
+__all__ = ["stream", "stream_messages", "stream_debug"]

--- a/tests/agents/test_content_weaver.py
+++ b/tests/agents/test_content_weaver.py
@@ -1,8 +1,21 @@
 import asyncio
 import json
+import sys
+import types
 
-from agents import content_weaver as cw
-from core.state import Outline, State
+
+class _Msg:
+    def __init__(self, content: str):
+        self.content = content
+
+
+sys.modules.setdefault(
+    "langchain_core.messages",
+    types.SimpleNamespace(HumanMessage=_Msg, SystemMessage=_Msg),
+)
+
+from agents import content_weaver as cw  # noqa: E402
+from core.state import Outline, State  # noqa: E402
 
 
 def test_call_openai_function_streams_tokens(monkeypatch):
@@ -71,6 +84,11 @@ def test_section_specific_prompt(monkeypatch):
 
     monkeypatch.setattr(cw, "call_openai_function", fake_call_openai_function)
     monkeypatch.setattr(cw, "stream_messages", lambda token: None)
+    monkeypatch.setattr(
+        cw,
+        "validate_against_schema",
+        lambda payload: cw.ValidationResult(valid=True, errors=[]),
+    )
 
     async def run_test():
         outline = Outline(steps=["first", "second"])

--- a/tests/agents/test_planner.py
+++ b/tests/agents/test_planner.py
@@ -16,6 +16,10 @@ def test_run_planner_parses_outline_and_confidence(monkeypatch):
         return "1. Intro\n2. Body\n3. Conclusion"
 
     monkeypatch.setattr(planner, "call_planner_llm", fake_llm)
+    tokens: list[str] = []
+    debugs: list[str] = []
+    monkeypatch.setattr(planner, "stream_messages", tokens.append)
+    monkeypatch.setattr(planner, "stream_debug", debugs.append)
 
     async def run_test():
         state = State(prompt="topic")
@@ -24,6 +28,8 @@ def test_run_planner_parses_outline_and_confidence(monkeypatch):
     result = asyncio.run(run_test())
     assert result.outline.steps == ["Intro", "Body", "Conclusion"]
     assert result.confidence == 0.8
+    assert tokens == ["1. Intro\n2. Body\n3. Conclusion"]
+    assert debugs == []
 
 
 def test_run_planner_empty_response(monkeypatch):
@@ -31,6 +37,10 @@ def test_run_planner_empty_response(monkeypatch):
         return ""
 
     monkeypatch.setattr(planner, "call_planner_llm", fake_llm)
+    tokens: list[str] = []
+    debugs: list[str] = []
+    monkeypatch.setattr(planner, "stream_messages", tokens.append)
+    monkeypatch.setattr(planner, "stream_debug", debugs.append)
 
     async def run_test():
         state = State(prompt="topic")
@@ -39,3 +49,5 @@ def test_run_planner_empty_response(monkeypatch):
     result = asyncio.run(run_test())
     assert result.outline.steps == []
     assert result.confidence == 0.0
+    assert tokens == [""]
+    assert debugs == ["planner produced empty outline"]

--- a/tests/test_perplexity_client.py
+++ b/tests/test_perplexity_client.py
@@ -1,3 +1,9 @@
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "x")
+os.environ.setdefault("PERPLEXITY_API_KEY", "x")
+os.environ.setdefault("DATA_DIR", "/tmp")
+
 from agents import offline_cache
 from agents.researcher_web import PerplexityClient, RawSearchResult
 
@@ -21,6 +27,13 @@ def test_search_hits_api_and_caches_results(monkeypatch, tmp_path):
 
             return Resp()
 
+    tokens: list[str] = []
+    debugs: list[str] = []
+    import agents.researcher_web as rw
+
+    monkeypatch.setattr(rw, "stream_messages", tokens.append)
+    monkeypatch.setattr(rw, "stream_debug", debugs.append)
+
     client = PerplexityClient(api_key="token", llm=DummyLLM())
     results = client.search("hello world")
 
@@ -28,6 +41,8 @@ def test_search_hits_api_and_caches_results(monkeypatch, tmp_path):
         RawSearchResult(url="http://example.com", snippet="snippet", title="title")
     ]
     assert (tmp_path / "hello_world.json").exists()
+    assert tokens == ["snippet"]
+    assert debugs == ["perplexity search: hello world"]
 
 
 def test_fallback_search_returns_cached(monkeypatch, tmp_path):
@@ -35,6 +50,15 @@ def test_fallback_search_returns_cached(monkeypatch, tmp_path):
     expected = [RawSearchResult(url="http://a", snippet="b", title="c")]
     offline_cache.save_cached_results("query", expected)
 
-    client = PerplexityClient(api_key="token")
+    tokens: list[str] = []
+    debugs: list[str] = []
+    import agents.researcher_web as rw
+
+    monkeypatch.setattr(rw, "stream_messages", tokens.append)
+    monkeypatch.setattr(rw, "stream_debug", debugs.append)
+
+    client = PerplexityClient(api_key="token", llm=object())
     results = client.fallback_search("query")
     assert results == expected
+    assert tokens == ["b"]
+    assert debugs == ["offline search: query"]


### PR DESCRIPTION
## Summary
- add reusable LangGraph streaming wrapper with safe console fallback
- stream planner outputs and researcher web search results
- document supported LangGraph stream channels

## Testing
- `ruff check src/agents/streaming.py src/agents/planner.py src/agents/researcher_web.py src/agents/content_weaver.py tests/agents/test_planner.py tests/test_perplexity_client.py tests/agents/test_content_weaver.py`
- `mypy .` *(fails: Cannot find implementation or library stub for module named "core.state"; Cannot find implementation or library stub for module named "fastapi"; and more)*
- `bandit -r src -ll`
- `pip-audit` *(fails: SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier)*
- `pytest tests/agents/test_planner.py tests/test_perplexity_client.py tests/agents/test_content_weaver.py`


------
https://chatgpt.com/codex/tasks/task_e_68908913c938832bae43c22b524523a8