### PR TITLE
Improve robustness of lecture generation JSON parsing

### DIFF
--- a/src/prompts.json
+++ b/src/prompts.json
@@ -1,5 +1,5 @@
 {
-  "content_weaver_system": "You are an academic content weaver producing lectures.",
+  "content_weaver_system": "You are an academic content weaver producing lectures. Always respond with a JSON object that conforms to the lecture_schema.json and omit any extra commentary.",
   "pedagogy_critic_classify": "Classify the learning objective below into one of Bloom's levels (remember, understand, apply, analyze, evaluate, create). Respond with only the level name.",
   "planner_system": "You are a meticulous curriculum planner. Given a topic, produce a numbered outline of key teaching steps."
 }

--- a/tests/test_content_weaver.py
+++ b/tests/test_content_weaver.py
@@ -1,0 +1,20 @@
+"""Tests for content weaver helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from agents.content_weaver import parse_function_response, RetryableError
+
+
+def test_parse_function_response_extracts_json() -> None:
+    """parse_function_response returns the inner JSON block."""
+    tokens = ["prefix", '{"title": "Demo"}', "suffix"]
+    result = parse_function_response(tokens)
+    assert result["title"] == "Demo"
+
+
+def test_parse_function_response_errors_without_json() -> None:
+    """parse_function_response raises when JSON is absent."""
+    with pytest.raises(RetryableError):
+        parse_function_response(["no json here"])


### PR DESCRIPTION
## Summary
- recover JSON from streamed model output by extracting the first complete object
- tighten content weaver prompt to demand schema-compliant JSON only
- add unit tests for JSON extraction helper

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: SSLError: CERTIFICATE_VERIFY_FAILED)*
- `pytest` *(fails: async def functions are not natively supported; test_config expected environment values)*

------
https://chatgpt.com/codex/tasks/task_e_6892d8ca544c832b83614c20d9326e07