### PR TITLE
Handle missing langgraph streaming gracefully

### DIFF
--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,6 +1,4 @@
 import logging
-import sys
-from types import SimpleNamespace
 
 from agents import streaming
 
@@ -11,9 +9,7 @@ def test_stream_uses_sdk(monkeypatch):
     def fake_stream(channel: str, payload: str) -> None:
         calls.append((channel, payload))
 
-    monkeypatch.setitem(
-        sys.modules, "langgraph_sdk", SimpleNamespace(stream=fake_stream)
-    )
+    monkeypatch.setattr(streaming, "_sdk_stream", fake_stream)
     streaming.stream("messages", "hello")
     assert calls == [("messages", "hello")]
 
@@ -22,12 +18,18 @@ def test_stream_logs_on_failure(monkeypatch, caplog):
     def failing_stream(*_args: object, **_kwargs: object) -> None:
         raise RuntimeError("boom")
 
-    monkeypatch.setitem(
-        sys.modules, "langgraph_sdk", SimpleNamespace(stream=failing_stream)
-    )
+    monkeypatch.setattr(streaming, "_sdk_stream", failing_stream)
     with caplog.at_level(logging.DEBUG):
         streaming.stream("messages", "hi")
         streaming.stream("debug", "dbg")
 
     assert "[messages] hi" in caplog.text
     assert "[debug] dbg" in caplog.text
+
+
+def test_stream_without_sdk(monkeypatch, caplog):
+    monkeypatch.setattr(streaming, "_sdk_stream", None)
+    with caplog.at_level(logging.INFO):
+        streaming.stream("messages", "hi")
+
+    assert "[messages] hi" in caplog.text


### PR DESCRIPTION
## Summary
- avoid repeated ImportError logs when langgraph_sdk lacks a stream helper
- update streaming tests for new lazy import behaviour

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: SSLCertVerificationError)*
- `pytest tests/test_streaming.py`


------
https://chatgpt.com/codex/tasks/task_e_6892d29adf88832b9960ffd52c8921cf