### PR TITLE
fix: ensure unique node names when initializing graph

### DIFF
--- a/src/core/orchestrator.py
+++ b/src/core/orchestrator.py
@@ -140,6 +140,7 @@ class GraphOrchestrator:
                         run.end(outputs=result)
                     return result
 
+        wrapped.__name__ = name
         return wrapped
 
     def initialize_graph(self) -> None:
@@ -151,8 +152,8 @@ class GraphOrchestrator:
         for node in spec.get("nodes", []):
             fn = _import_callable(node["callable"])
             graph.add_node(
+                node["name"],
                 self._wrap(node["name"], fn),
-                name=node["name"],
                 streams=node.get("streams"),
             )
         self._graph = graph


### PR DESCRIPTION
## Summary
- avoid duplicate node registrations by assigning explicit names when building the graph
- propagate node names to the wrapper to aid debugging

## Testing
- `black .`
- `ruff check .`
- `mypy .` *(fails: Cannot find implementation or library stub for module named "agents.planner", etc.)*
- `bandit -r src -ll`
- `pip-audit` *(fails: SSLCertVerificationError for pypi.org)*
- `pytest` *(fails: ImportError: cannot import name 'Field' from 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_6891ec4e9870832bba15f17e2cae4869