### PR TITLE
Include lecture schema in ContentWeaver prompts

### DIFF
--- a/src/agents/content_weaver.py
+++ b/src/agents/content_weaver.py
@@ -76,7 +76,11 @@ def parse_function_response(tokens: list[str]) -> dict:
 
 
 async def call_openai_function(prompt: str) -> AsyncGenerator[str, None]:
-    """Invoke an LLM via LangChain and yield streamed tokens."""
+    """Invoke an LLM via LangChain and yield streamed tokens.
+
+    The lecture schema is supplied as a system message so the model knows the
+    exact structure required for its response.
+    """
 
     try:
         from langchain_core.messages import HumanMessage, SystemMessage
@@ -100,8 +104,12 @@ async def call_openai_function(prompt: str) -> AsyncGenerator[str, None]:
         return empty()
 
     async def generator() -> AsyncGenerator[str, None]:
+        schema = json.dumps(load_schema(), indent=2)
         messages = [
             SystemMessage(content=get_prompt("content_weaver_system")),
+            SystemMessage(
+                content=f"Output must conform to this JSON schema:\n{schema}"
+            ),
             HumanMessage(content=prompt),
         ]
         stream = model.astream(messages)

--- a/tests/test_content_weaver.py
+++ b/tests/test_content_weaver.py
@@ -2,8 +2,14 @@
 
 from __future__ import annotations
 
+import json
+import sys
+import types
+from typing import Any
+
 import pytest
 
+from agents import content_weaver
 from agents.content_weaver import parse_function_response, RetryableError
 
 
@@ -18,3 +24,48 @@ def test_parse_function_response_errors_without_json() -> None:
     """parse_function_response raises when JSON is absent."""
     with pytest.raises(RetryableError):
         parse_function_response(["no json here"])
+
+
+def test_call_openai_function_supplies_schema(monkeypatch: Any) -> None:
+    """call_openai_function sends the lecture schema to the model."""
+
+    class FakeMessage:
+        def __init__(self, content: str) -> None:
+            self.content = content
+
+    fake_messages = types.SimpleNamespace(
+        HumanMessage=FakeMessage, SystemMessage=FakeMessage
+    )
+    monkeypatch.setitem(sys.modules, "langchain_core.messages", fake_messages)
+
+    captured: dict[str, Any] = {}
+
+    class DummyModel:
+        async def astream(self, messages: list[FakeMessage]) -> Any:
+            captured["messages"] = messages
+
+            async def gen() -> Any:
+                yield FakeMessage("")
+
+            return gen()
+
+    def fake_init_chat_model(streaming: bool = True) -> DummyModel:
+        return DummyModel()
+
+    fake_wrapper = types.SimpleNamespace(init_chat_model=fake_init_chat_model)
+    monkeypatch.setitem(sys.modules, "agents.agent_wrapper", fake_wrapper)
+
+    schema_marker = {"marker": "value"}
+    monkeypatch.setattr(content_weaver, "load_schema", lambda: schema_marker)
+
+    async def run() -> None:
+        stream = await content_weaver.call_openai_function("topic")
+        _ = [token async for token in stream]
+
+    import asyncio
+
+    asyncio.run(run())
+
+    schema_str = json.dumps(schema_marker, indent=2)
+    messages = captured.get("messages", [])
+    assert any(schema_str in m.content for m in messages)


### PR DESCRIPTION
## Summary
- ensure ContentWeaver passes lecture schema details to the LLM
- add regression test verifying schema is provided to model

## Testing
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: SSLCertVerificationError)*
- `pytest tests/test_content_weaver.py`


------
https://chatgpt.com/codex/tasks/task_e_68933b621134832b84925488391398d5