### PR TITLE
Expose default settings instance

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -83,4 +83,8 @@ def load_settings() -> Settings:
     return Settings()  # type: ignore[call-arg]
 
 
-__all__ = ["Settings", "load_settings", "load_env", "MODEL_NAME"]
+# Backwards compatible convenience instance.
+settings = load_settings()
+
+
+__all__ = ["Settings", "settings", "load_settings", "load_env", "MODEL_NAME"]


### PR DESCRIPTION
## Summary
- provide backward-compatible `settings` instance
- expose `settings` in module exports

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: certificate verify failed)*
- `OPENAI_API_KEY=a PERPLEXITY_API_KEY=b pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892a119f3e4832b8d4562032d6e2a29