### PR TITLE
feat(core): add timestamp and level to action log

### DIFF
--- a/src/core/state.py
+++ b/src/core/state.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import field as dc_field
+from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
 from pydantic import BaseModel, Field
@@ -58,15 +59,18 @@ class Outline(BaseModel):
     modules: List[Module] = Field(default_factory=list)
 
 
-# TODO: Extend to capture timestamps and log levels.
 class ActionLog(BaseModel):
     """Record of an action taken during processing.
 
     Attributes:
         message: Human-readable description of the action.
+        level: Severity level of the log entry.
+        timestamp: Time when the action occurred.
     """
 
     message: str
+    level: str = "INFO"
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 @dataclass

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,5 +1,7 @@
 import pytest
 
+from datetime import datetime
+
 from core.state import (
     ActionLog,
     Citation,
@@ -41,6 +43,12 @@ def test_to_dict_from_dict_roundtrip():
 def test_validate_state_success():
     state = State(prompt="topic", sources=[Citation(url="https://example.com")])
     validate_state(state)
+
+
+def test_action_log_defaults():
+    entry = ActionLog(message="hello")
+    assert entry.level == "INFO"
+    assert isinstance(entry.timestamp, datetime)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- extend `ActionLog` with `level` and `timestamp`
- test default `ActionLog` metadata

## Testing
- `black .`
- `ruff check .`
- `mypy .` *(fails: Cannot find implementation or library stub for multiple modules)*
- `bandit -r src -ll`
- `pip-audit` *(fails: SSLCertVerificationError)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiosqlite', No module named 'fastapi', No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_689284c27814832bb900c52c2e318913