### PR TITLE
Implement export and approval flows

### DIFF
--- a/src/agents/approver.py
+++ b/src/agents/approver.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any, Dict
 
-from core.state import State
+from core.state import ActionLog, State
+from .streaming import stream
 
 
 @dataclass(slots=True)
@@ -17,7 +19,24 @@ class StateEdits:
 async def run_approver(state: State) -> StateEdits:
     """Expose edits to the user and await confirmation.
 
-    TODO: Hook into UI for manual review.
+    The function expects two optional attributes on ``state``:
+
+    ``pending_edits``
+        Mapping of attribute names to proposed new values.
+    ``user_decision``
+        Boolean flag supplied by the UI indicating whether the edits should be
+        applied. Defaults to ``True`` when not provided.
     """
 
-    return StateEdits()
+    edits: Dict[str, Any] = getattr(state, "pending_edits", {})
+    stream("values", {"pending_edits": edits})
+    accepted = getattr(state, "user_decision", True)
+    if accepted:
+        for key, value in edits.items():
+            setattr(state, key, value)
+    stream("values", {"accepted": accepted})
+    state.log.append(
+        ActionLog(message=f"Edits {'accepted' if accepted else 'rejected'}")
+    )
+    state.pending_edits = {}
+    return StateEdits(accepted=accepted)

--- a/src/agents/exporter.py
+++ b/src/agents/exporter.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from core.state import State
+from config import settings
+from core.state import ActionLog, State
+from export.docx_exporter import DocxExporter
+from export.markdown_exporter import MarkdownExporter
+from export.pdf_exporter import PdfExporter
 
 
 @dataclass(slots=True)
@@ -17,7 +21,50 @@ class ExportStatus:
 async def run_exporter(state: State) -> ExportStatus:
     """Trigger Markdown/DOCX/PDF renders and report completion.
 
-    TODO: Implement real export functionality.
+    Parameters
+    ----------
+    state:
+        Mutable orchestration state. A ``workspace_id`` attribute is expected to
+        be present on the instance identifying which workspace should be
+        exported. The function mutates ``state`` by appending log entries and by
+        recording the filesystem locations of the generated files under an
+        ``exports`` attribute.
+
+    Returns
+    -------
+    ExportStatus
+        Simple dataclass indicating whether all export operations succeeded.
     """
 
-    return ExportStatus()
+    workspace_id = getattr(state, "workspace_id", "default")
+
+    db_path = settings.data_dir / "workspace.db"
+    export_dir = settings.data_dir / "exports" / workspace_id
+    export_dir.mkdir(parents=True, exist_ok=True)
+
+    status = ExportStatus(success=True)
+    exported: dict[str, str] = {}
+
+    try:
+        md = MarkdownExporter(str(db_path)).export(workspace_id)
+        md_path = export_dir / "lecture.md"
+        md_path.write_text(md, encoding="utf-8")
+        exported["markdown"] = str(md_path)
+
+        docx_bytes = DocxExporter(str(db_path)).export(workspace_id)
+        docx_path = export_dir / "lecture.docx"
+        docx_path.write_bytes(docx_bytes)
+        exported["docx"] = str(docx_path)
+
+        pdf_bytes = PdfExporter(str(db_path)).export(workspace_id)
+        pdf_path = export_dir / "lecture.pdf"
+        pdf_path.write_bytes(pdf_bytes)
+        exported["pdf"] = str(pdf_path)
+
+        state.log.append(ActionLog(message="Export complete"))
+        state.exports = exported
+    except Exception as exc:  # pragma: no cover - defensive
+        state.log.append(ActionLog(message=f"Export failed: {exc}"))
+        status.success = False
+
+    return status

