### PR TITLE
Fix incorrect orchestrator config imports

### DIFF
--- a/src/core/orchestrator.py
+++ b/src/core/orchestrator.py
@@ -10,8 +10,8 @@ from pathlib import Path
 from typing import Awaitable, Callable, Optional, TypeVar
 
 import tiktoken
-from agentic_demo import config
-from agentic_demo.config import Settings
+import config
+from config import Settings
 from langgraph.graph import END, START, StateGraph
 from langgraph.graph.state import CompiledStateGraph
 from langsmith import Client


### PR DESCRIPTION
## Summary
- fix orchestrator config imports to use local module

## Testing
- `black .`
- `ruff check .`
- `mypy .` *(fails: Cannot find implementation or library stub for module named "core.state", etc.)*
- `bandit -r src -ll`
- `pip-audit` *(fails: SSLError: certificate verify failed: Missing Authority Key Identifier)*
- `OPENAI_API_KEY=dummy PERPLEXITY_API_KEY=dummy DATA_DIR=/tmp poetry run ./scripts/run.sh --offline` *(fails: Command not found: alembic)*

------
https://chatgpt.com/codex/tasks/task_e_6891e764153c832ba7ddea6a7fa2979f