### PR TITLE
Use app factory with uvicorn

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ cp .env.example .env
 1. **Start the backend** (FastAPI + LangGraph):
 
    ```bash
+   ./scripts/run.sh [--offline]
+   ```
+
+   This helper invokes Uvicorn with:
+
+   ```bash
    poetry run uvicorn web.main:create_app --reload
    ```
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -22,4 +22,4 @@ fi
 poetry run alembic upgrade head
 
 # Forward all arguments (e.g., --offline) to uvicorn
-poetry run uvicorn web.main:app --reload "$@"
+poetry run uvicorn web.main:create_app --reload "$@"


### PR DESCRIPTION
## Summary
- start uvicorn using the `create_app` factory
- document new run script invocation and underlying uvicorn command

## Testing
- `poetry run black .`
- `poetry run ruff check .` *(fails: E402 Module level import not at top of file)*
- `poetry run mypy .` *(fails: Cannot find implementation or library stub for module named "core.state", among others)*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /pypi/anyio/4.10.0/json (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)'))))*
- `PYTHONPATH=src ./scripts/run.sh --help` *(fails: ValidationError: 3 validation errors for Settings)*

------
https://chatgpt.com/codex/tasks/task_e_68909b6f7aa4832b8bb7f34ec427cea1