### PR TITLE
Improve researcher pipeline resilience to failures

### DIFF
--- a/src/agents/researcher_pipeline.py
+++ b/src/agents/researcher_pipeline.py
@@ -33,23 +33,45 @@ async def researcher_pipeline(query: str, state: State) -> List[Citation]:
     """Execute the researcher pipeline for ``query``."""
 
     state.prompt = query
-    drafts: List[CitationDraft] = run_web_search(state)
+    try:
+        drafts: List[CitationDraft] = run_web_search(state)
+    except Exception:
+        logging.exception("Web search failed")
+        return []
+
     ranked = rank_by_authority(drafts)
     kept, _ = filter_allowlist(ranked)
     citations: List[Citation] = []
     workspace_id = getattr(state, "workspace_id", "default")
 
-    licences = await asyncio.gather(*(_lookup_licence(draft.url) for draft in kept))
+    try:
+        licence_results: List[str | BaseException] = await asyncio.gather(
+            *(_lookup_licence(draft.url) for draft in kept),
+            return_exceptions=True,
+        )
+    except Exception:
+        logging.exception("Licence lookups failed")
+        licence_results = ["unknown" for _ in kept]
 
     async with get_db_session() as conn:
         repo = CitationRepo(conn, workspace_id)
-        for draft, licence in zip(kept, licences):
+        for draft, licence in zip(kept, licence_results):
+            licence_text = "unknown"
+            if isinstance(licence, BaseException):
+                logging.exception("Licence lookup failed for %s", draft.url)
+            elif isinstance(licence, str) and licence:
+                licence_text = licence
+
             citation = Citation(
                 url=draft.url,
                 title=draft.title,
                 retrieved_at=datetime.utcnow(),
-                licence=licence or "unknown",
+                licence=licence_text,
             )
-            await repo.insert(citation)
+            try:
+                await repo.insert(citation)
+            except Exception:
+                logging.exception("Failed to insert citation for %s", draft.url)
+                continue
             citations.append(citation)
     return citations

--- a/tests/test_researcher_pipeline.py
+++ b/tests/test_researcher_pipeline.py
@@ -1,0 +1,52 @@
+import os
+
+import httpx
+import pytest
+
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("PERPLEXITY_API_KEY", "test")
+
+from agents.researcher_pipeline import CitationDraft, researcher_pipeline
+from core.state import State
+
+
+@pytest.mark.asyncio
+async def test_pipeline_handles_web_search_error(monkeypatch):
+    def fail_search(_state):
+        raise httpx.HTTPError("search failure")
+
+    monkeypatch.setattr("agents.researcher_pipeline.run_web_search", fail_search)
+    state = State(prompt="topic")
+    citations = await researcher_pipeline("query", state)
+    assert citations == []
+
+
+@pytest.mark.asyncio
+async def test_pipeline_continues_on_license_and_db_errors(monkeypatch):
+    drafts = [
+        CitationDraft(url="https://example.edu/a", snippet="", title="A"),
+        CitationDraft(url="https://example.edu/b", snippet="", title="B"),
+    ]
+
+    def good_search(_state):
+        return drafts
+
+    async def flaky_lookup(url: str) -> str:
+        if url.endswith("/b"):
+            raise httpx.HTTPError("network issue")
+        return "MIT"
+
+    async def flaky_insert(self, citation):
+        if str(citation.url).endswith("/b"):
+            raise RuntimeError("db down")
+        return None
+
+    monkeypatch.setattr("agents.researcher_pipeline.run_web_search", good_search)
+    monkeypatch.setattr("agents.researcher_pipeline._lookup_licence", flaky_lookup)
+    monkeypatch.setattr("agents.researcher_pipeline.CitationRepo.insert", flaky_insert)
+
+    state = State(prompt="topic")
+    citations = await researcher_pipeline("query", state)
+    assert len(citations) == 1
+    assert str(citations[0].url) == "https://example.edu/a"
+    assert citations[0].licence == "MIT"


### PR DESCRIPTION
## Summary
- handle web search, licence lookup, and database insert errors without aborting the pipeline
- use `asyncio.gather(..., return_exceptions=True)` for licence lookups
- add tests covering web search, licence, and database failures

## Testing
- `black src/agents/researcher_pipeline.py tests/test_researcher_pipeline.py`
- `ruff check src/agents/researcher_pipeline.py tests/test_researcher_pipeline.py`
- `mypy src/agents/researcher_pipeline.py tests/test_researcher_pipeline.py`
- `bandit -r src -ll`
- `pip-audit` *(fails: SSL: CERTIFICATE_VERIFY_FAILED)*
- `pytest tests/test_researcher_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_6892be7d60c8832b9fe34582bdcc72dd