### PR TITLE
Require FastAPI OTel instrumentation via configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "langsmith (>=0.4,<0.5)",
     "loguru (>=0.7,<1.0)",
     "opentelemetry-instrumentation (>=0.50b0,<0.51)",
+    "opentelemetry-instrumentation-fastapi (>=0.50b0,<0.51)",
     "faiss-cpu (>=1.7,<2.0)",
     "uvicorn[standard] (>=0.30,<1.0)"
 ]

--- a/src/config.py
+++ b/src/config.py
@@ -56,6 +56,9 @@ class Settings:
         self.search_provider = os.getenv("SEARCH_PROVIDER", "perplexity")
         self.model_name = os.getenv("MODEL_NAME", MODEL_NAME)
         self.offline_mode = os.getenv("OFFLINE_MODE", "false").lower() == "true"
+        # Toggle for OpenTelemetry instrumentation. Modules are always imported
+        # but instrumentation can be disabled via configuration.
+        self.enable_tracing = os.getenv("ENABLE_TRACING", "true").lower() == "true"
         allowlist_raw = os.getenv("ALLOWLIST_DOMAINS")
         if allowlist_raw:
             try:

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -31,7 +31,9 @@ def create_app() -> FastAPI:
     settings = load_settings()
     app = FastAPI()
     app.state.settings = settings
-    _configure_tracing(app)
+
+    if settings.enable_tracing:
+        _configure_tracing(app)
 
     # Bind search and fact-checking behaviour depending on offline mode.
     if settings.offline_mode:


### PR DESCRIPTION
## Summary
- require `opentelemetry-instrumentation-fastapi`
- gate tracing setup behind `ENABLE_TRACING` setting

## Testing
- `black .`
- `ruff check .`
- `mypy .` *(fails: Missing modules like `core.state`, `config`, etc.)*
- `bandit -r src -ll`
- `pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /pypi/anyio/4.10.0/json)*
- `pytest -q` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_6891e30054dc832bbd929e53d572d07b