### PR TITLE
Add core base classes and export integrations

### DIFF
--- a/docs/MODULE_OVERVIEW.md
+++ b/docs/MODULE_OVERVIEW.md
@@ -1,0 +1,24 @@
+# Module Overview
+
+This document summarises the foundational modules that were recently
+introduced.
+
+## Core
+
+- `core.Agent` – abstract base class that defines the agent interface.
+- `core.AgentError` – base exception type for agent failures.
+- `core.get_logger` – helper returning a configured `logging.Logger`.
+
+## Agents
+
+- `agents.EchoAgent` – echoes input text without modification.
+- `agents.ReverseAgent` – reverses text input for demonstration purposes.
+
+## Export
+
+The `export` package exposes concrete export utilities through the
+`EXPORTERS` registry mapping format names to implementations:
+
+ - `markdown` and `pdf` map to exporter classes.
+ - `metadata` maps to the `export_citations_json` function that serialises
+   citation metadata to JSON.

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,7 +1,23 @@
-"""Agent implementations for the demo.
+"""Concrete agent implementations built on :mod:`core` utilities."""
 
-This package will contain concrete agent classes and related behaviors used
-throughout the system.
+from __future__ import annotations
 
-TODO: Implement agent classes and behaviors.
-"""
+from core import Agent
+
+__all__ = ["EchoAgent", "ReverseAgent"]
+
+
+class EchoAgent(Agent):
+    """Return the provided message unchanged."""
+
+    def act(self, message: str, /, **kwargs: object) -> str:
+        self.logger.debug("echoing %s", message)
+        return message
+
+
+class ReverseAgent(Agent):
+    """Return the reversed representation of the provided message."""
+
+    def act(self, message: str, /, **kwargs: object) -> str:
+        self.logger.debug("reversing %s", message)
+        return message[::-1]

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,7 +1,42 @@
-"""Core functionality for the agentic demo.
+"""Core utilities and base classes for agent components.
 
-This package will house foundational utilities and base classes that are
-shared across the project.
-
-TODO: Define foundational utilities and base classes shared across modules.
+This module provides minimal infrastructure that can be reused across the
+project.  The :class:`Agent` base class defines the interface for all agents
+and offers a simple logger through :func:`get_logger`.
 """
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Any
+
+__all__ = ["Agent", "AgentError", "get_logger"]
+
+
+class AgentError(Exception):
+    """Base exception for agent-related failures."""
+
+
+class Agent(ABC):
+    """Abstract base class for all agents.
+
+    Parameters
+    ----------
+    name:
+        Human-readable identifier used for logging and debugging.
+    """
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.logger = get_logger(name)
+
+    @abstractmethod
+    def act(self, message: str, /, **kwargs: Any) -> Any:
+        """Execute the agent's core behaviour and return the result."""
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a ``logging.Logger`` configured for ``name``."""
+
+    return logging.getLogger(name)

--- a/src/export/__init__.py
+++ b/src/export/__init__.py
@@ -1,7 +1,21 @@
-"""Data export functionality.
+"""Helpers for exporting lecture data into multiple formats."""
 
-This package will be responsible for exporting data into various formats or
-external systems.
+from __future__ import annotations
 
-TODO: Implement export formats and mechanisms.
-"""
+from .markdown_exporter import MarkdownExporter
+from .metadata_exporter import export_citations_json
+from .pdf_exporter import PdfExporter
+
+__all__ = [
+    "MarkdownExporter",
+    "PdfExporter",
+    "export_citations_json",
+    "EXPORTERS",
+]
+
+
+EXPORTERS = {
+    "markdown": MarkdownExporter,
+    "pdf": PdfExporter,
+    "metadata": export_citations_json,
+}

--- a/tests/test_agents_init.py
+++ b/tests/test_agents_init.py
@@ -1,0 +1,11 @@
+from agents import EchoAgent, ReverseAgent
+
+
+def test_echo_agent_returns_same_message():
+    agent = EchoAgent("echo")
+    assert agent.act("hello") == "hello"
+
+
+def test_reverse_agent_returns_reversed_message():
+    agent = ReverseAgent("rev")
+    assert agent.act("abc") == "cba"

--- a/tests/test_core_init.py
+++ b/tests/test_core_init.py
@@ -1,0 +1,19 @@
+import logging
+
+from core import Agent, get_logger
+
+
+class DummyAgent(Agent):
+    def act(self, message: str, /, **kwargs: object) -> str:
+        return message.upper()
+
+
+def test_agent_act_returns_uppercase():
+    agent = DummyAgent("dummy")
+    assert agent.act("hi") == "HI"
+
+
+def test_get_logger_matches_name():
+    logger = get_logger("sample")
+    assert isinstance(logger, logging.Logger)
+    assert logger.name == "sample"

--- a/tests/test_export_init.py
+++ b/tests/test_export_init.py
@@ -1,0 +1,5 @@
+from export import EXPORTERS, MarkdownExporter
+
+
+def test_exporters_registry_contains_markdown():
+    assert EXPORTERS["markdown"] is MarkdownExporter


### PR DESCRIPTION
## Summary
- define foundational `Agent` base class with logging utilities
- implement simple `EchoAgent` and `ReverseAgent`
- expose markdown, PDF, and metadata exporters via `EXPORTERS`
- document modules and add unit tests

## Testing
- `black src/agents/__init__.py src/core/__init__.py src/export/__init__.py tests/test_core_init.py tests/test_agents_init.py tests/test_export_init.py`
- `ruff check src/agents/__init__.py src/core/__init__.py src/export/__init__.py tests/test_core_init.py tests/test_agents_init.py tests/test_export_init.py`
- `mypy src/agents/__init__.py src/core/__init__.py src/export/__init__.py tests/test_core_init.py tests/test_agents_init.py tests/test_export_init.py`
- `bandit -r src -ll`
- `pip-audit` *(failed: SSL certificate verify failed)*
- `pytest tests/test_core_init.py tests/test_agents_init.py tests/test_export_init.py`


------
https://chatgpt.com/codex/tasks/task_e_6892c567debc832b98de6117962140c6