### PR TITLE
Handle optional LLM dependency failures with logging

### DIFF
--- a/src/agents/agent_wrapper.py
+++ b/src/agents/agent_wrapper.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Dict, Optional
 
 from agentic_demo import config
@@ -75,6 +76,7 @@ def init_chat_model(**overrides: Any) -> Optional[Any]:
         _MODEL_CACHE[model_name] = model
         return model
     except Exception:  # pragma: no cover - optional dependencies
+        logging.exception("Failed to initialize chat model")
         return None
 
 

--- a/src/agents/content_weaver.py
+++ b/src/agents/content_weaver.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import AsyncGenerator, List
@@ -81,6 +82,7 @@ async def call_openai_function(prompt: str, schema: dict) -> AsyncGenerator[str,
     try:
         from langchain_core.messages import HumanMessage, SystemMessage
     except Exception:  # pragma: no cover - dependency not installed
+        logging.exception("Content weaver dependencies unavailable")
 
         async def empty() -> AsyncGenerator[str, None]:
             if False:

--- a/src/agents/dense_retriever.py
+++ b/src/agents/dense_retriever.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 from typing import List, TYPE_CHECKING
 
+import logging
 import numpy as np
 
 try:  # pragma: no cover - optional dependency
     import faiss  # type: ignore
 except Exception:  # pragma: no cover - optional dependency
+    logging.exception("faiss library unavailable")
     faiss = None
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only

--- a/src/agents/exporter.py
+++ b/src/agents/exporter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 
 from config import settings
@@ -64,6 +65,7 @@ async def run_exporter(state: State) -> ExportStatus:
         state.log.append(ActionLog(message="Export complete"))
         state.exports = exported
     except Exception as exc:  # pragma: no cover - defensive
+        logging.exception("Export failed")
         state.log.append(ActionLog(message=f"Export failed: {exc}"))
         status.success = False
 

--- a/src/agents/fact_checker.py
+++ b/src/agents/fact_checker.py
@@ -7,6 +7,7 @@ import re
 from dataclasses import dataclass
 from typing import List
 
+import logging
 import httpx
 
 from config import Settings
@@ -116,6 +117,7 @@ async def verify_sources(urls: List[str]) -> List[SourceVerification]:
             status = "ok" if response.status_code < 400 else "error"
             licence = response.headers.get("License")
         except Exception:
+            logging.exception("Source verification failed")
             status = "error"
             licence = None
         return SourceVerification(url=url, status=status, licence=licence)

--- a/src/agents/pedagogy_critic.py
+++ b/src/agents/pedagogy_critic.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from collections import Counter
 from dataclasses import dataclass
 from typing import Callable, Dict, List, cast
+import logging
 
 from agents.agent_wrapper import init_chat_model
 from agents.models import Activity
@@ -83,7 +84,7 @@ def classify_bloom_level(text: str) -> str:
             if level in BLOOM_LEVELS:
                 return level
     except Exception:
-        pass
+        logging.exception("Bloom level classification failed")
     return _keyword_classify(text)
 
 

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass
 
@@ -34,6 +35,7 @@ async def call_planner_llm(topic: str) -> str:
     try:  # pragma: no cover - exercised via monkeypatch in tests
         from langchain_core.messages import HumanMessage, SystemMessage
     except Exception:  # dependency missing
+        logging.exception("Planner dependencies unavailable")
         return ""
 
     model = init_chat_model()

--- a/src/agents/researcher_pipeline.py
+++ b/src/agents/researcher_pipeline.py
@@ -7,6 +7,7 @@ from typing import List
 
 import asyncio
 import httpx
+import logging
 
 from core.state import State
 from persistence import Citation, CitationRepo, get_db_session
@@ -24,6 +25,7 @@ async def _lookup_licence(url: str) -> str:
             response = await client.head(url, timeout=5.0)
             return response.headers.get("License", "")
     except Exception:
+        logging.exception("Failed to look up licence")
         return ""
 
 

--- a/src/agents/researcher_web.py
+++ b/src/agents/researcher_web.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from dataclasses import asdict, dataclass
 from typing import Any, List, Optional, Protocol
 from urllib.parse import urlparse
@@ -130,6 +131,7 @@ async def _cached_search_async(
     try:
         results = client.search(query)
     except Exception:
+        logging.exception("Search client failed")
         if dense is None:
             raise
         stream_debug(f"dense retrieval fallback: {query}")

--- a/src/agents/streaming.py
+++ b/src/agents/streaming.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 
@@ -17,6 +18,7 @@ def stream(channel: str, payload: Any) -> None:
 
         _stream(channel, payload)
     except Exception:  # pragma: no cover - optional dependency
+        logging.exception("Streaming via langgraph_sdk failed")
         if channel == "messages":
             print(payload, end="", flush=True)
         else:

--- a/src/core/orchestrator.py
+++ b/src/core/orchestrator.py
@@ -37,7 +37,7 @@ except KeyError:
 try:
     langsmith_client: Client | None = Client()
 except Exception:  # pragma: no cover - optional client
-    logger.info("LangSmith client disabled")
+    logger.exception("LangSmith client disabled")
     langsmith_client = None
 
 

--- a/tests/agents/test_llm_failures.py
+++ b/tests/agents/test_llm_failures.py
@@ -1,0 +1,75 @@
+"""Tests for LLM failure handling and logging."""
+
+from types import SimpleNamespace
+import logging
+import os
+import sys
+import types
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[2] / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+# Provide minimal configuration so modules importing ``agentic_demo`` succeed.
+os.environ.setdefault("OPENAI_API_KEY", "test-openai")
+os.environ.setdefault("PERPLEXITY_API_KEY", "test-perplexity")
+os.environ.setdefault("DATA_DIR", "/tmp")
+
+config = types.SimpleNamespace(
+    settings=types.SimpleNamespace(model_name="gpt-4", perplexity_api_key="pk")
+)
+
+pkg = types.ModuleType("agentic_demo")
+pkg.config = config
+sys.modules["agentic_demo"] = pkg
+sys.modules["agentic_demo.config"] = config
+
+core_pkg = types.ModuleType("core")
+core_state = types.ModuleType("core.state")
+core_state.State = type("State", (), {})
+core_pkg.state = core_state
+sys.modules["core"] = core_pkg
+sys.modules["core.state"] = core_state
+
+sys.modules["prompts"] = types.SimpleNamespace(get_prompt=lambda *_args, **_kwargs: "")
+
+from agents import agent_wrapper  # noqa: E402
+from agents.pedagogy_critic import classify_bloom_level  # noqa: E402
+
+
+def test_init_chat_model_logs_on_failure(monkeypatch, caplog):
+    """Chat model initialization failures are logged and return ``None``."""
+
+    class DummyChat:
+        def __init__(self, *args, **kwargs):  # pragma: no cover - test stub
+            raise RuntimeError("boom")
+
+    monkeypatch.setitem(
+        sys.modules, "langchain_openai", SimpleNamespace(ChatOpenAI=DummyChat)
+    )
+    agent_wrapper.clear_model_cache()
+    caplog.set_level(logging.ERROR)
+
+    model = agent_wrapper.init_chat_model(model="gpt-4")
+
+    assert model is None
+    assert "Failed to initialize chat model" in caplog.text
+
+
+def test_classify_bloom_level_logs_and_falls_back(monkeypatch, caplog):
+    """Classification falls back and logs when the LLM raises an error."""
+
+    class FailingModel:
+        def invoke(self, _prompt):  # pragma: no cover - test stub
+            raise RuntimeError("fail")
+
+    monkeypatch.setattr(
+        "agents.pedagogy_critic.init_chat_model", lambda: FailingModel()
+    )
+    caplog.set_level(logging.ERROR)
+
+    level = classify_bloom_level("list the items")
+
+    assert level == "remember"  # falls back to keyword classifier
+    assert "Bloom level classification failed" in caplog.text


### PR DESCRIPTION
## Summary
- log planner dependency issues instead of silently swallowing them
- log chat model construction failures and LLM search fallbacks
- add tests for LLM failure logging and keyword fallback

## Testing
- `black .`
- `ruff check .`
- `mypy .` *(fails: Cannot find implementation or library stub for module named "agents.researcher_web" and others)*
- `bandit -r src -ll`
- `pip-audit` *(fails: SSLError: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded)*
- `pytest tests/agents/test_llm_failures.py`


------
https://chatgpt.com/codex/tasks/task_e_689139ede234832b81bfd39f45e23ae8