### PR TITLE
Remove unused Langsmith streaming

### DIFF
--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -3,33 +3,18 @@ import logging
 from agents import streaming
 
 
-def test_stream_uses_sdk(monkeypatch):
-    calls = []
-
-    def fake_stream(channel: str, payload: str) -> None:
-        calls.append((channel, payload))
-
-    monkeypatch.setattr(streaming, "_sdk_stream", fake_stream)
-    streaming.stream("messages", "hello")
-    assert calls == [("messages", "hello")]
-
-
-def test_stream_logs_on_failure(monkeypatch, caplog):
-    def failing_stream(*_args: object, **_kwargs: object) -> None:
-        raise RuntimeError("boom")
-
-    monkeypatch.setattr(streaming, "_sdk_stream", failing_stream)
-    with caplog.at_level(logging.DEBUG):
-        streaming.stream("messages", "hi")
-        streaming.stream("debug", "dbg")
-
-    assert "[messages] hi" in caplog.text
-    assert "[debug] dbg" in caplog.text
-
-
-def test_stream_without_sdk(monkeypatch, caplog):
-    monkeypatch.setattr(streaming, "_sdk_stream", None)
+def test_stream_noop_without_fallback(caplog):
     with caplog.at_level(logging.INFO):
         streaming.stream("messages", "hi")
+
+    assert caplog.text == ""
+
+
+def test_stream_uses_fallback(caplog):
+    def fallback(channel: str, payload: str) -> None:
+        logging.getLogger("test").info("[%s] %s", channel, payload)
+
+    with caplog.at_level(logging.INFO):
+        streaming.stream("messages", "hi", fallback=fallback)
 
     assert "[messages] hi" in caplog.text


### PR DESCRIPTION
## Summary
- stop attempting to stream through LangGraph SDK; helpers are now no-ops unless a fallback is provided
- update streaming tests for new no-op behavior

## Testing
- `black tests/test_streaming.py src/agents/streaming.py`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: certificate verify failed)*
- `pytest` *(fails: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68933ef4b114832b87d359bad964a25a