### PR TITLE
Expose separate SSE streams for state, actions and citations

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -95,53 +95,56 @@ This document provides a **detailed**, **explicit** reference for all backend HT
 
 ## 4. Server-Sent Events (SSE)
 
-Clients subscribe to three SSE endpoints to receive real-time updates. Each SSE stream sends newline-delimited JSON messages.
+Clients subscribe to three SSE endpoints to receive real-time updates. Each SSE
+stream sends newline-delimited JSON messages where the `event` field indicates
+the channel and the payload conforms to the `SseEvent` schema
+(`type`, `payload`, `timestamp`).
 
 ### 4.1 State Snapshots
 
-#### GET `/api/stream/state?job_id=<job_id>`
+#### GET `/api/stream/{workspace_id}/state`
 
 - **Purpose**: Stream structured state snapshots as each agent completes.
-
 - **Authentication**: Required (`viewer`, `editor`, or `admin`).
+- **Path Parameter**:
 
-- **Query Parameter**:
+  | Parameter      | Type   | Description                          |
+  | -------------- | ------ | ------------------------------------ |
+  | `workspace_id` | String | Identifier of the workspace/job run. |
 
-  | Parameter | Type   | Required | Description      |
-  | --------- | ------ | -------- | ---------------- |
-  | `job_id`  | String | Yes      | UUID of the job. |
-
-- **Event Format**: `event: state` followed by JSON data.
+- **Event Format**: `event: state` followed by a serialized `SseEvent`.
 
   ```plaintext
   event: state
-  data: { "version": 1, "learning_objectives": ["..."], "modules": [...] }
+  data: { "type": "state", "payload": { "version": 1, "modules": [...] }, "timestamp": "2025-08-04T10:15:30Z" }
   ```
 
 ### 4.2 Action Log
 
-#### GET `/api/stream/actions?job_id=<job_id>`
+#### GET `/api/stream/{workspace_id}/actions`
 
 - **Purpose**: Stream chronological action records from agents.
 - **Authentication**: Required (`viewer`, `editor`, or `admin`).
-- **Event Format**: `event: action`.
+- **Path Parameter**: Same as `/state` above.
+- **Event Format**: `event: action` and an `SseEvent` payload.
 
   ```plaintext
   event: action
-  data: { "timestamp": "2025-08-04T10:15:30Z", "agent": "Researcher-Web", "message": "Fetched 5 citations", "tokens": 123, "cost_usd": 0.01 }
+  data: { "type": "action", "payload": { "agent": "Researcher-Web", "message": "Fetched 5 citations" }, "timestamp": "2025-08-04T10:15:30Z" }
   ```
 
 ### 4.3 New Citations
 
-#### GET `/api/stream/citations?job_id=<job_id>`
+#### GET `/api/stream/{workspace_id}/citations`
 
 - **Purpose**: Stream citation objects as they are added.
 - **Authentication**: Required (`viewer`, `editor`, or `admin`).
-- **Event Format**: `event: citation`.
+- **Path Parameter**: Same as `/state` above.
+- **Event Format**: `event: citation` and an `SseEvent` payload.
 
   ```plaintext
   event: citation
-  data: { "citation_id": "c1", "url": "https://example.edu/paper", "title": "...", "retrieved_at": "...", "license": "CC-BY" }
+  data: { "type": "citation", "payload": { "citation_id": "c1", "url": "https://example.edu/paper" }, "timestamp": "2025-08-04T10:15:30Z" }
   ```
 
 ---

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -37,9 +37,9 @@ This document provides a **comprehensive** and **explicit** description of the L
    - **Endpoints**:
     - `POST /run` — start new lecture build job
     - `POST /resume/{job_id}` — resume after crash
-     - `SSE /stream/state` — state snapshots
-     - `SSE /stream/actions` — action log
-     - `SSE /stream/citations` — new citations
+     - `SSE /stream/{workspace_id}/state` — state snapshots
+     - `SSE /stream/{workspace_id}/actions` — action log
+     - `SSE /stream/{workspace_id}/citations` — new citations
      - `GET /download/{job_id}/{format}` — retrieve final artifact
 
 2. **LangGraph Orchestrator**

