### PR TITLE
feat: add frontend build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "private": true,
   "scripts": {
+    "build": "tsc -p tsconfig.json",
     "test": "vitest run"
   },
   "devDependencies": {

--- a/scripts/build_frontend.sh
+++ b/scripts/build_frontend.sh
@@ -5,13 +5,13 @@
 #   ./scripts/build_frontend.sh
 #
 # The script will:
-#   1. Install frontend dependencies
+#   1. Install Node dependencies
 #   2. Build the production bundle in frontend/dist
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-cd "${REPO_ROOT}/frontend"
+cd "${REPO_ROOT}"
 npm ci
 npm run build

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,9 @@
     "strict": true,
     "skipLibCheck": true,
     "baseUrl": ".",
-    "paths": { "@/*": ["frontend/src/*"] }
+    "paths": { "@/*": ["frontend/src/*"] },
+    "outDir": "frontend/dist",
+    "rootDir": "frontend/src"
   },
-  "include": ["frontend/src", "tests/frontend"]
+  "include": ["frontend/src"]
 }


### PR DESCRIPTION
## Summary
- add `build` script to npm package
- output compiled frontend assets to `frontend/dist`
- fix `build_frontend.sh` script to run from repository root

## Testing
- `npm run build`
- `npm test`
- `black .`
- `ruff check .`
- `mypy .` (fails: Cannot find implementation or library stub for modules)
- `bandit -r src -ll` (command not found)
- `pip-audit` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_6891db5abd6c832b94cfb64935373fdb