### PR TITLE
Improve streaming logging fallback and add tests

### DIFF
--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,33 @@
+import logging
+import sys
+from types import SimpleNamespace
+
+from agents import streaming
+
+
+def test_stream_uses_sdk(monkeypatch):
+    calls = []
+
+    def fake_stream(channel: str, payload: str) -> None:
+        calls.append((channel, payload))
+
+    monkeypatch.setitem(
+        sys.modules, "langgraph_sdk", SimpleNamespace(stream=fake_stream)
+    )
+    streaming.stream("messages", "hello")
+    assert calls == [("messages", "hello")]
+
+
+def test_stream_logs_on_failure(monkeypatch, caplog):
+    def failing_stream(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setitem(
+        sys.modules, "langgraph_sdk", SimpleNamespace(stream=failing_stream)
+    )
+    with caplog.at_level(logging.DEBUG):
+        streaming.stream("messages", "hi")
+        streaming.stream("debug", "dbg")
+
+    assert "[messages] hi" in caplog.text
+    assert "[debug] dbg" in caplog.text


### PR DESCRIPTION
## Summary
- replace `print` fallback in streaming utilities with log-based handler and optional callback
- tag fallback logs with their channel
- add tests for SDK and fallback streaming paths

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: certificate verify failed)*
- `pytest tests/test_streaming.py`


------
https://chatgpt.com/codex/tasks/task_e_6892b7f14ebc832baad75cf537300985