### PR TITLE
feat: add workspace-scoped control routes

### DIFF
--- a/src/web/routes/control.py
+++ b/src/web/routes/control.py
@@ -6,11 +6,11 @@ from uuid import uuid4
 
 from fastapi import APIRouter, Body
 
-router = APIRouter()
+router = APIRouter(prefix="/workspaces/{workspace_id}")
 
 
 @router.post("/run", status_code=201)
-async def run(topic: str = Body(..., embed=True)) -> dict[str, str]:
+async def run(workspace_id: str, topic: str = Body(..., embed=True)) -> dict[str, str]:
     """Start a new lecture generation job.
 
     This endpoint is a stub used for testing the HTTP interface.
@@ -19,8 +19,31 @@ async def run(topic: str = Body(..., embed=True)) -> dict[str, str]:
     return {"job_id": str(uuid4())}
 
 
-@router.post("/resume/{job_id}")
-async def resume(job_id: str) -> dict[str, str]:
+@router.post("/pause")
+async def pause(workspace_id: str) -> dict[str, str]:
+    """Pause the graph execution for a workspace."""
+
+    return {"workspace_id": workspace_id, "status": "paused"}
+
+
+@router.post("/retry")
+async def retry(workspace_id: str) -> dict[str, str]:
+    """Retry the graph using the last inputs for a workspace."""
+
+    return {"workspace_id": workspace_id, "status": "retried"}
+
+
+@router.post("/resume")
+async def resume(workspace_id: str) -> dict[str, str]:
     """Resume processing for a previously started job."""
 
-    return {"job_id": job_id, "status": "resumed"}
+    return {"workspace_id": workspace_id, "status": "resumed"}
+
+
+@router.post("/model")
+async def model(
+    workspace_id: str, model: str = Body(..., embed=True)
+) -> dict[str, str]:
+    """Select the model to run subsequent operations against."""
+
+    return {"workspace_id": workspace_id, "model": model}

--- a/tests/test_control_routes.py
+++ b/tests/test_control_routes.py
@@ -1,0 +1,55 @@
+"""Tests for control API routes."""
+
+from pathlib import Path
+import sys
+
+repo_src = Path(__file__).resolve().parents[1] / "src"
+if str(repo_src) in sys.path:
+    sys.path.remove(str(repo_src))
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+sys.path.insert(0, str(repo_src))
+
+import importlib.util  # noqa: E402
+
+spec = importlib.util.spec_from_file_location(
+    "control", repo_src / "web" / "routes" / "control.py"
+)
+assert spec and spec.loader
+control_routes = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(control_routes)
+
+
+def create_app() -> FastAPI:
+    """Create a FastAPI app with the control router."""
+
+    app = FastAPI()
+    app.include_router(control_routes.router)
+    return app
+
+
+def test_control_endpoints() -> None:
+    """Ensure control routes respond with placeholders."""
+
+    client = TestClient(create_app())
+
+    resp = client.post("/workspaces/abc/run", json={"topic": "unit"})
+    assert resp.status_code == 201
+    assert "job_id" in resp.json()
+
+    resp = client.post("/workspaces/abc/pause")
+    assert resp.status_code == 200
+    assert resp.json() == {"workspace_id": "abc", "status": "paused"}
+
+    resp = client.post("/workspaces/abc/retry")
+    assert resp.status_code == 200
+    assert resp.json() == {"workspace_id": "abc", "status": "retried"}
+
+    resp = client.post("/workspaces/abc/resume")
+    assert resp.status_code == 200
+    assert resp.json() == {"workspace_id": "abc", "status": "resumed"}
+
+    resp = client.post("/workspaces/abc/model", json={"model": "gpt"})
+    assert resp.status_code == 200
+    assert resp.json() == {"workspace_id": "abc", "model": "gpt"}


### PR DESCRIPTION
## Summary
- namespace execution control routes under `/workspaces/{workspace_id}`
- add stub handlers for pause, retry, resume, and model selection
- cover control routes with tests

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: SSLCertVerificationError: certificate verify failed)*
- `pytest tests/test_control_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_6893604afa50832bb8d6be8d0f3bad57