### PR TITLE
Inject runtime graph into SSE streaming routes

### DIFF
--- a/src/web/routes/stream.py
+++ b/src/web/routes/stream.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter  # type: ignore[import-not-found]
+from fastapi import APIRouter, Request  # type: ignore[import-not-found]
 from sse_starlette.sse import EventSourceResponse  # type: ignore[import-not-found]
 
 from web.sse import stream_workspace_events  # type: ignore[import-not-found]
@@ -11,21 +11,27 @@ router = APIRouter()
 
 
 @router.get("/stream/{workspace}/state", response_model=None)
-async def stream_state(workspace: str) -> EventSourceResponse:
+async def stream_state(request: Request, workspace: str) -> EventSourceResponse:
     """Stream state snapshot events for ``workspace``."""
 
-    return EventSourceResponse(stream_workspace_events(workspace, "state"))
+    return EventSourceResponse(
+        stream_workspace_events(workspace, "state", graph=request.app.state.graph)
+    )
 
 
 @router.get("/stream/{workspace}/actions", response_model=None)
-async def stream_actions(workspace: str) -> EventSourceResponse:
+async def stream_actions(request: Request, workspace: str) -> EventSourceResponse:
     """Stream action log events for ``workspace``."""
 
-    return EventSourceResponse(stream_workspace_events(workspace, "action"))
+    return EventSourceResponse(
+        stream_workspace_events(workspace, "action", graph=request.app.state.graph)
+    )
 
 
 @router.get("/stream/{workspace}/citations", response_model=None)
-async def stream_citations(workspace: str) -> EventSourceResponse:
+async def stream_citations(request: Request, workspace: str) -> EventSourceResponse:
     """Stream citation events for ``workspace``."""
 
-    return EventSourceResponse(stream_workspace_events(workspace, "citation"))
+    return EventSourceResponse(
+        stream_workspace_events(workspace, "citation", graph=request.app.state.graph)
+    )


### PR DESCRIPTION
## Summary
- allow `stream_workspace_events` to accept or derive a LangGraph instance
- update streaming routes to forward `app.state.graph`
- test SSE streaming against app's graph

## Testing
- `black src/web/sse.py src/web/routes/stream.py tests/web/test_sse.py`
- `ruff check .` *(fails: E402 Module level import not at top of file)*
- `mypy .` *(fails: Cannot find implementation or library stub for module named "web.metrics_endpoint" and others)*
- `bandit -r src -ll`
- `pip-audit` *(fails: HTTPSConnectionPool... SSLCertVerificationError)*
- `pytest tests/web/test_sse.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6890b2de0680832b822268ac6df59c82