### PR TITLE
Expose core state models

### DIFF
--- a/src/core/state.py
+++ b/src/core/state.py
@@ -197,3 +197,16 @@ def validate_state(state: State) -> None:
     urls = [src.url for src in state.sources]
     if len(urls) != len(set(urls)):
         raise ValueError("citation URLs must be unique")
+
+
+__all__ = [
+    "Citation",
+    "Module",
+    "CritiqueReport",
+    "FactCheckReport",
+    "Outline",
+    "ActionLog",
+    "State",
+    "increment_version",
+    "validate_state",
+]


### PR DESCRIPTION
## Summary
- export core models like `Outline` via `__all__` in `core.state` for reliable imports
- tidy state definitions

## Testing
- `poetry run black --check .`
- `poetry run ruff check .`
- `poetry run mypy .` *(fails: Cannot find implementation or library stub for module named "agents.researcher_web" and other import-not-found errors)*
- `poetry run bandit -r src -ll` *(command not found)*
- `poetry run pip-audit` *(command not found)*
- `poetry run pytest --maxfail=1 --disable-warnings -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6891d1701cac832bb84569b5de0375e4