--- a/tests/agents/test_approver.py
+++ b/tests/agents/test_approver.py
@@ -1,0 +1,51 @@
+"""Tests for the human-in-loop approver node."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_run_approver_accepts_edits(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Edits are applied when the user accepts them."""
+
+    import agents.approver as approver
+    from core.state import State
+
+    events: list[tuple[str, dict]] = []
+    monkeypatch.setattr(
+        approver, "stream", lambda ch, payload: events.append((ch, payload))
+    )
+
+    state = State(prompt="old")
+    state.pending_edits = {"prompt": "new"}
+    state.user_decision = True
+
+    result = await approver.run_approver(state)
+    assert result.accepted is True
+    assert state.prompt == "new"
+    assert events[0] == ("values", {"pending_edits": {"prompt": "new"}})
+    assert events[1] == ("values", {"accepted": True})
+
+
+@pytest.mark.asyncio
+async def test_run_approver_rejects_edits(monkeypatch: pytest.MonkeyPatch) -> None:
+    """State remains unchanged when the user rejects edits."""
+
+    import agents.approver as approver
+    from core.state import State
+
+    events: list[tuple[str, dict]] = []
+    monkeypatch.setattr(
+        approver, "stream", lambda ch, payload: events.append((ch, payload))
+    )
+
+    state = State(prompt="orig")
+    state.pending_edits = {"prompt": "new"}
+    state.user_decision = False
+
+    result = await approver.run_approver(state)
+    assert result.accepted is False
+    assert state.prompt == "orig"
+    assert events[0] == ("values", {"pending_edits": {"prompt": "new"}})
+    assert events[1] == ("values", {"accepted": False})

--- a/tests/agents/test_exporter.py
+++ b/tests/agents/test_exporter.py
@@ -1,0 +1,98 @@
+"""Tests for the exporter agent node."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+def _setup_db(path: Path) -> None:
+    """Create a minimal workspace database under ``path``."""
+
+    db_path = path / "workspace.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE lectures (workspace_id TEXT, lecture_json TEXT, created_at TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE citations (workspace_id TEXT, url TEXT, title TEXT, retrieved_at TEXT, licence TEXT)"
+    )
+    lecture = {
+        "title": "Intro to AI",
+        "author": "Alice",
+        "date": "2024-01-01",
+        "version": "1.0",
+        "summary": "Basics of AI",
+        "tags": ["ai", "intro"],
+        "prerequisites": ["Python"],
+        "duration_min": 60,
+        "learning_objectives": ["Understand basics"],
+        "activities": [
+            {
+                "type": "Lecture",
+                "description": "Overview",
+                "duration_min": 30,
+                "learning_objectives": ["Understand basics"],
+            }
+        ],
+        "slide_bullets": [{"slide_number": 1, "bullets": ["What is AI?", "History"]}],
+        "speaker_notes": "Engage audience",
+        "assessment": [{"type": "Quiz", "description": "Check", "max_score": 10}],
+        "references": [
+            {
+                "url": "http://example.com",
+                "title": "Example",
+                "retrieved_at": "2024-01-01",
+                "licence": "CC",
+            }
+        ],
+    }
+    conn.execute(
+        "INSERT INTO lectures VALUES (?,?,?)",
+        ("ws1", json.dumps(lecture), "2024-01-01"),
+    )
+    conn.execute(
+        "INSERT INTO citations VALUES (?,?,?,?,?)",
+        ("ws1", "http://example.com", "Example", "2024-01-01", "CC"),
+    )
+    conn.commit()
+    conn.close()
+
+
+@pytest.mark.asyncio
+async def test_run_exporter_writes_all_formats(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Exporter writes Markdown, DOCX and PDF outputs to disk."""
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk")
+    monkeypatch.setenv("PERPLEXITY_API_KEY", "pk")
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+
+    import config
+
+    importlib.reload(config)
+
+    _setup_db(tmp_path)
+
+    import agents.exporter as exporter
+
+    importlib.reload(exporter)
+
+    from core.state import State
+
+    state = State(prompt="hi")
+    state.workspace_id = "ws1"
+
+    status = await exporter.run_exporter(state)
+    assert status.success
+
+    export_dir = tmp_path / "exports" / "ws1"
+    assert (export_dir / "lecture.md").exists()
+    assert (export_dir / "lecture.docx").exists()
+    assert (export_dir / "lecture.pdf").exists()
+    assert "markdown" in getattr(state, "exports")


### PR DESCRIPTION
## Summary
- generate Markdown, DOCX and PDF files via exporter node and track outputs in state
- surface pending edits through approver node and apply user decisions
- add unit tests for exporter and approver flows

## Testing
- `ruff check src/agents/exporter.py src/agents/approver.py tests/agents/test_exporter.py tests/agents/test_approver.py`
- `mypy src/agents/exporter.py src/agents/approver.py tests/agents/test_exporter.py tests/agents/test_approver.py` (missing imports)
- `bandit -r src -ll`
- `pip-audit` (failed: SSL certificate verify failed)
- `pytest tests/agents/test_exporter.py tests/agents/test_approver.py`


------
https://chatgpt.com/codex/tasks/task_e_6890a4647984832b95d931f2eece9c80