### PR TITLE
feat(cli): add optional verbose logging

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -14,6 +14,14 @@ Command-line shortcuts for running the application, executing tests, and handlin
 
   Launches the backend with hot reload; use `--offline` to disable external network calls.
 
+- **Generate lecture material**
+
+  ```bash
+  ./scripts/cli.sh [--verbose] "<topic>"
+  ```
+
+  Produces lecture JSON for the topic. `--verbose` shows progress logs.
+
 ## Testing
 
 - **Backend tests**

--- a/scripts/cli.sh
+++ b/scripts/cli.sh
@@ -2,12 +2,12 @@
 # Starts the CLI application locally without Docker.
 #
 # Usage:
-#   ./scripts/cli.sh <topic>
+#   ./scripts/cli.sh [--verbose] <topic>
 #
 # The script will:
 #   1. Source environment variables from .env
 #   2. Apply database migrations via Alembic
-#   3. Launch the CLI instance
+#   3. Launch the CLI instance (forwarding any flags like --verbose)
 
 set -euo pipefail
 

--- a/src/cli/generate_lecture.py
+++ b/src/cli/generate_lecture.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import logging
 from dataclasses import asdict
 from typing import Any, Dict
 
@@ -15,9 +16,14 @@ from core.state import State
 def parse_args() -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(
-        description="Generate lecture material from a topic prompt."
+        description="Generate lecture material from a topic prompt.",
     )
     parser.add_argument("topic", help="Topic or outline for the lecture")
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable progress feedback on the console",
+    )
     return parser.parse_args()
 
 
@@ -39,6 +45,8 @@ async def _generate(topic: str) -> Dict[str, Any]:
 def main() -> None:
     """Entry point for console scripts."""
     args = parse_args()
+    if args.verbose:
+        logging.basicConfig(level=logging.DEBUG)
     try:
         payload = asyncio.run(_generate(args.topic))
     except Exception as exc:  # pragma: no cover - defensive

--- a/tests/test_generate_lecture.py
+++ b/tests/test_generate_lecture.py
@@ -41,3 +41,14 @@ def test_generate(monkeypatch):
 
     result = asyncio.run(_generate("topic"))
     assert result["title"] == "Test"
+
+
+def test_parse_args_verbose(monkeypatch):
+    """parse_args recognizes the --verbose flag."""
+
+    from cli.generate_lecture import parse_args
+
+    monkeypatch.setattr(sys, "argv", ["prog", "topic", "--verbose"])
+    args = parse_args()
+    assert args.verbose is True
+    assert args.topic == "topic"


### PR DESCRIPTION
## Summary
- add `--verbose` flag to lecture generator CLI to enable console progress logs
- document verbose usage and forward flags in helper script
- test argument parsing for verbose option

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: SSLCertVerificationError)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*
- `pytest tests/test_generate_lecture.py`

------
https://chatgpt.com/codex/tasks/task_e_6892d5cd05c4832b846cf806613de053