### PR TITLE
fix: load React app via CDN

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,9 +3,17 @@
   <head>
     <meta charset="utf-8" />
     <title>Agentic Demo</title>
+    <script type="importmap">
+      {
+        "imports": {
+          "react": "https://esm.sh/react@19",
+          "react-dom/client": "https://esm.sh/react-dom@19/client"
+        }
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="./index.js"></script>
+    <script type="module" src="./dist/index.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- wire up React index.html to use CDN-hosted React and compiled bundle

## Testing
- `black .`
- `ruff check .`
- `mypy .` *(fails: Cannot find implementation or library stub for module named "fastapi" [import-not-found])* 
- `bandit -r src -ll`
- `pip-audit` *(fails: SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED])* 
- `npm run build`
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6891f513b168832ba108d93af424f39d