### PR TITLE
fix: correct CLI entrypoint invocation

### DIFF
--- a/scripts/cli.sh
+++ b/scripts/cli.sh
@@ -2,7 +2,7 @@
 # Starts the CLI application locally without Docker.
 #
 # Usage:
-#   ./scripts/cli.sh [--offline]
+#   ./scripts/cli.sh <topic>
 #
 # The script will:
 #   1. Source environment variables from .env
@@ -21,5 +21,5 @@ fi
 # Run database migrations
 poetry run alembic upgrade head
 
-# Forward all arguments (e.g., --offline) to uvicorn
-poetry run cli.generate_lecture:main --reload "$@"
+# Forward all arguments (e.g., the topic) to the CLI entry point
+poetry run generate-lecture "$@"


### PR DESCRIPTION
## Summary
- run CLI via the `generate-lecture` entrypoint
- document required `topic` argument for CLI helper script

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: SSL certificate verify failed)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6892946cfdac832bace4136b77175d6c