### PR TITLE
Simplify entry screen to topic-only submission

### DIFF
--- a/frontend/src/components/DataEntryForm.css
+++ b/frontend/src/components/DataEntryForm.css
@@ -5,22 +5,20 @@
 
 .data-entry__form {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
+  align-items: center;
   gap: 0.5rem;
-  align-items: flex-end;
   margin-bottom: 1rem;
 }
 
-.data-entry__label {
-  display: flex;
-  flex-direction: column;
-  font-weight: 600;
-}
-
-.data-entry__input {
-  padding: 0.25rem 0.5rem;
+.data-entry__textarea {
+  width: 100%;
+  max-width: 400px;
+  padding: 0.5rem;
   border: 1px solid #ccc;
   border-radius: 4px;
+  resize: none;
+  overflow: hidden;
 }
 
 .data-entry__submit {

--- a/frontend/src/components/DataEntryForm.tsx
+++ b/frontend/src/components/DataEntryForm.tsx
@@ -1,19 +1,18 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import "./DataEntryForm.css";
 
 interface Entry {
   id: number;
-  name: string;
-  email: string;
+  topic: string;
 }
 
 /**
- * Simple data entry form with a tracking table that lists all submissions.
+ * Topic submission form with a tracking table that lists all submitted topics.
  */
 const DataEntryForm: React.FC = () => {
-  const [name, setName] = useState("");
-  const [email, setEmail] = useState("");
+  const [topic, setTopic] = useState("");
   const [entries, setEntries] = useState<Entry[]>([]);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
     (async () => {
@@ -31,44 +30,47 @@ const DataEntryForm: React.FC = () => {
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!name || !email) return;
+    if (!topic) return;
     try {
       const res = await fetch("/entries", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name, email }),
+        body: JSON.stringify({ topic }),
       });
       if (res.ok) {
         const entry: Entry = await res.json();
         setEntries((prev) => [...prev, entry]);
-        setName("");
-        setEmail("");
+        setTopic("");
+        const el = textareaRef.current;
+        if (el) {
+          el.style.height = "auto";
+        }
       }
     } catch {
       // ignore network errors
     }
   };
 
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setTopic(e.target.value);
+    const el = textareaRef.current;
+    if (el) {
+      el.style.height = "auto";
+      el.style.height = `${el.scrollHeight}px`;
+    }
+  };
+
   return (
     <div className="data-entry">
       <form onSubmit={onSubmit} className="data-entry__form">
-        <label className="data-entry__label">
-          Name
-          <input
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            className="data-entry__input"
-          />
-        </label>
-        <label className="data-entry__label">
-          Email
-          <input
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            className="data-entry__input"
-          />
-        </label>
+        <textarea
+          ref={textareaRef}
+          value={topic}
+          onChange={handleChange}
+          className="data-entry__textarea"
+          placeholder="Enter topic"
+          rows={1}
+        />
         <button type="submit" className="data-entry__submit">
           Add
         </button>
@@ -77,15 +79,13 @@ const DataEntryForm: React.FC = () => {
         <table className="data-entry__table">
           <thead>
             <tr>
-              <th>Name</th>
-              <th>Email</th>
+              <th>Topic</th>
             </tr>
           </thead>
           <tbody>
             {entries.map((e) => (
               <tr key={e.id}>
-                <td>{e.name}</td>
-                <td>{e.email}</td>
+                <td>{e.topic}</td>
               </tr>
             ))}
           </tbody>

--- a/src/web/routes/entries.py
+++ b/src/web/routes/entries.py
@@ -11,8 +11,7 @@ router = APIRouter()
 class EntryCreate(BaseModel):
     """Payload for creating a new entry."""
 
-    name: str
-    email: str
+    topic: str
 
 
 class Entry(EntryCreate):

--- a/tests/dataEntryForm.test.tsx
+++ b/tests/dataEntryForm.test.tsx
@@ -11,24 +11,20 @@ describe("DataEntryForm", () => {
       .mockResolvedValueOnce({ ok: true, json: async () => [] })
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ id: 1, name: "Alice", email: "alice@example.com" }),
+        json: async () => ({ id: 1, topic: "Graph Theory" }),
       });
   });
 
   it("adds entries to tracking table", async () => {
     render(<DataEntryForm />);
-    fireEvent.change(screen.getByLabelText(/name/i), {
-      target: { value: "Alice" },
-    });
-    fireEvent.change(screen.getByLabelText(/email/i), {
-      target: { value: "alice@example.com" },
+    fireEvent.change(screen.getByPlaceholderText(/enter topic/i), {
+      target: { value: "Graph Theory" },
     });
     fireEvent.click(screen.getByRole("button", { name: /add/i }));
 
     await waitFor(() => {
-      expect(screen.getByText("Alice")).toBeInTheDocument();
+      expect(screen.getByText("Graph Theory")).toBeInTheDocument();
     });
-    expect(screen.getByText("alice@example.com")).toBeInTheDocument();
     expect(global.fetch).toHaveBeenCalledWith(
       "/entries",
       expect.objectContaining({ method: "POST" })

--- a/tests/test_entries.py
+++ b/tests/test_entries.py
@@ -34,11 +34,11 @@ def test_create_and_list_entries() -> None:
 
     entries_routes._entries.clear()
     client = TestClient(create_app())
-    resp = client.post("/entries", json={"name": "Alice", "email": "alice@example.com"})
+    resp = client.post("/entries", json={"topic": "Graph Theory"})
     assert resp.status_code == 200
     data = resp.json()
-    assert data["name"] == "Alice"
+    assert data["topic"] == "Graph Theory"
     resp = client.get("/entries")
     assert resp.status_code == 200
     entries = resp.json()
-    assert entries[0]["email"] == "alice@example.com"
+    assert entries[0]["topic"] == "Graph Theory"


### PR DESCRIPTION
## Summary
- remove name/email fields from entry form
- add centered expanding textbox for topic entries
- adjust backend and tests for topic-based entries

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: certificate verify failed)*
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892962c9ef4832b8053a43cc8b8a7a1