### PR TITLE
Add document DAG helper and tests

### DIFF
--- a/src/core/document_dag.py
+++ b/src/core/document_dag.py
@@ -1,0 +1,79 @@
+"""Section-wise document generation using nested StateGraphs."""
+
+from __future__ import annotations
+
+from langgraph.graph import END, START, StateGraph
+from langgraph.graph.state import CompiledStateGraph
+
+from agents.content_weaver import run_content_weaver
+from agents.pedagogy_critic import run_pedagogy_critic
+from agents.planner import run_planner
+from agents.researcher_web_node import run_researcher_web
+from core.policies import policy_retry_on_critic_failure
+from core.state import State
+
+
+def _build_section_graph(section_id: int) -> CompiledStateGraph[State]:
+    """Construct a graph to process a single outline section.
+
+    The graph executes the Research → Draft → Critic loop for the specified
+    ``section_id``. Critic failures trigger retries of the drafting step via
+    :func:`policy_retry_on_critic_failure`.
+
+    Args:
+        section_id: Index of the outline section to process.
+
+    Returns:
+        CompiledStateGraph[State]: Ready-to-run graph for the section.
+    """
+
+    graph = StateGraph(State)
+    graph.add_node("Researcher-Web", run_researcher_web)
+
+    async def _draft(state: State) -> None:
+        await run_content_weaver(state, section_id=section_id)
+
+    graph.add_node("Content-Weaver", _draft)
+    graph.add_node("Pedagogy-Critic", run_pedagogy_critic)
+    graph.add_edge(START, "Researcher-Web")
+    graph.add_edge("Researcher-Web", "Content-Weaver")
+    graph.add_edge("Content-Weaver", "Pedagogy-Critic")
+    graph.add_conditional_edges(
+        "Pedagogy-Critic",
+        policy_retry_on_critic_failure,
+        {True: "Content-Weaver", False: END},
+    )
+    return graph.compile()
+
+
+async def run_document_dag(state: State, skip_plan: bool = False) -> State:
+    """Generate content for each outline section and merge into ``state``.
+
+    Args:
+        state: Current application state used across nodes.
+        skip_plan: When ``True``, assumes planning has already populated
+            ``state.outline`` and therefore skips the planner.
+
+    Returns:
+        State: Updated state with ``outline.modules`` reflecting generated
+        sections.
+    """
+
+    if not skip_plan:
+        await run_planner(state)
+
+    for idx, _ in enumerate(state.outline.steps):
+        section_graph = _build_section_graph(idx)
+        invoke = getattr(section_graph, "ainvoke", None)
+        if invoke is None:
+            invoke = getattr(section_graph, "invoke")
+        await invoke(state)  # type: ignore[func-returns-value]
+        if state.modules:
+            state.outline.steps[idx] = (
+                state.modules[-1].title or state.outline.steps[idx]
+            )
+    state.outline.modules = list(state.modules)
+    return state
+
+
+__all__ = ["run_document_dag"]

--- a/tests/test_document_dag.py
+++ b/tests/test_document_dag.py
@@ -1,0 +1,116 @@
+import types
+import sys
+
+import os
+
+# mypy: ignore-errors
+
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("PERPLEXITY_API_KEY", "test")
+
+# Stub langgraph modules before importing document_dag
+langgraph_graph = types.ModuleType("langgraph.graph")
+
+
+class _CompiledGraph:
+    def __init__(self, nodes):
+        self.nodes = nodes
+
+    async def ainvoke(self, state):
+        await self.nodes["Researcher-Web"](state)
+        await self.nodes["Content-Weaver"](state)
+        await self.nodes["Pedagogy-Critic"](state)
+
+
+class _StateGraph:
+    def __init__(self, _state):
+        self.nodes: dict[str, callable] = {}
+
+    def add_node(self, name, fn, streams=None):  # noqa: D401 - stub
+        self.nodes[name] = fn
+
+    def add_edge(self, *_args, **_kwargs):
+        pass
+
+    def add_conditional_edges(self, *_args, **_kwargs):
+        pass
+
+    def compile(self):
+        return _CompiledGraph(self.nodes)
+
+
+langgraph_graph.StateGraph = _StateGraph
+langgraph_graph.START = "START"
+langgraph_graph.END = "END"
+langgraph_state = types.ModuleType("langgraph.graph.state")
+langgraph_state.CompiledStateGraph = _CompiledGraph
+sys.modules["langgraph"] = types.ModuleType("langgraph")
+sys.modules["langgraph.graph"] = langgraph_graph
+sys.modules["langgraph.graph.state"] = langgraph_state
+
+
+# Stub policy
+core_policies = types.ModuleType("core.policies")
+core_policies.policy_retry_on_critic_failure = lambda *_, **__: False
+sys.modules["core.policies"] = core_policies
+
+
+# Stub agent functions
+calls: list[str] = []
+
+
+a_research = types.ModuleType("agents.researcher_web_node")
+
+
+async def run_researcher_web(state):  # noqa: D401 - stub
+    calls.append("research")
+
+
+a_research.run_researcher_web = run_researcher_web
+sys.modules["agents.researcher_web_node"] = a_research
+
+
+a_weaver = types.ModuleType("agents.content_weaver")
+
+
+async def run_content_weaver(state, section_id=None):  # noqa: D401 - stub
+    calls.append("draft")
+    module = Module(id=str(section_id), title=f"t{section_id}", duration_min=1)
+    state.modules.append(module)
+    return module
+
+
+a_weaver.run_content_weaver = run_content_weaver
+sys.modules["agents.content_weaver"] = a_weaver
+
+
+a_critic = types.ModuleType("agents.pedagogy_critic")
+
+
+async def run_pedagogy_critic(state):  # noqa: D401 - stub
+    calls.append("critic")
+
+
+a_critic.run_pedagogy_critic = run_pedagogy_critic
+sys.modules["agents.pedagogy_critic"] = a_critic
+
+
+# Import after stubs
+from core.document_dag import run_document_dag  # noqa: E402
+from core.state import Outline, State, Module  # noqa: E402
+
+
+def test_run_document_dag_processes_sections():
+    state = State(prompt="p", outline=Outline(steps=["a", "b"]))
+    asyncio_run = getattr(__import__("asyncio"), "run")
+    asyncio_run(run_document_dag(state, skip_plan=True))
+    assert calls == [
+        "research",
+        "draft",
+        "critic",
+        "research",
+        "draft",
+        "critic",
+    ]
+    assert len(state.modules) == 2
+    assert state.outline.modules == state.modules


### PR DESCRIPTION
## Summary
- build document DAG helper that walks each outline section through Research→Draft→Critic loops
- support optional `skip_plan` to avoid re-planning and merge module titles back into the outline
- cover the helper with unit tests using stubbed LangGraph components

## Testing
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: SSLCertVerificationError)*
- `pytest tests/test_document_dag.py`
- `pytest` *(fails: ImportError: cannot import name 'ActionLog' from 'core.state')*

------
https://chatgpt.com/codex/tasks/task_e_6893603cfa7c832bb7b5d65628ce8097