### PR TITLE
docs: expand env config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,9 @@
 OPENAI_API_KEY=your-openai-key
 PERPLEXITY_API_KEY=your-perplexity-key
+TAVILY_API_KEY=your-tavily-key
+SEARCH_PROVIDER=perplexity
+LANGCHAIN_API_KEY=your-langchain-key
+LANGCHAIN_ENDPOINT=https://api.smith.langchain.com
 MODEL_NAME=o4-mini
 DATA_DIR=./workspace
 OFFLINE_MODE=false

--- a/README.md
+++ b/README.md
@@ -203,11 +203,11 @@ cp .env.example .env
 | `PERPLEXITY_API_KEY` | API key for Perplexity Sonar            | Required if `SEARCH_PROVIDER=perplexity` |
 | `TAVILY_API_KEY`     | API key for Tavily search               | Required if `SEARCH_PROVIDER=tavily` |
 | `SEARCH_PROVIDER`    | `perplexity` or `tavily`                 | `perplexity` |
-| `MODEL_NAME`         | Model to use (`o4-mini` or `o3`)         | `o4-mini`  |
-| `DATA_DIR`           | Path for SQLite DB, cache, logs          | (required) |
-| `DATABASE_URL`       | Postgres connection string (optional)    |            |
 | `LANGCHAIN_API_KEY`  | API key for LangSmith tracing            |            |
 | `LANGCHAIN_ENDPOINT` | LangSmith API endpoint                   | `https://api.smith.langchain.com` |
+| `MODEL_NAME`         | Model to use (`o4-mini` or `o3`)         | `o4-mini`  |
+| `DATA_DIR`           | Path for SQLite DB, cache, logs          | (required) |
+| `OFFLINE_MODE`       | Run without external network calls       | `false`    |
 
 ---
 


### PR DESCRIPTION
## Summary
- expand `.env.example` with search provider, Tavily, and LangSmith placeholders
- document new and existing environment variables in README

## Testing
- `black .`
- `ruff check .` *(fails: E402 imports not at top)*
- `mypy .` *(fails: missing modules, attribute errors)*
- `bandit -r src -ll`
- `pip-audit` *(fails: SSL certificate verify failed)*

------
https://chatgpt.com/codex/tasks/task_e_689099909938832b8ce9c26ce1f9a2e8