### PR TITLE
Ensure settings loaded before model validation

### DIFF
--- a/src/core/orchestrator.py
+++ b/src/core/orchestrator.py
@@ -48,7 +48,14 @@ def _token_count(payload: object) -> int:
 
 
 def validate_model_configuration() -> None:
-    """Ensure the configured model matches the enforced default."""
+    """Ensure the configured model matches the enforced default.
+
+    Loads :mod:`config` settings on demand to avoid requiring environment
+    variables at import time.
+    """
+
+    if config.settings is None:
+        config.settings = config.load_settings()
     configured = config.settings.model_name
     if configured != config.MODEL_NAME:
         raise ValueError(


### PR DESCRIPTION
## Summary
- avoid `NoneType` error by loading config settings before validating model name

## Testing
- `black .`
- `ruff check .`
- `mypy .` *(fails: Cannot find implementation or library stub for module named "core.state"; Cannot find implementation or library stub for module named "alembic"; Cannot find implementation or library stub for module named "sqlalchemy"; Cannot find implementation or library stub for module named "config"; Cannot find implementation or library stub for module named "persistence"; Cannot find implementation or library stub for module named "langchain_community.utilities.tavily_search"; Cannot find implementation or library stub for module named "models"; Found 126 errors in 44 files (checked 84 source files))*
- `bandit -r src -ll`
- `pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /pypi/anyio/4.10.0/json (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)'))))*
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6891ea4a3328832bbfbd2b45150bb5ae