### PR TITLE
fix: register lecture CLI script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,15 +38,15 @@ dependencies = [
     "weasyprint",
 ]
 
-[project.scripts]
-"generate-lecture" = "cli.generate_lecture:main"
-
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 package-mode = false
+
+[tool.poetry.scripts]
+generate-lecture = "cli.generate_lecture:main"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
## Summary
- expose generate-lecture CLI through Poetry scripts

## Testing
- `poetry install` *(fails: All attempts to connect to pypi.org failed)*
- `poetry run black .`
- `poetry run ruff check .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll` *(fails: Command not found)*
- `poetry run pip-audit` *(fails: Command not found)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6892a1417aa4832b88cca66268c242b8