### PR TITLE
fix: update SSE client path

### DIFF
--- a/frontend/src/api/sseClient.ts
+++ b/frontend/src/api/sseClient.ts
@@ -1,13 +1,16 @@
-// Utility for connecting to the server-sent events workspace stream.
-// Includes very basic reconnect logic with a fixed backoff.
-export function connectToWorkspaceStream(workspaceId: string): EventSource {
-  const url = `/stream/${workspaceId}`;
+// Utility for connecting to server-sent event streams for a workspace.
+// Includes basic reconnect logic with a fixed backoff.
+export function connectToWorkspaceStream(
+  workspaceId: string,
+  channel = "state",
+): EventSource {
+  const url = `/stream/${workspaceId}/${channel}`;
   let source = new EventSource(url);
 
   source.onerror = () => {
     source.close();
     setTimeout(() => {
-      source = connectToWorkspaceStream(workspaceId);
+      source = connectToWorkspaceStream(workspaceId, channel);
     }, 1000);
   };
 


### PR DESCRIPTION
## Summary
- handle channel selection for workspace SSE streams

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: SSLCertVerificationError)*
- `npm test`
- `pytest` *(fails: async plugin missing, config assertion, etc.)*
- `npm run typecheck` *(fails: missing test globals)*

------
https://chatgpt.com/codex/tasks/task_e_6892e6474b88832bb91311a7f516d341