### PR TITLE
feat: add retrieval cache and dense retriever

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,8 @@ dependencies = [
     "fastapi (>=0.111,<1.0)",
     "langsmith (>=0.4,<0.5)",
     "loguru (>=0.7,<1.0)",
-    "opentelemetry-instrumentation (>=0.50b0,<0.51)"
+    "opentelemetry-instrumentation (>=0.50b0,<0.51)",
+    "faiss-cpu (>=1.7,<2.0)"
 ]
 
 [build-system]

--- a/src/agents/dense_retriever.py
+++ b/src/agents/dense_retriever.py
@@ -1,0 +1,59 @@
+"""Lightweight dense retriever using FAISS with a NumPy fallback."""
+
+from __future__ import annotations
+
+from typing import List, TYPE_CHECKING
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency
+    import faiss  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    faiss = None
+
+if TYPE_CHECKING:  # pragma: no cover - type checking only
+    from .researcher_web import RawSearchResult
+
+
+class DenseRetriever:
+    """Perform simple dense similarity search over snippets."""
+
+    _DIM = 64
+
+    def __init__(self, documents: List["RawSearchResult"]) -> None:
+        self._docs = documents
+        vectors = self._embed_batch([d.snippet for d in documents])
+        if faiss is not None and vectors.size > 0:
+            self._index = faiss.IndexFlatL2(self._DIM)
+            self._index.add(vectors)
+            self._vectors = None
+        else:
+            self._index = None
+            self._vectors = vectors
+
+    @classmethod
+    def _embed(cls, text: str) -> np.ndarray:
+        arr = np.zeros(cls._DIM, dtype="float32")
+        data = text.encode("utf-8")[: cls._DIM]
+        for i, b in enumerate(data):
+            arr[i] = float(b)
+        return arr
+
+    @classmethod
+    def _embed_batch(cls, texts: List[str]) -> np.ndarray:
+        if not texts:
+            return np.empty((0, cls._DIM), dtype="float32")
+        return np.vstack([cls._embed(t) for t in texts])
+
+    def search(self, query: str, k: int = 5) -> List["RawSearchResult"]:
+        """Return top ``k`` documents similar to ``query``."""
+
+        if not self._docs:
+            return []
+        vector = self._embed(query).reshape(1, -1)
+        if self._index is not None:
+            _, indices = self._index.search(vector, k)
+            return [self._docs[i] for i in indices[0] if i < len(self._docs)]
+        distances = ((self._vectors - vector) ** 2).sum(axis=1)
+        order = np.argsort(distances)[:k]
+        return [self._docs[i] for i in order]

--- a/src/persistence/__init__.py
+++ b/src/persistence/__init__.py
@@ -1,13 +1,17 @@
 """Persistence layer for the agentic demo."""
 
 from .db import get_db_session
-from .models import Citation
+from .models import CachedSearchResult, Citation, RetrievalCache
 from .repositories.citation_repo import CitationRepo
+from .repositories.retrieval_cache_repo import RetrievalCacheRepo
 from .sqlite import AsyncSqliteSaver
 
 __all__ = [
     "AsyncSqliteSaver",
+    "CachedSearchResult",
     "Citation",
     "CitationRepo",
+    "RetrievalCache",
+    "RetrievalCacheRepo",
     "get_db_session",
 ]

--- a/src/persistence/migrations/0002_create_retrieval_cache_table.py
+++ b/src/persistence/migrations/0002_create_retrieval_cache_table.py
@@ -1,0 +1,30 @@
+"""Create retrieval_cache table."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa  # type: ignore[import]
+from alembic import op  # type: ignore[import]
+
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Apply the migration."""
+
+    op.create_table(
+        "retrieval_cache",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("query", sa.String, nullable=False, unique=True),
+        sa.Column("results", sa.Text, nullable=False),
+        sa.Column("hit_count", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime, nullable=False),
+    )
+
+
+def downgrade() -> None:
+    """Revert the migration."""
+
+    op.drop_table("retrieval_cache")

--- a/src/persistence/models.py
+++ b/src/persistence/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import List
 
 from pydantic import BaseModel, HttpUrl
 
@@ -14,3 +15,20 @@ class Citation(BaseModel):
     title: str
     retrieved_at: datetime
     licence: str
+
+
+class CachedSearchResult(BaseModel):
+    """Cached search result snippet stored in the retrieval cache."""
+
+    url: HttpUrl
+    snippet: str
+    title: str
+
+
+class RetrievalCache(BaseModel):
+    """Record of cached search results for a query."""
+
+    query: str
+    results: List[CachedSearchResult]
+    hit_count: int
+    created_at: datetime

--- a/src/persistence/repositories/retrieval_cache_repo.py
+++ b/src/persistence/repositories/retrieval_cache_repo.py
@@ -1,0 +1,55 @@
+"""Repository for managing retrieval cache entries."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import List, Optional
+
+import aiosqlite
+
+
+class RetrievalCacheRepo:
+    """Persist and retrieve cached search results."""
+
+    def __init__(self, conn: aiosqlite.Connection) -> None:
+        self._conn = conn
+
+    async def get(self, query: str) -> Optional[List[dict]]:
+        """Return cached results for ``query`` if present.
+
+        Increments the ``hit_count`` when a cache entry is found.
+        """
+
+        cur = await self._conn.execute(
+            "SELECT results FROM retrieval_cache WHERE query = ?",
+            (query,),
+        )
+        row = await cur.fetchone()
+        await cur.close()
+        if row is None:
+            return None
+        await self._conn.execute(
+            "UPDATE retrieval_cache SET hit_count = hit_count + 1 WHERE query = ?",
+            (query,),
+        )
+        await self._conn.commit()
+        return json.loads(row[0])
+
+    async def set(self, query: str, results: List[dict]) -> None:
+        """Store ``results`` for ``query`` in the cache."""
+
+        now = datetime.utcnow().isoformat()
+        await self._conn.execute(
+            """
+            INSERT OR REPLACE INTO retrieval_cache (query, results, hit_count, created_at)
+            VALUES (
+                ?,
+                ?,
+                COALESCE((SELECT hit_count FROM retrieval_cache WHERE query = ?), 0),
+                ?
+            )
+            """,
+            (query, json.dumps(results), query, now),
+        )
+        await self._conn.commit()


### PR DESCRIPTION
## Summary
- add retrieval_cache models, repository, and migration
- integrate a FAISS-backed DenseRetriever with caching
- test cache hit/miss behaviour and dense fallback

## Testing
- `black src/agents/researcher_web.py src/persistence/__init__.py src/persistence/models.py src/agents/dense_retriever.py src/persistence/migrations/0002_create_retrieval_cache_table.py src/persistence/repositories/retrieval_cache_repo.py tests/test_search_clients.py`
- `ruff check src/agents/researcher_web.py src/persistence/__init__.py src/persistence/models.py src/agents/dense_retriever.py src/persistence/migrations/0002_create_retrieval_cache_table.py src/persistence/repositories/retrieval_cache_repo.py tests/test_search_clients.py`
- `mypy .` *(fails: Cannot find implementation or library stubs for many modules)*
- `bandit -r src -ll`
- `pip-audit` *(fails: SSL certificate verify failed connecting to pypi.org)*
- `pytest` *(fails: 35 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68912fba930c832bab0edb88eba26ad1