### PR TITLE
feat: add pluggable web search clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lecture Builder Agent
 
-A local-first, multi-agent system that generates high‑quality, university‑grade lecture and workshop outlines (with supporting materials) from a single topic prompt. Orchestrated by LangGraph and implemented in Python, the system integrates OpenAI o4‑mini/o3 models, Perplexity Sonar via LangChain, and a React‑based UX. Full state, citations, logs, and intermediates persist in SQLite (with optional Postgres fallback). Exports include Markdown, DOCX, and PDF.
+A local-first, multi-agent system that generates high‑quality, university‑grade lecture and workshop outlines (with supporting materials) from a single topic prompt. Orchestrated by LangGraph and implemented in Python, the system integrates OpenAI o4‑mini/o3 models, pluggable web search (Perplexity Sonar or Tavily) via LangChain, and a React‑based UX. Full state, citations, logs, and intermediates persist in SQLite (with optional Postgres fallback). Exports include Markdown, DOCX, and PDF.
 
 ---
 
@@ -38,7 +38,7 @@ A local-first, multi-agent system that generates high‑quality, university‑gr
 
 - **Multi-Agent Workflow**: Planner, Researcher, Synthesiser, Pedagogy Critic, Fact Checker, Human-in-Loop, and Exporter nodes working in a LangGraph state graph.
 - **Streaming UI**: Token-level draft streaming with diff highlights; action/reasoning log streaming via SSE.
-- **Robust Citations**: Perplexity Sonar integration, citation metadata stored in SQLite, Creative Commons and university domain filtering.
+- **Robust Citations**: Pluggable Perplexity or Tavily search, citation metadata stored in SQLite, Creative Commons and university domain filtering.
 - **Local-First**: Operates offline using cached corpora and fallback to local dense retrieval.
 - **Flexible Exports**: Markdown (canonical), DOCX (python-docx), PDF (WeasyPrint), with cover page, TOC, and bibliography.
 - **Audit & Governance**: Immutable action logs, SHA‑256 state hashes, role‑based access, optional database encryption.
@@ -82,7 +82,7 @@ subscribe to:
 - Node.js 18+ (for frontend)
 - `poetry` (recommended) or `pipenv`
 - OpenAI API key
-- Perplexity API key
+- Perplexity or Tavily API key
 
 ### Installation
 
@@ -115,6 +115,8 @@ cp .env.example .env
 # Edit .env:
 # OPENAI_API_KEY=sk-...
 # PERPLEXITY_API_KEY=...
+# TAVILY_API_KEY=...
+# SEARCH_PROVIDER=perplexity  # or 'tavily'
 # MODEL_NAME=o4-mini
 # DATA_DIR=./workspace
 # LANGCHAIN_API_KEY=...
@@ -150,7 +152,7 @@ cp .env.example .env
 
 ### Retrieval & Citation
 
-- **ChatPerplexity** in `src/agents/researcher_web.py`
+- **SearchClient** abstraction in `src/agents/researcher_web.py` supporting Perplexity and Tavily
 - Citation objects stored in `state.citations` table.
 - Filtering by domain allowlist and SPDX license checks.
 
@@ -198,7 +200,9 @@ cp .env.example .env
 | Variable             | Description                              | Default    |
 | -------------------- | ---------------------------------------- | ---------- |
 | `OPENAI_API_KEY`     | API key for OpenAI                       | (required) |
-| `PERPLEXITY_API_KEY` | API key for Perplexity Sonar            | (required) |
+| `PERPLEXITY_API_KEY` | API key for Perplexity Sonar            | Required if `SEARCH_PROVIDER=perplexity` |
+| `TAVILY_API_KEY`     | API key for Tavily search               | Required if `SEARCH_PROVIDER=tavily` |
+| `SEARCH_PROVIDER`    | `perplexity` or `tavily`                 | `perplexity` |
 | `MODEL_NAME`         | Model to use (`o4-mini` or `o3`)         | `o4-mini`  |
 | `DATA_DIR`           | Path for SQLite DB, cache, logs          | (required) |
 | `DATABASE_URL`       | Postgres connection string (optional)    |            |

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -107,9 +107,9 @@ Further ER diagrams in ARCHITECTURE.md.
 
 ## 6. Retrieval & Citation
 
-### 6.1 Perplexity Sonar Integration
+### 6.1 Web Search Providers
 
-- **Client**: `ChatPerplexity` from `langchain_perplexity` wraps Sonar chat calls.
+- **Clients**: `ChatPerplexity` from `langchain_perplexity` or `TavilySearchAPIWrapper` from `langchain_community`, exposed via the `SearchClient` abstraction.
 - **Query templates**: Include objective keywords, `--QDF=3` for recency boost.
 - **Rate limiting**: Token bucket, configurable via env var.
 
@@ -255,7 +255,9 @@ Further ER diagrams in ARCHITECTURE.md.
 | Name                 | Purpose                                    | Required?              |
 | -------------------- | ------------------------------------------ | ---------------------- |
 | `OPENAI_API_KEY`     | OpenAI authentication                      | Yes                    |
