### PR TITLE
chore: expose metrics and alerts endpoints

### DIFF
--- a/src/web/main.py
+++ b/src/web/main.py
@@ -66,6 +66,7 @@ async def setup_database(app: FastAPI) -> None:
             yield session
 
     app.state.db = _session_factory
+    app.state.db_path = str(db_path)
 
 
 def setup_graph(app: FastAPI) -> None:
@@ -91,12 +92,16 @@ def mount_frontend(app: FastAPI) -> None:
 def register_routes(app: FastAPI) -> None:
     """Include API routers."""
 
+    from .alert_endpoint import post_alerts
+    from .metrics_endpoint import get_metrics
     from .routes import citation, control, export, stream
 
     app.include_router(stream.router)
     app.include_router(control.router)
     app.include_router(export.router)
     app.include_router(citation.router)
+    app.add_api_route("/metrics", get_metrics, methods=["GET"])
+    app.add_api_route("/alerts/{workspace_id}", post_alerts, methods=["POST"])
 
 
 def main() -> None:

--- a/tests/integration/test_metrics_and_alerts.py
+++ b/tests/integration/test_metrics_and_alerts.py
@@ -1,0 +1,86 @@
+"""Integration tests for metrics and alert endpoints."""
+
+from fastapi.testclient import TestClient
+import pytest
+import sys
+import types
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch) -> TestClient:
+    """Provide a configured :class:`TestClient` instance."""
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setenv("PERPLEXITY_API_KEY", "y")
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("OFFLINE_MODE", "1")
+    fake_settings = types.SimpleNamespace(model_name="gpt-4", perplexity_api_key="x")
+    fake_config = types.SimpleNamespace(settings=fake_settings)
+    sys.modules["agentic_demo"] = types.ModuleType("agentic_demo")
+    sys.modules["agentic_demo.config"] = fake_config
+    sys.modules["agentic_demo"].config = fake_config
+
+    class DummyCacheBackedResearcher:  # pragma: no cover - placeholder
+        pass
+
+    class DummyPerplexityClient:  # pragma: no cover - placeholder
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+    class DummyTavilyClient:  # pragma: no cover - placeholder
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+    class DummyCheckpointManager:  # pragma: no cover - placeholder
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+    class DummyGraphOrchestrator:  # pragma: no cover - placeholder
+        def __init__(self, *args, **kwargs) -> None:
+            self.graph = {}
+
+        def initialize_graph(self) -> None:
+            pass
+
+        def register_edges(self) -> None:
+            pass
+
+    sys.modules["agents.cache_backed_researcher"] = types.SimpleNamespace(
+        CacheBackedResearcher=DummyCacheBackedResearcher
+    )
+    sys.modules["agents.researcher_web"] = types.SimpleNamespace(
+        PerplexityClient=DummyPerplexityClient, TavilyClient=DummyTavilyClient
+    )
+    sys.modules["core.checkpoint"] = types.SimpleNamespace(
+        SqliteCheckpointManager=DummyCheckpointManager
+    )
+    sys.modules["core.orchestrator"] = types.SimpleNamespace(
+        GraphOrchestrator=DummyGraphOrchestrator
+    )
+
+    from fastapi import APIRouter
+
+    dummy_routes_pkg = types.ModuleType("web.routes")
+    sys.modules["web.routes"] = dummy_routes_pkg
+    empty_router = APIRouter()
+    for name in ["citation", "control", "export", "stream"]:
+        module = types.ModuleType(f"web.routes.{name}")
+        module.router = empty_router
+        setattr(dummy_routes_pkg, name, module)
+        sys.modules[f"web.routes.{name}"] = module
+    from web.main import create_app
+
+    app = create_app()
+    with TestClient(app) as client:
+        yield client
+
+
+def test_metrics_endpoint_returns_success(client: TestClient) -> None:
+    """``/metrics`` responds with HTTP 200."""
+    res = client.get("/metrics")
+    assert res.status_code == 200
+
+
+def test_alert_endpoint_returns_success(client: TestClient) -> None:
+    """``/alerts/{workspace_id}`` responds with HTTP 204."""
+    res = client.post("/alerts/ws1")
+    assert res.status_code == 204


### PR DESCRIPTION
## Summary
- persist database path on application state during startup
- register metrics and alert endpoints on the API
- add integration tests for new endpoints

## Testing
- `black tests/integration/test_metrics_and_alerts.py >/tmp/black.log && tail -n 20 /tmp/black.log`
- `ruff check tests/integration/test_metrics_and_alerts.py src/web/main.py >/tmp/ruff.log && tail -n 20 /tmp/ruff.log`
- `mypy src/web/main.py tests/integration/test_metrics_and_alerts.py >/tmp/mypy.log && tail -n 20 /tmp/mypy.log` *(failed: Module not found errors)*
- `bandit -r src -ll >/tmp/bandit.log && tail -n 20 /tmp/bandit.log`
- `pip-audit >/tmp/pip-audit.log && tail -n 20 /tmp/pip-audit.log` *(failed: SSLCertVerificationError)*
- `pytest tests/integration/test_metrics_and_alerts.py >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68909f05f468832bbbc4ece2dcb4ce3e