### PR TITLE
refactor: adopt async sqlite saver

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -265,8 +265,8 @@ Each node module defines a single `async` handler function and its input/output 
 
 - **In `orchestrator.py`**, wiring:
 
-- Instantiate `SqliteCheckpointManager` with `DATA_DIR`.
-- Pass it into `GraphOrchestrator`, so every node completion triggers `save_checkpoint()`.
+- Instantiate an `AsyncSqliteSaver` with `DATA_DIR`.
+- Execute the compiled graph via `graph.ainvoke(..., config={"checkpoint": saver, "resume": True})` so each node snapshot is persisted and runs can resume from any step.
 
 ---
 

--- a/src/cli/generate_lecture.py
+++ b/src/cli/generate_lecture.py
@@ -9,7 +9,7 @@ import logging
 from typing import Any, Dict
 
 from agents.streaming import stream_messages
-from core.orchestrator import graph
+from core.orchestrator import create_checkpoint_saver, graph
 
 
 def parse_args() -> argparse.Namespace:
@@ -36,9 +36,16 @@ async def _generate(topic: str) -> Dict[str, Any]:
         Dict[str, Any]: Final graph state serialized to a plain dictionary.
     """
 
-    return await graph.ainvoke(
-        {"prompt": topic}, config={"configurable": {"thread_id": "cli"}}
-    )
+    async with create_checkpoint_saver() as saver:
+        return await graph.ainvoke(
+            {"prompt": topic},
+            config={
+                "checkpoint": saver,
+                "resume": True,
+                "configurable": {"thread_id": "cli"},
+            },
+        )
+
 
 def main() -> None:
     """Entry point for console scripts."""

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -20,7 +20,6 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExport
 from agents.cache_backed_researcher import CacheBackedResearcher
 from agents.researcher_web import PerplexityClient, TavilyClient
 from config import Settings, load_settings
-from core.checkpoint import SqliteCheckpointManager
 from core.orchestrator import GraphOrchestrator
 from persistence.database import get_db_session, init_db
 
@@ -90,12 +89,9 @@ async def setup_database(app: FastAPI) -> None:
 
 
 def setup_graph(app: FastAPI) -> None:
-    """Initialize the LangGraph graph and checkpoint saver."""
+    """Initialize the LangGraph graph."""
 
-    settings: Settings = app.state.settings
-    checkpoint_path = settings.data_dir / "checkpoint.db"
-    manager = SqliteCheckpointManager(str(checkpoint_path))
-    orchestrator = GraphOrchestrator(manager)
+    orchestrator = GraphOrchestrator()
     orchestrator.initialize_graph()
     orchestrator.register_edges()
     app.state.graph = orchestrator.graph

--- a/tests/test_cli_logging.py
+++ b/tests/test_cli_logging.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+from contextlib import asynccontextmanager
 from types import ModuleType, SimpleNamespace
 
 
@@ -16,6 +17,12 @@ def test_main_logs_stream_boundaries(monkeypatch, caplog):
     fake_orchestrator.graph = SimpleNamespace(
         ainvoke=lambda *_a, **_k: {"result": "ok"}
     )
+
+    @asynccontextmanager
+    async def fake_saver():
+        yield object()
+
+    fake_orchestrator.create_checkpoint_saver = fake_saver
     sys.modules["core.orchestrator"] = fake_orchestrator
 
     from cli import generate_lecture

--- a/tests/test_generate_lecture.py
+++ b/tests/test_generate_lecture.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import sys
 import types
+from contextlib import asynccontextmanager
 
 
 def test_generate(monkeypatch):
@@ -15,8 +16,15 @@ def test_generate(monkeypatch):
         return {"title": "Test"}
 
     fake_graph = types.SimpleNamespace(ainvoke=fake_ainvoke)
+
+    @asynccontextmanager
+    async def fake_saver():
+        yield object()
+
     monkeypatch.setitem(
-        sys.modules, "core.orchestrator", types.SimpleNamespace(graph=fake_graph)
+        sys.modules,
+        "core.orchestrator",
+        types.SimpleNamespace(graph=fake_graph, create_checkpoint_saver=fake_saver),
     )
 
     from cli.generate_lecture import _generate

--- a/tests/test_orchestrator_edges.py
+++ b/tests/test_orchestrator_edges.py
@@ -149,20 +149,6 @@ core_policies_stub.policy_retry_on_low_confidence = policy_retry_on_low_confiden
 core_policies_stub.policy_retry_on_critic_failure = policy_retry_on_critic_failure
 sys.modules["core.policies"] = core_policies_stub
 
-core_checkpoint_stub = types.ModuleType("core.checkpoint")
-
-
-class SqliteCheckpointManager:  # type: ignore[too-many-ancestors]
-    def __init__(self, *_args, **_kwargs):
-        pass
-
-    async def save_checkpoint(self, _state):
-        pass
-
-
-core_checkpoint_stub.SqliteCheckpointManager = SqliteCheckpointManager
-sys.modules["core.checkpoint"] = core_checkpoint_stub
-
 core_logging_stub = types.ModuleType("core.logging")
 
 


### PR DESCRIPTION
## Summary
- remove custom start/resume functions and integrate LangGraph's `AsyncSqliteSaver`
- invoke graphs with checkpointed, resumable execution
- adjust CLI and docs for new checkpoint flow

## Testing
- `black src/cli/generate_lecture.py src/core/orchestrator.py src/web/main.py src/web/sse.py tests/test_cli_logging.py tests/test_generate_lecture.py tests/test_orchestrator_edges.py`
- `ruff check src/core/orchestrator.py src/web/sse.py tests/test_cli_logging.py tests/test_generate_lecture.py tests/test_orchestrator_edges.py src/cli/generate_lecture.py src/web/main.py`
- `mypy src/core/orchestrator.py src/web/sse.py src/cli/generate_lecture.py src/web/main.py tests/test_cli_logging.py tests/test_generate_lecture.py tests/test_orchestrator_edges.py`
- `bandit -r src -ll`
- `pip-audit` *(failed: Certificate verify failed)*
- `pytest` *(failed: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_689364e41df4832b8abd11ffdcb15d18