### PR TITLE
refactor: derive retry predicate from report

### DIFF
--- a/src/core/policies.py
+++ b/src/core/policies.py
@@ -64,11 +64,16 @@ def policy_retry_on_critic_failure(
         agent_name: Identifier passed to :func:`retry_tracker`.
 
     Returns:
-        ``True`` when issues were flagged and the content weaver should be
-        reinvoked, ``False`` when critique passes.
+        ``True`` when recommendations or factual issues were flagged and the
+        content weaver should be reinvoked, ``False`` when critique passes.
     """
 
-    should_retry = bool(report.issues)
+    if isinstance(report, CritiqueReport):
+        should_retry = bool(report.recommendations)
+    else:
+        should_retry = bool(
+            report.hallucination_count or report.unsupported_claims_count
+        )
     if should_retry:
         retry_tracker(state, agent_name)
     return should_retry


### PR DESCRIPTION
## Summary
- refine critic failure policy to inspect actual report fields
- update policy tests to use realistic report shapes

## Testing
- `black src/core/policies.py tests/test_policies.py`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: SSLCertVerificationError: certificate verify failed)*
- `pytest tests/test_policies.py`


------
https://chatgpt.com/codex/tasks/task_e_68935c1c8538832ba9c00c9a5c799f7f