### PR TITLE
feat(cli): log stream boundaries

### DIFF
--- a/src/cli/generate_lecture.py
+++ b/src/cli/generate_lecture.py
@@ -10,6 +10,7 @@ from dataclasses import asdict
 from typing import Any, Dict
 
 from agents.content_weaver import run_content_weaver
+from agents.streaming import stream_messages
 from core.state import State
 
 
@@ -47,10 +48,13 @@ def main() -> None:
     args = parse_args()
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
+        stream_messages("LLM response stream start")
     try:
         payload = asyncio.run(_generate(args.topic))
     except Exception as exc:  # pragma: no cover - defensive
         raise SystemExit(f"Error generating lecture: {exc}") from exc
+    if args.verbose:
+        stream_messages("LLM response stream complete: %s" % json.dumps(payload))
     print(json.dumps(payload, indent=2))
 
 

--- a/tests/test_cli_logging.py
+++ b/tests/test_cli_logging.py
@@ -1,0 +1,53 @@
+import logging
+import sys
+from types import ModuleType, SimpleNamespace
+
+
+def test_main_logs_stream_boundaries(monkeypatch, caplog):
+    fake_agents = ModuleType("agents")
+    fake_cw = ModuleType("agents.content_weaver")
+    fake_streaming = ModuleType("agents.streaming")
+
+    async def fake_run_content_weaver(state):
+        return SimpleNamespace()
+
+    fake_cw.run_content_weaver = fake_run_content_weaver
+    fake_agents.content_weaver = fake_cw
+
+    def fake_stream_messages(message: str) -> None:
+        logging.getLogger("agents.streaming").info("[messages] %s", message)
+
+    fake_streaming.stream_messages = fake_stream_messages
+    fake_agents.streaming = fake_streaming
+    sys.modules["agents"] = fake_agents
+    sys.modules["agents.content_weaver"] = fake_cw
+    sys.modules["agents.streaming"] = fake_streaming
+
+    fake_core = ModuleType("core")
+    fake_state = ModuleType("core.state")
+
+    class State:  # type: ignore[too-few-public-methods]
+        def __init__(self, prompt: str):
+            self.prompt = prompt
+
+    fake_state.State = State
+    fake_core.state = fake_state
+    sys.modules["core"] = fake_core
+    sys.modules["core.state"] = fake_state
+
+    from cli import generate_lecture
+
+    async def fake_generate(topic: str):
+        return {"result": "ok"}
+
+    def fake_parse_args():
+        return SimpleNamespace(topic="demo", verbose=True)
+
+    monkeypatch.setattr(generate_lecture, "_generate", fake_generate)
+    monkeypatch.setattr(generate_lecture, "parse_args", fake_parse_args)
+
+    with caplog.at_level(logging.INFO):
+        generate_lecture.main()
+
+    assert "[messages] LLM response stream start" in caplog.text
+    assert '[messages] LLM response stream complete: {"result": "ok"}' in caplog.text


### PR DESCRIPTION
## Summary
- route verbose CLI logging through the streaming logger to emit start and completion markers
- expand CLI logging test to stub streaming module and verify boundary messages

## Testing
- `black tests/test_cli_logging.py src/cli/generate_lecture.py`
- `ruff check src/cli/generate_lecture.py tests/test_cli_logging.py`
- `mypy src/cli/generate_lecture.py tests/test_cli_logging.py`
- `bandit -r src -ll`
- `pip-audit` *(fails: SSLError: certificate verify failed)*
- `pytest tests/test_cli_logging.py`
- `OPENAI_API_KEY=dummy PERPLEXITY_API_KEY=dummy pytest` *(fails: missing async plugin and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_689333531e70832bbc220e9c019c0c24