### PR TITLE
feat: add fallback root route

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Agentic Demo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./index.js"></script>
+  </body>
+</html>

--- a/scripts/build_frontend.sh
+++ b/scripts/build_frontend.sh
@@ -15,3 +15,4 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${REPO_ROOT}"
 npm ci
 npm run build
+cp frontend/index.html frontend/dist/index.html

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -105,8 +105,15 @@ def mount_frontend(app: FastAPI) -> None:
     """Serve the built frontend from `frontend/dist`."""
 
     frontend_dist = Path(__file__).resolve().parents[2] / "frontend" / "dist"
-    if frontend_dist.exists():
+    index_file = frontend_dist / "index.html"
+    if frontend_dist.exists() and index_file.exists():
         app.mount("/", StaticFiles(directory=frontend_dist, html=True), name="frontend")
+    else:
+
+        @app.get("/", include_in_schema=False)
+        async def root() -> dict[str, str]:
+            """Fallback response when frontend assets are missing."""
+            return {"detail": "Frontend build not found"}
 
 
 def register_routes(app: FastAPI) -> None:


### PR DESCRIPTION
## Summary
- add default JSON response when frontend assets are missing
- copy built index.html into dist and ensure it exists before mounting static frontend

## Testing
- `poetry run black .`
- `poetry run ruff .` *(fails: unrecognized subcommand)*
- `poetry run ruff check .`
- `poetry run mypy .` *(fails: missing library stubs)*
- `poetry run bandit -r src -ll` *(fails: command not found)*
- `poetry run pip-audit` *(fails: command not found)*
- `poetry run pytest` *(fails: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_6891efbbceb0832b943d0365bc0aeafe