### PR TITLE
feat: add export status and URL endpoints

### DIFF
--- a/src/web/routes/export.py
+++ b/src/web/routes/export.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 from fastapi import APIRouter, Response
 
 from web.api.export_endpoints import (
+    ExportStatus,
+    ExportUrls,
     get_all_exports,
     get_citations_json,
     get_docx_export,
+    get_export_status,
+    get_export_urls,
     get_markdown_export,
     get_pdf_export,
 )
@@ -43,4 +47,18 @@ router.add_api_route(
     get_all_exports,
     methods=["GET"],
     response_class=Response,
+)
+
+router.add_api_route(
+    "/workspaces/{workspace_id}/export/status",
+    get_export_status,
+    methods=["GET"],
+    response_model=ExportStatus,
+)
+
+router.add_api_route(
+    "/workspaces/{workspace_id}/export/urls",
+    get_export_urls,
+    methods=["GET"],
+    response_model=ExportUrls,
 )

--- a/tests/test_export_routes.py
+++ b/tests/test_export_routes.py
@@ -1,0 +1,60 @@
+"""Tests for export API routes."""
+
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+repo_src = Path(__file__).resolve().parents[1] / "src"
+if str(repo_src) in sys.path:
+    sys.path.remove(str(repo_src))
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+sys.path.insert(0, str(repo_src))
+
+import importlib.util  # noqa: E402
+
+spec = importlib.util.spec_from_file_location(
+    "export", repo_src / "web" / "routes" / "export.py"
+)
+assert spec and spec.loader
+export_routes = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(export_routes)
+
+
+def create_app(tmp_path: Path) -> FastAPI:
+    """Create a FastAPI app with the export router."""
+
+    app = FastAPI()
+    app.state.settings = SimpleNamespace(data_dir=tmp_path)
+    app.include_router(export_routes.router)
+    return app
+
+
+def test_export_status_and_urls(tmp_path: Path) -> None:
+    """Ensure status and URL routes respond correctly."""
+
+    client = TestClient(create_app(tmp_path))
+
+    resp = client.get("/workspaces/ws/export/status")
+    assert resp.status_code == 200
+    assert resp.json() == {"ready": False}
+
+    export_dir = tmp_path / "exports" / "ws"
+    export_dir.mkdir(parents=True)
+    (export_dir / "lecture.md").write_text("x")
+    (export_dir / "lecture.docx").write_bytes(b"x")
+    (export_dir / "lecture.pdf").write_bytes(b"x")
+
+    resp = client.get("/workspaces/ws/export/status")
+    assert resp.status_code == 200
+    assert resp.json() == {"ready": True}
+
+    resp = client.get("/workspaces/ws/export/urls")
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "md": "/export/ws/md",
+        "docx": "/export/ws/docx",
+        "pdf": "/export/ws/pdf",
+        "zip": "/export/ws/all",
+    }


### PR DESCRIPTION
## Summary
- add ExportStatus and ExportUrls models with helpers to build readiness and download links
- wire new export status and URL routes under /workspaces/{workspace_id}/export
- cover new API surface with tests

## Testing
- `ruff check src/web/api/export_endpoints.py src/web/routes/export.py tests/test_export_routes.py`
- `mypy src/web/api/export_endpoints.py src/web/routes/export.py tests/test_export_routes.py`
- `bandit -r src -ll`
- `pip-audit` *(fails: SSL certificate verify failed)*
- `pytest tests/test_export_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_689364f03314832b998189f55a099899