### PR TITLE
feat: add citation retrieval endpoint

### DIFF
--- a/src/web/routes/citation.py
+++ b/src/web/routes/citation.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
-router = APIRouter(prefix="/citation")
+router = APIRouter(prefix="/workspaces/{workspace_id}/citations")
 
 
-@router.get("/{workspace_id}")
+@router.get("")
 async def list_citations(workspace_id: str) -> list[dict[str, str]]:
     """Return stored citations for ``workspace_id``.
 
@@ -15,3 +15,18 @@ async def list_citations(workspace_id: str) -> list[dict[str, str]]:
     """
 
     return []
+
+
+@router.get("/{citation_id}")
+async def get_citation(workspace_id: str, citation_id: str) -> dict[str, str]:
+    """Return citation ``citation_id`` for ``workspace_id``.
+
+    The implementation is a placeholder that returns minimal metadata.
+    """
+
+    return {
+        "url": f"https://example.org/{citation_id}",
+        "title": "Placeholder",
+        "retrieved_at": "1970-01-01",
+        "licence": "unknown",
+    }

--- a/tests/test_citation_routes.py
+++ b/tests/test_citation_routes.py
@@ -1,0 +1,44 @@
+"""Tests for citation API routes."""
+
+from pathlib import Path
+import sys
+
+repo_src = Path(__file__).resolve().parents[1] / "src"
+if str(repo_src) in sys.path:
+    sys.path.remove(str(repo_src))
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+sys.path.insert(0, str(repo_src))
+
+import importlib.util  # noqa: E402
+
+spec = importlib.util.spec_from_file_location(
+    "citation", repo_src / "web" / "routes" / "citation.py"
+)
+assert spec and spec.loader
+citation_routes = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(citation_routes)
+
+
+def create_app() -> FastAPI:
+    """Create a FastAPI app with the citation router."""
+
+    app = FastAPI()
+    app.include_router(citation_routes.router)
+    return app
+
+
+def test_list_and_get_citation() -> None:
+    """Ensure citation routes respond with placeholders."""
+
+    client = TestClient(create_app())
+    resp = client.get("/workspaces/abc/citations")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+    resp = client.get("/workspaces/abc/citations/123")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["url"].endswith("/123")
+    assert data["title"] == "Placeholder"


### PR DESCRIPTION
## Summary
- expand citation router to support `/workspaces/{workspace_id}/citations` paths
- add placeholder endpoint for retrieving a single citation
- add tests for listing citations and fetching a single citation

## Testing
- `black .`
- `ruff .` *(fails: unrecognized subcommand, used `ruff check .`)*
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(failed: SSL certificate verify failed)*
- `pip install .` *(failed: Building a package is not possible in non-package mode.)*
- `pytest` *(failed: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68935bfbb228832b88fab554c1c77924