### PR TITLE
Add CLI to generate lecture material

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ dependencies = [
     "weasyprint",
 ]
 
+[project.scripts]
+"generate-lecture" = "cli.generate_lecture:main"
+
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -1,0 +1,1 @@
+"""CLI entry points for the lecture generator."""

--- a/src/cli/generate_lecture.py
+++ b/src/cli/generate_lecture.py
@@ -1,0 +1,50 @@
+"""Command-line interface for generating lecture material."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from dataclasses import asdict
+from typing import Any, Dict
+
+from agents.content_weaver import run_content_weaver
+from core.state import State
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Generate lecture material from a topic prompt."
+    )
+    parser.add_argument("topic", help="Topic or outline for the lecture")
+    return parser.parse_args()
+
+
+async def _generate(topic: str) -> Dict[str, Any]:
+    """Invoke the content weaver for ``topic``.
+
+    Args:
+        topic: Subject matter to base the lecture on.
+
+    Returns:
+        Dict[str, Any]: Lecture material as a plain dictionary.
+    """
+
+    state = State(prompt=topic)
+    result = await run_content_weaver(state)
+    return asdict(result)
+
+
+def main() -> None:
+    """Entry point for console scripts."""
+    args = parse_args()
+    try:
+        payload = asyncio.run(_generate(args.topic))
+    except Exception as exc:  # pragma: no cover - defensive
+        raise SystemExit(f"Error generating lecture: {exc}") from exc
+    print(json.dumps(payload, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_generate_lecture.py
+++ b/tests/test_generate_lecture.py
@@ -1,0 +1,43 @@
+"""Tests for the lecture generation CLI."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+import sys
+import types
+
+
+@dataclass
+class DummyResult:
+    """Minimal stand-in for :class:`agents.models.WeaveResult`."""
+
+    title: str
+    learning_objectives: list[str]
+    activities: list
+    duration_min: int
+
+
+def test_generate(monkeypatch):
+    """_generate returns a dictionary derived from the weave result."""
+
+    async def fake_run_content_weaver(_state):
+        return DummyResult("Test", [], [], 0)
+
+    class DummyState:
+        def __init__(self, prompt: str) -> None:
+            self.prompt = prompt
+
+    monkeypatch.setitem(
+        sys.modules,
+        "agents.content_weaver",
+        types.SimpleNamespace(run_content_weaver=fake_run_content_weaver),
+    )
+    monkeypatch.setitem(
+        sys.modules, "core.state", types.SimpleNamespace(State=DummyState)
+    )
+
+    from cli.generate_lecture import _generate
+
+    result = asyncio.run(_generate("topic"))
+    assert result["title"] == "Test"


### PR DESCRIPTION
## Summary
- add `generate-lecture` CLI to produce lecture content from a topic
- document CLI usage via script entry in `pyproject.toml`
- cover CLI with a unit test mocking dependencies

## Testing
- `black .`
- `ruff check .`
- `mypy .` *(fails: Cannot find implementation or library stub for module named "agents.content_weaver", and others)*
- `bandit -r src -ll`
- `pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443)... certificate verify failed)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689217bc5764832b83acc3f6dfd78326