### PR TITLE
test: silence import-order lints

### DIFF
--- a/tests/agents/test_agent_wrapper.py
+++ b/tests/agents/test_agent_wrapper.py
@@ -13,7 +13,7 @@ os.environ.setdefault("OPENAI_API_KEY", "test-openai")
 os.environ.setdefault("PERPLEXITY_API_KEY", "test-perplexity")
 os.environ.setdefault("DATA_DIR", "/tmp")
 
-import config
+import config  # noqa: E402
 
 # Provide a minimal ``agentic_demo`` package for modules expecting it.
 pkg = types.ModuleType("agentic_demo")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,7 +13,7 @@ os.environ.setdefault("OPENAI_API_KEY", "placeholder-openai")
 os.environ.setdefault("PERPLEXITY_API_KEY", "placeholder-perplexity")
 os.environ.setdefault("DATA_DIR", "/tmp")
 
-import config
+import config  # noqa: E402
 
 # Required configuration values for the application.
 REQUIRED_ENV = {

--- a/tests/test_search_clients.py
+++ b/tests/test_search_clients.py
@@ -18,7 +18,11 @@ sys.modules["agentic_demo.config"] = config
 from agents import offline_cache  # noqa: E402
 from agents.dense_retriever import DenseRetriever  # noqa: E402
 from agents.researcher_web import PerplexityClient  # noqa: E402
-from agents.researcher_web import RawSearchResult, TavilyClient, cached_search
+from agents.researcher_web import (  # noqa: E402
+    RawSearchResult,
+    TavilyClient,
+    cached_search,
+)
 from persistence import get_db_session  # noqa: E402
 
 


### PR DESCRIPTION
## Summary
- quiet ruff E402 warnings in tests that set up environment variables before imports

## Testing
- `black .`
- `ruff check .`
- `mypy .` *(fails: Cannot find implementation or library stub for module named "config" and 306 more)*
- `bandit -r src -ll`
- `pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url)*
- `pytest tests/agents/test_agent_wrapper.py tests/test_config.py tests/test_search_clients.py`


------
https://chatgpt.com/codex/tasks/task_e_6891cf28d108832bbae95764aef00ed4