### PR TITLE
feat(frontend): adopt FromHereOn-inspired styling

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,8 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <title>Agentic Demo</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,400;0,700;1,400;1,700&family=Domine:ital,wght@0,400;0,700&display=swap"
+      rel="stylesheet"
+    />
   </head>
-  <body class="bg-gray-100 font-sans">
+  <body class="bg-white text-gray-900 font-sans antialiased">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,26 +22,26 @@ const App: React.FC = () => {
   }, [connect]);
 
   return (
-    <div className="max-w-4xl mx-auto p-4 space-y-4">
-      <div className="bg-white rounded shadow p-4">
+    <div className="max-w-4xl mx-auto p-6 space-y-6">
+      <div className="card">
         <DataEntryForm />
       </div>
-      <div className="bg-white rounded shadow p-4">
+      <div className="card">
         <DocumentPanel text={document || ""} onAcceptDiff={() => {}} />
       </div>
-      <div className="bg-white rounded shadow p-4">
+      <div className="card">
         <LogPanel logs={logs} />
       </div>
-      <div className="bg-white rounded shadow p-4">
+      <div className="card">
         <SourcesPanel sources={sources} />
       </div>
       {workspaceId && (
-        <div className="bg-white rounded shadow p-4">
+        <div className="card">
           <ControlsPanel workspaceId={workspaceId} />
         </div>
       )}
       {workspaceId && exportStatus === "ready" && (
-        <div className="bg-white rounded shadow p-4">
+        <div className="card">
           <DownloadsPanel workspaceId={workspaceId} />
         </div>
       )}

--- a/frontend/src/components/ControlsPanel.tsx
+++ b/frontend/src/components/ControlsPanel.tsx
@@ -41,28 +41,28 @@ const ControlsPanel: React.FC<Props> = ({ workspaceId }) => {
       <button
         onClick={onRunClick}
         disabled={status === "running"}
-        className="px-3 py-1 bg-green-500 text-white rounded disabled:opacity-50"
+        className="btn disabled:opacity-50"
       >
         Run
       </button>
       <button
         onClick={onPauseClick}
         disabled={status !== "running"}
-        className="px-3 py-1 bg-yellow-500 text-white rounded disabled:opacity-50"
+        className="btn disabled:opacity-50"
       >
         Pause
       </button>
       <button
         onClick={onRetryClick}
         disabled={status === "running"}
-        className="px-3 py-1 bg-blue-500 text-white rounded disabled:opacity-50"
+        className="btn disabled:opacity-50"
       >
         Retry
       </button>
       <button
         onClick={onResumeClick}
         disabled={status !== "paused"}
-        className="px-3 py-1 bg-purple-500 text-white rounded disabled:opacity-50"
+        className="btn disabled:opacity-50"
       >
         Resume
       </button>

--- a/frontend/src/components/DataEntryForm.tsx
+++ b/frontend/src/components/DataEntryForm.tsx
@@ -70,10 +70,7 @@ const DataEntryForm: React.FC = () => {
           placeholder="Enter topic"
           rows={1}
         />
-        <button
-          type="submit"
-          className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
-        >
+        <button type="submit" className="btn">
           Add
         </button>
       </form>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,3 +3,24 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @apply font-serif;
+  }
+}
+
+@layer components {
+  .card {
+    @apply bg-white rounded shadow-card p-6;
+  }
+
+  .btn {
+    @apply px-4 py-2 rounded bg-primary text-white hover:bg-accent hover:text-black transition-colors;
+  }
+}
+

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,19 @@
 export default {
   content: ["./frontend/index.html", "./frontend/src/**/*.{ts,tsx}"],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ["Montserrat", "sans-serif"],
+        serif: ["Domine", "serif"],
+      },
+      colors: {
+        primary: "#000000",
+        accent: "#00ffc6",
+      },
+      boxShadow: {
+        card: "0 4px 8px rgba(0, 0, 0, 0.05)",
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- define reusable Tailwind card and button components with accent hover states
- apply card component across main panels and expand layout spacing
- configure custom shadow and enable antialiased body text

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: SSL certificate verify failed)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68931b281f10832ba85839587ea64cd2