### PR TITLE
refactor: run CLI without poetry

### DIFF
--- a/scripts/cli.sh
+++ b/scripts/cli.sh
@@ -11,6 +11,9 @@
 
 set -euo pipefail
 
+# Ensure project modules are discoverable
+export PYTHONPATH="${PYTHONPATH:-}:$(pwd)/src"
+
 # Source environment variables if .env exists
 if [ -f .env ]; then
   set -a
@@ -19,7 +22,7 @@ if [ -f .env ]; then
 fi
 
 # Run database migrations
-poetry run alembic upgrade head
+python -m alembic upgrade head
 
 # Forward all arguments (e.g., the topic) to the CLI entry point
-poetry run generate-lecture "$@"
+python -m cli.generate_lecture "$@"


### PR DESCRIPTION
## Summary
- run Alembic migrations and CLI directly with Python
- ensure local modules resolve by exporting `PYTHONPATH`

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: Missing Authority Key Identifier)*
- `OPENAI_API_KEY=a PERPLEXITY_API_KEY=b pytest`
- `OPENAI_API_KEY=a PERPLEXITY_API_KEY=b ./scripts/cli.sh "Introduction to Foundational Models"` *(fails: Connection error)*

------
https://chatgpt.com/codex/tasks/task_e_6892a47b3e4c832b9b39db62ae48d43e