### PR TITLE
test: ensure src on path

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+"""Test configuration setup for the repository.
+
+Adds the project's ``src`` directory to ``sys.path`` so test modules can
+import application code without requiring the project to be installed as a
+package.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Compute the absolute path to the project root and ``src`` directory.
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SRC_DIR = PROJECT_ROOT / "src"
+
+# Prepend ``src`` to ``sys.path`` if it's not already present.
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))


### PR DESCRIPTION
## Summary
- ensure tests can import from the src directory without installing the package

## Testing
- `python -m black tests/conftest.py`
- `ruff check tests/conftest.py`
- `mypy tests/conftest.py`
- `bandit -r src -ll`
- `pip-audit` *(fails: CERTIFICATE_VERIFY_FAILED)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_6893dce60a68832b95c3852d7c01ad4c