### PR TITLE
fix: include uvicorn dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
     "langsmith (>=0.4,<0.5)",
     "loguru (>=0.7,<1.0)",
     "opentelemetry-instrumentation (>=0.50b0,<0.51)",
-    "faiss-cpu (>=1.7,<2.0)"
+    "faiss-cpu (>=1.7,<2.0)",
+    "uvicorn[standard] (>=0.30,<1.0)"
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary
- add `uvicorn[standard]` to runtime dependencies so the FastAPI server script can run

## Testing
- `black .`
- `ruff check .`
- `mypy .` *(fails: Cannot find implementation or library stub for module named ...)*
- `bandit -r src -ll`
- `pip-audit` *(fails: CERTIFICATE_VERIFY_FAILED)*
- `pytest` *(fails: 25 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6891ded5e064832b9f6b6a05377e046a