### PR TITLE
feat: adopt pydantic ai client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lecture Builder Agent
 
-A local-first, multi-agent system that generates high‑quality, university‑grade lecture and workshop outlines (with supporting materials) from a single topic prompt. Orchestrated by LangGraph and implemented in Python, the system integrates OpenAI o4‑mini/o3 models, pluggable web search (Perplexity Sonar or Tavily) via LangChain, and a React‑based UX. Full state, citations, logs, and intermediates persist in SQLite (with optional Postgres fallback). Exports include Markdown, DOCX, and PDF.
+A local-first, multi-agent system that generates high‑quality, university‑grade lecture and workshop outlines (with supporting materials) from a single topic prompt. Orchestrated by LangGraph and implemented in Python, the system integrates OpenAI o4‑mini/o3 models, pluggable web search (Perplexity Sonar or Tavily) via Pydantic AI, and a React‑based UX. Full state, citations, logs, and intermediates persist in SQLite (with optional Postgres fallback). Exports include Markdown, DOCX, and PDF.
 
 ---
 

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -1220,7 +1220,7 @@ def from_schema(weave: WeaveResult) -> str:
      _Runs at startup to assert `config.MODEL_NAME == "o4-mini"`, or raise a clear error._
 
 3. **`src/agents/agent_wrapper.py`**
-   - **Method:** `get_llm_params()`
+   - **Method:** `get_llm_params()` removed in favor of direct Pydantic AI configuration.
      _Reads `config.MODEL_NAME` and injects into every OpenAI API call payload._
 
 4. **Acceptance:**

--- a/src/agents/content_weaver.py
+++ b/src/agents/content_weaver.py
@@ -83,7 +83,10 @@ async def call_openai_function(prompt: str) -> AsyncGenerator[str, None]:
     """
 
     try:
-        from langchain_core.messages import HumanMessage, SystemMessage
+        from pydantic_ai.messages import (
+            SystemPromptPart as SystemMessage,
+            UserPromptPart as HumanMessage,
+        )
         from .agent_wrapper import init_chat_model
     except Exception:  # pragma: no cover - dependency not installed
         logging.exception("Content weaver dependencies unavailable")

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -33,7 +33,10 @@ async def call_planner_llm(topic: str) -> str:
     """
 
     try:  # pragma: no cover - exercised via monkeypatch in tests
-        from langchain_core.messages import HumanMessage, SystemMessage
+        from pydantic_ai.messages import (
+            SystemPromptPart as SystemMessage,
+            UserPromptPart as HumanMessage,
+        )
     except Exception:  # dependency missing
         logging.exception("Planner dependencies unavailable")
         return ""

--- a/tests/test_content_weaver.py
+++ b/tests/test_content_weaver.py
@@ -36,7 +36,7 @@ def test_call_openai_function_supplies_schema(monkeypatch: Any) -> None:
     fake_messages = types.SimpleNamespace(
         HumanMessage=FakeMessage, SystemMessage=FakeMessage
     )
-    monkeypatch.setitem(sys.modules, "langchain_core.messages", fake_messages)
+    monkeypatch.setitem(sys.modules, "pydantic_ai.messages", fake_messages)
 
     captured: dict[str, Any] = {}
 


### PR DESCRIPTION
## Summary
- replace LangChain chat wrappers with a thin Pydantic-AI client and cache instances
- use Pydantic-AI message types in planner and content weaver
- document removal of `get_llm_params`

## Testing
- `black .`
- `ruff check src/agents/agent_wrapper.py src/agents/content_weaver.py src/agents/planner.py tests/test_content_weaver.py`
- `mypy src/agents/agent_wrapper.py src/agents/content_weaver.py src/agents/planner.py tests/test_content_weaver.py`
- `python -m bandit -r src -ll`
- `python -m pip_audit` *(fails: SSLCertVerificationError)*
- `pytest` *(fails: ImportError: cannot import name 'ActionLog' from 'core.state')*

------
https://chatgpt.com/codex/tasks/task_e_6893e9e25d8c832bb27fbe51fc1505ee