-| `PERPLEXITY_API_KEY` | Perplexity Sonar authentication           | No                     |
+| `PERPLEXITY_API_KEY` | Perplexity Sonar authentication           | No (if using Tavily)   |
+| `TAVILY_API_KEY`     | Tavily search authentication              | No (if using Perplexity) |
+| `SEARCH_PROVIDER`    | `perplexity` or `tavily`                   | No (default `perplexity`) |
 | `MODEL_NAME`         | `o4-mini` or `o3`                          | No (default `o4-mini`) |
 | `DATA_DIR`           | Path for SQLite DB, cache, workspace files | No (default `./data`)  |
 | `DATABASE_URL`       | Postgres connection string (optional)      | No                     |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "langgraph (>=0.6.3,<0.7.0)",
     "langgraph-sdk (>=0.2.0,<0.3.0)",
     "langchain (>=0.3.7,<0.4.0)",
+    "langchain-community (>=0.3,<0.4)",
     "langchain-openai (>=0.3.0,<0.4.0)",
     "langchain-perplexity (>=0.1.2,<0.2.0)",
     "jsonschema (>=4.25.0,<5.0.0)",

--- a/src/agents/researcher_web_runner.py
+++ b/src/agents/researcher_web_runner.py
@@ -8,7 +8,13 @@ from config import Settings
 from core.state import State
 
 from .cache_backed_researcher import CacheBackedResearcher
-from .researcher_web import CitationDraft, PerplexityClient, RawSearchResult
+from .researcher_web import (
+    CitationDraft,
+    PerplexityClient,
+    RawSearchResult,
+    SearchClient,
+    TavilyClient,
+)
 
 
 def _to_draft(result: RawSearchResult) -> CitationDraft:
@@ -16,10 +22,12 @@ def _to_draft(result: RawSearchResult) -> CitationDraft:
 
 
 def run_web_search(state: State) -> List[CitationDraft]:
-    """Run a Perplexity Sonar search using the state's prompt as query."""
+    """Run a web search using the configured provider."""
     settings = Settings()
     if settings.offline_mode:
-        client = CacheBackedResearcher()
+        client: SearchClient = CacheBackedResearcher()
+    elif settings.search_provider == "tavily":
+        client = TavilyClient(settings.tavily_api_key or "")
     else:
         client = PerplexityClient(settings.perplexity_api_key)
     results = client.search(state.prompt)

--- a/src/config.py
+++ b/src/config.py
@@ -6,7 +6,7 @@ Exposes configuration via a :class:`pydantic_settings.BaseSettings` subclass.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List
+from typing import List, Literal
 
 from dotenv import load_dotenv
 from pydantic import Field
