### PR TITLE
Unify frontend static path

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ subscribe to:
    npm install
    ```
 
+4. Build the frontend:
+
+   ```bash
+   ./scripts/build_frontend.sh
+   ```
+
+   This generates the static assets in `frontend/dist` that the FastAPI server serves.
+
 ### Configuration
 
 Copy the sample environment file and provide your secrets:

--- a/scripts/build_frontend.sh
+++ b/scripts/build_frontend.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
-# Builds the React/Tailwind frontend and copies the static assets for serving.
+# Builds the React/Tailwind frontend and outputs static assets for serving.
 #
 # Usage:
 #   ./scripts/build_frontend.sh
 #
 # The script will:
 #   1. Install frontend dependencies
-#   2. Build the production bundle
-#   3. Copy the built assets to src/web/static
+#   2. Build the production bundle in frontend/dist
 
 set -euo pipefail
 
@@ -16,7 +15,3 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${REPO_ROOT}/frontend"
 npm ci
 npm run build
-
-# Copy built assets to backend static directory
-mkdir -p "${REPO_ROOT}/src/web/static"
-cp -r dist/* "${REPO_ROOT}/src/web/static/"

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -82,11 +82,11 @@ def setup_graph(app: FastAPI) -> None:
 
 
 def mount_frontend(app: FastAPI) -> None:
-    """Serve the React build directory at the root path."""
+    """Serve the built frontend from `frontend/dist`."""
 
-    dist_path = Path(__file__).resolve().parents[2] / "frontend" / "dist"
-    if dist_path.exists():
-        app.mount("/", StaticFiles(directory=dist_path, html=True), name="frontend")
+    frontend_dist = Path(__file__).resolve().parents[2] / "frontend" / "dist"
+    if frontend_dist.exists():
+        app.mount("/", StaticFiles(directory=frontend_dist, html=True), name="frontend")
 
 
 def register_routes(app: FastAPI) -> None:


### PR DESCRIPTION
## Summary
- serve React build from a single `frontend/dist` directory
- streamline frontend build script and reference same path in backend
- document how to build the frontend

## Testing
- `poetry run black .`
- `poetry run ruff check .` *(fails: module import errors in tests)*
- `poetry run mypy .` *(fails: missing imports and stubs)*
- `poetry run bandit -r src -ll` *(command not found)*
- `poetry run pip-audit` *(command not found)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890a7cba934832bb627c9d32ba58cbd