### PR TITLE
docs: add CLI reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,3 +264,4 @@ This project is licensed under the [MIT License](./LICENSE).
 - **SECURITY.md** — Security posture, secrets management, and encryption options
 - **TEST_PLAN.md** — Test cases, performance benchmarks, and QA checklist
 - **GOVERNANCE.md** — SLOs, metrics dashboard configuration, and audit procedures
+- [**CLI_REFERENCE.md**](./docs/CLI_REFERENCE.md) — Commands for running, testing, and maintenance tasks

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -1,0 +1,51 @@
+# CLI Reference
+
+Command-line shortcuts for running the application, executing tests, and handling maintenance tasks. All commands are run from the repository root.
+
+---
+
+## Running the Application
+
+- **Start the FastAPI server**
+
+  ```bash
+  ./scripts/run.sh [--offline]
+  ```
+
+  Launches the backend with hot reload; use `--offline` to disable external network calls.
+
+## Testing
+
+- **Backend tests**
+
+  ```bash
+  poetry run pytest
+  ```
+
+- **Frontend tests**
+
+  ```bash
+  npm test
+  ```
+
+- **Resume workflow smoke test**
+
+  ```bash
+  ./scripts/test_resume.sh "<prompt>"
+  ```
+
+  Starts the server, generates an outline for the prompt, and verifies export resume functionality.
+
+## Maintenance
+
+- **Reset the workspace database**
+
+  ```bash
+  ./scripts/reset_db.sh
+  ```
+
+- **Build the production frontend**
+
+  ```bash
+  ./scripts/build_frontend.sh
+  ```


### PR DESCRIPTION
## Summary
- document run, test, and maintenance commands
- link CLI reference in main README

## Testing
- `black .`
- `ruff check .` *(fails: E402 import order errors)*
- `mypy .` *(fails: missing stubs and modules)*
- `bandit -r src -ll`
- `pip-audit` *(fails: SSL certificate verification failed)*
- `poetry run pytest` *(fails: 35 errors during collection)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890a30da1b4832b84feeb7bc0af4ee3