@@ -45,6 +45,14 @@ class Settings(BaseSettings):
     )
     perplexity_api_key: str = Field(
         ..., alias="PERPLEXITY_API_KEY", description="API key for Perplexity services."
+    )
+    tavily_api_key: str | None = Field(
+        None, alias="TAVILY_API_KEY", description="API key for Tavily search."
+    )
+    search_provider: Literal["perplexity", "tavily"] = Field(
+        "perplexity",
+        alias="SEARCH_PROVIDER",
+        description="Web search provider to use.",
     )
     model_name: str = Field(
         MODEL_NAME,

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -12,7 +12,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
 from agents.cache_backed_researcher import CacheBackedResearcher
-from agents.researcher_web import PerplexityClient
+from agents.researcher_web import PerplexityClient, TavilyClient
 from config import Settings, load_settings
 from core.checkpoint import SqliteCheckpointManager
 from core.orchestrator import GraphOrchestrator
@@ -31,7 +31,10 @@ def create_app() -> FastAPI:
         app.state.research_client = CacheBackedResearcher()
         app.state.fact_check_offline = True
     else:
-        app.state.research_client = PerplexityClient(settings.perplexity_api_key)
+        if settings.search_provider == "tavily":
+            app.state.research_client = TavilyClient(settings.tavily_api_key or "")
+        else:
+            app.state.research_client = PerplexityClient(settings.perplexity_api_key)
         app.state.fact_check_offline = False
 
     app.add_middleware(

--- a/tests/test_researcher_web_runner.py
+++ b/tests/test_researcher_web_runner.py
@@ -1,18 +1,30 @@
+import sys
+import types
+
+import config
+
+pkg = types.ModuleType("agentic_demo")
+pkg.config = config
+sys.modules["agentic_demo"] = pkg
+sys.modules["agentic_demo.config"] = config
+
 from agents.researcher_web import CitationDraft, RawSearchResult
 from agents.researcher_web_runner import run_web_search
 from core.state import State
 
 
-def _set_env(monkeypatch, offline: bool) -> None:
+def _set_env(monkeypatch, offline: bool, provider: str = "perplexity") -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "sk")
     monkeypatch.setenv("PERPLEXITY_API_KEY", "pp")
+    monkeypatch.setenv("TAVILY_API_KEY", "tv")
     monkeypatch.setenv("MODEL_NAME", "gpt")
     monkeypatch.setenv("DATA_DIR", "/tmp")
     monkeypatch.setenv("OFFLINE_MODE", "1" if offline else "0")
+    monkeypatch.setenv("SEARCH_PROVIDER", provider)
 
 
 def test_run_web_search_online(monkeypatch):
-    _set_env(monkeypatch, offline=False)
+    _set_env(monkeypatch, offline=False, provider="perplexity")
 
     state = State(prompt="cats")
     called = {"search": False, "fallback": False}
@@ -61,3 +73,25 @@ def test_run_web_search_offline(monkeypatch):
     citations = run_web_search(state)
     assert called["search"] is True
     assert citations == [CitationDraft(url="u2", snippet="s2", title="t2")]
+
+
+def test_run_web_search_tavily(monkeypatch):
+    _set_env(monkeypatch, offline=False, provider="tavily")
+
+    state = State(prompt="birds")
+    called = {"search": False}
+    results = [RawSearchResult(url="u3", snippet="s3", title="t3")]
+
+    class Dummy:
+        def __init__(self, api_key: str):
+            pass
+
+        def search(self, query):
+            called["search"] = True
+            return results
+
+    monkeypatch.setattr("agents.researcher_web_runner.TavilyClient", Dummy)
+
+    citations = run_web_search(state)
+    assert called["search"] is True
+    assert citations == [CitationDraft(url="u3", snippet="s3", title="t3")]

--- a/tests/test_search_clients.py
+++ b/tests/test_search_clients.py
@@ -1,14 +1,24 @@
 import os
+import sys
+import types
 
 os.environ.setdefault("OPENAI_API_KEY", "x")
 os.environ.setdefault("PERPLEXITY_API_KEY", "x")
+os.environ.setdefault("TAVILY_API_KEY", "x")
 os.environ.setdefault("DATA_DIR", "/tmp")
 
+import config
+
+pkg = types.ModuleType("agentic_demo")
+pkg.config = config
+sys.modules["agentic_demo"] = pkg
+sys.modules["agentic_demo.config"] = config
+
 from agents import offline_cache
-from agents.researcher_web import PerplexityClient, RawSearchResult
+from agents.researcher_web import PerplexityClient, RawSearchResult, TavilyClient
 
 
-def test_search_hits_api_and_caches_results(monkeypatch, tmp_path):
+def test_perplexity_search_hits_api_and_caches_results(monkeypatch, tmp_path):
     monkeypatch.setattr(offline_cache, "CACHE_DIR", tmp_path)
 
     class DummyLLM:
@@ -45,7 +55,7 @@ def test_search_hits_api_and_caches_results(monkeypatch, tmp_path):
     assert debugs == ["perplexity search: hello world"]
 
 
-def test_fallback_search_returns_cached(monkeypatch, tmp_path):
+def test_perplexity_fallback_search_returns_cached(monkeypatch, tmp_path):
     monkeypatch.setattr(offline_cache, "CACHE_DIR", tmp_path)
     expected = [RawSearchResult(url="http://a", snippet="b", title="c")]
     offline_cache.save_cached_results("query", expected)
@@ -62,3 +72,34 @@ def test_fallback_search_returns_cached(monkeypatch, tmp_path):
     assert results == expected
     assert tokens == ["b"]
     assert debugs == ["offline search: query"]
+
+
+def test_tavily_search_hits_api_and_caches_results(monkeypatch, tmp_path):
+    monkeypatch.setattr(offline_cache, "CACHE_DIR", tmp_path)
+
+    class DummyWrapper:
+        def results(self, query: str):
+            return [
+                {
+                    "url": "http://example.com",
+                    "content": "snippet",
+                    "title": "title",
+                }
+            ]
+
+    tokens: list[str] = []
+    debugs: list[str] = []
+    import agents.researcher_web as rw
+
+    monkeypatch.setattr(rw, "stream_messages", tokens.append)
+    monkeypatch.setattr(rw, "stream_debug", debugs.append)
+
+    client = TavilyClient(api_key="token", wrapper=DummyWrapper())
+    results = client.search("hello world")
+
+    assert results == [
+        RawSearchResult(url="http://example.com", snippet="snippet", title="title")
+    ]
+    assert (tmp_path / "hello_world.json").exists()
+    assert tokens == ["snippet"]
+    assert debugs == ["tavily search: hello world"]


### PR DESCRIPTION
## Summary
- abstract Perplexity behind SearchClient protocol and add Tavily implementation
- allow choosing Tavily or Perplexity via config and app startup
- document search provider options and add tests for both clients

## Testing
- `ruff check .`
- `mypy .` *(fails: Cannot find implementation or library stub for module named "agents.planner", etc.)*
- `bandit -r src -ll`
- `pip-audit` *(fails: SSLCertVerificationError: certificate verify failed)*
- `pytest tests/test_search_clients.py tests/test_researcher_web_runner.py`


------
https://chatgpt.com/codex/tasks/task_e_689092393b48832bacee13321566ab64