--- a/src/web/routes/stream.py
+++ b/src/web/routes/stream.py
@@ -1,17 +1,31 @@
-"""Streaming endpoints."""
+"""Streaming endpoints exposing LangGraph updates by channel."""
 
 from __future__ import annotations
 
-from fastapi import APIRouter
-from sse_starlette.sse import EventSourceResponse
+from fastapi import APIRouter  # type: ignore[import-not-found]
+from sse_starlette.sse import EventSourceResponse  # type: ignore[import-not-found]
 
-from web.sse import stream_workspace_events
+from web.sse import stream_workspace_events  # type: ignore[import-not-found]
 
 router = APIRouter()
 
 
-@router.get("/stream/{workspace}", response_model=None)
-async def stream_events(workspace: str) -> EventSourceResponse:
-    """Stream LangGraph events for a workspace as Server Sent Events."""
+@router.get("/stream/{workspace}/state", response_model=None)
+async def stream_state(workspace: str) -> EventSourceResponse:
+    """Stream state snapshot events for ``workspace``."""
 
-    return EventSourceResponse(stream_workspace_events(workspace))
+    return EventSourceResponse(stream_workspace_events(workspace, "state"))
+
+
+@router.get("/stream/{workspace}/actions", response_model=None)
+async def stream_actions(workspace: str) -> EventSourceResponse:
+    """Stream action log events for ``workspace``."""
+
+    return EventSourceResponse(stream_workspace_events(workspace, "action"))
+
+
+@router.get("/stream/{workspace}/citations", response_model=None)
+async def stream_citations(workspace: str) -> EventSourceResponse:
+    """Stream citation events for ``workspace``."""
+
+    return EventSourceResponse(stream_workspace_events(workspace, "citation"))

--- a/src/web/sse.py
+++ b/src/web/sse.py
@@ -7,25 +7,41 @@ from datetime import datetime, timezone
 from typing import Any
 
 try:  # pragma: no cover - imported for side effects
-    from core.orchestrator import graph
+    from core.orchestrator import graph  # type: ignore[import-not-found]
 except Exception:  # pragma: no cover - missing optional dependency
     graph = None
 
-from web.schemas.sse import SseEvent
+from web.schemas.sse import SseEvent  # type: ignore[import-not-found]
 
 
 async def stream_workspace_events(
     workspace_id: str,
+    event_type: str,
 ) -> AsyncGenerator[dict[str, Any], None]:
-    """Yield LangGraph updates for ``workspace_id`` as SSE events."""
+    """Yield filtered LangGraph updates as SSE events.
+
+    Parameters
+    ----------
+    workspace_id:
+        Identifier for the workspace whose events should be streamed.
+    event_type:
+        The event category to forward (``"state"``, ``"action"`` or ``"citation"``).
+    """
+
     if graph is None:  # pragma: no cover - sanity guard
         return
+
     async for update in graph.astream(
         {}, config={"configurable": {"thread_id": workspace_id}}
     ):
+        if update.get("type") != event_type:
+            # Only forward updates matching the requested channel.
+            continue
+
         event = SseEvent(
-            type=update.get("type", "message"),
+            type=event_type,
             payload=update.get("payload", update),
             timestamp=datetime.now(timezone.utc),
         )
-        yield {"data": event.model_dump_json()}
+        # ``event`` field allows clients to subscribe to specific SSE types.
+        yield {"event": event_type, "data": event.model_dump_json()}


### PR DESCRIPTION
## Summary
- add `/stream/{workspace}/state`, `/actions`, and `/citations` endpoints
- filter SSE events server-side and emit per-channel event types
- document the new SSE API and architecture

## Testing
- `black src/web/routes/stream.py src/web/sse.py`
- `ruff check src/web/routes/stream.py src/web/sse.py`
- `mypy --ignore-missing-imports src/web/routes/stream.py src/web/sse.py`
- `bandit -r src/web/routes/stream.py src/web/sse.py -ll`
- `pip-audit` *(fails: SSLCertVerificationError)*
- `pytest tests/web/test_sse.py` *(fails: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6890b02b9f6c832b8980f6ea03ac45ee