### PR TITLE
refactor: adopt pydantic models for weaving

### DIFF
--- a/src/agents/content_weaver.py
+++ b/src/agents/content_weaver.py
@@ -4,16 +4,14 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import dataclass
-from pathlib import Path
 from typing import AsyncGenerator
 
-from jsonschema import Draft202012Validator
+from pydantic import ValidationError
 
 from core.state import Module, State
 from prompts import get_prompt
 
-from .models import Activity, AssessmentItem, Citation, SlideBullet, WeaveResult
+from .models import WeaveResult
 from .streaming import stream_debug, stream_messages
 
 
@@ -21,106 +19,42 @@ class RetryableError(RuntimeError):
     """Signal that the operation can be retried."""
 
 
-class SchemaError(RetryableError):
-    """Raised when LLM output fails schema validation."""
-
-
-_schema_cache: dict | None = None
-
-
-def load_schema() -> dict:
-    """Load the lecture schema from disk once."""
-    global _schema_cache
-    if _schema_cache is None:
-        schema_path = (
-            Path(__file__).resolve().parents[1] / "schemas" / "lecture_schema.json"
-        )
-        with schema_path.open("r", encoding="utf-8") as f:
-            _schema_cache = json.load(f)
-    return _schema_cache
-
-
-@dataclass(slots=True)
-class ValidationResult:
-    """Outcome of schema validation."""
-
-    valid: bool
-    errors: list[str]
-
-
-def validate_against_schema(payload: dict) -> ValidationResult:
-    """Validate payload using the lecture schema."""
-    schema = load_schema()
-    validator = Draft202012Validator(schema)
-    errors = [
-        f"{'/'.join(str(p) for p in err.path)}: {err.message}"
-        for err in validator.iter_errors(payload)
-    ]
-    return ValidationResult(valid=not errors, errors=errors)
-
-
-def parse_function_response(tokens: list[str]) -> dict:
-    """Assemble streamed ``tokens`` into a JSON object."""
-
-    raw = "".join(tokens)
-    try:
-        return json.loads(raw)
-    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
-        start, end = raw.find("{"), raw.rfind("}") + 1
-        if start >= 0 and end > start:
-            try:
-                return json.loads(raw[start:end])
-            except json.JSONDecodeError as inner_exc:  # pragma: no cover - defensive
-                raise RetryableError("model returned invalid JSON") from inner_exc
-        raise RetryableError("model returned invalid JSON") from exc
-
-
 async def call_openai_function(prompt: str) -> AsyncGenerator[str, None]:
-    """Invoke an LLM via LangChain and yield streamed tokens.
-
-    The lecture schema is supplied as a system message so the model knows the
-    exact structure required for its response.
-    """
+    """Invoke an LLM via Pydantic AI and yield streamed tokens."""
 
     try:
-        from pydantic_ai.messages import (
-            SystemPromptPart as SystemMessage,
-            UserPromptPart as HumanMessage,
-        )
+        from pydantic_ai import Agent
         from .agent_wrapper import init_chat_model
     except Exception:  # pragma: no cover - dependency not installed
         logging.exception("Content weaver dependencies unavailable")
 
         async def empty() -> AsyncGenerator[str, None]:
             if False:
-                yield ""  # type: ignore
+                yield ""  # type: ignore[misc]
 
         return empty()
 
-    model = init_chat_model(streaming=True)
-    if model is None:
+    wrapper = init_chat_model()
+    if wrapper is None:
 
         async def empty() -> AsyncGenerator[str, None]:
             if False:
-                yield ""  # type: ignore
+                yield ""  # type: ignore[misc]
 
         return empty()
 
+    schema = json.dumps(WeaveResult.model_json_schema(), indent=2)
+    instructions = [
+        get_prompt("content_weaver_system"),
+        f"Output must conform to this JSON schema:\n{schema}",
+    ]
+    agent = Agent(model=wrapper._model, instructions=instructions)  # type: ignore[attr-defined]
+
     async def generator() -> AsyncGenerator[str, None]:
-        schema = json.dumps(load_schema(), indent=2)
-        messages = [
-            SystemMessage(content=get_prompt("content_weaver_system")),
-            SystemMessage(
-                content=f"Output must conform to this JSON schema:\n{schema}"
-            ),
-            HumanMessage(content=prompt),
-        ]
-        stream = model.astream(messages)
-        if hasattr(stream, "__await__"):
-            stream = await stream
-        async for chunk in stream:  # pragma: no cover - streaming
-            if chunk.content:
-                yield chunk.content
+        async with agent.run_stream(prompt) as response:  # pragma: no cover - streaming
+            async for chunk in response.stream_text(delta=True):
+                if chunk:
+                    yield chunk
 
     return generator()
 
@@ -147,44 +81,12 @@ async def content_weaver(state: State, section_id: int | None = None) -> WeaveRe
     async for token in stream:
         tokens.append(token)
         stream_messages(token)
-    payload = parse_function_response(tokens)
-    validation = validate_against_schema(payload)
-    if not validation.valid:
-        error_msg = "; ".join(validation.errors)
-        stream_debug(error_msg)
-        raise SchemaError(error_msg)
-    activities = [Activity(**a) for a in payload.get("activities", [])]
-    slide_bullets = (
-        [SlideBullet(**b) for b in payload.get("slide_bullets", [])]
-        if payload.get("slide_bullets")
-        else None
-    )
-    assessment = (
-        [AssessmentItem(**a) for a in payload.get("assessment", [])]
-        if payload.get("assessment")
-        else None
-    )
-    references = (
-        [Citation(**c) for c in payload.get("references", [])]
-        if payload.get("references")
-        else None
-    )
-    return WeaveResult(
-        title=payload.get("title", ""),
-        learning_objectives=payload.get("learning_objectives", []),
-        activities=activities,
-        duration_min=payload.get("duration_min", 0),
-        author=payload.get("author"),
-        date=payload.get("date"),
-        version=payload.get("version"),
-        summary=payload.get("summary"),
-        tags=payload.get("tags"),
-        prerequisites=payload.get("prerequisites"),
-        slide_bullets=slide_bullets,
-        speaker_notes=payload.get("speaker_notes"),
-        assessment=assessment,
-        references=references,
-    )
+    raw = "".join(tokens)
+    try:
+        return WeaveResult.model_validate_json(raw)
+    except ValidationError as exc:  # pragma: no cover - defensive
+        stream_debug(str(exc))
+        raise RetryableError("model returned invalid schema") from exc
 
 
 async def run_content_weaver(state: State, section_id: int | None = None) -> Module:

--- a/src/agents/models.py
+++ b/src/agents/models.py
@@ -2,62 +2,56 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import List, Optional
+from pydantic import BaseModel, Field
 
 
-@dataclass(slots=True)
-class Activity:
+class Activity(BaseModel):
     """Learning activity performed during the lecture."""
 
     type: str
     description: str
     duration_min: int
-    learning_objectives: List[str] = field(default_factory=list)
+    learning_objectives: list[str] = Field(default_factory=list)
 
 
-@dataclass(slots=True)
-class SlideBullet:
+class SlideBullet(BaseModel):
     """Bullet points associated with a slide."""
 
     slide_number: int
-    bullets: List[str]
+    bullets: list[str]
 
 
-@dataclass(slots=True)
-class AssessmentItem:
+class AssessmentItem(BaseModel):
     """Assessment or quiz used to evaluate understanding."""
 
     type: str
     description: str
-    max_score: Optional[float] = None
+    max_score: float | None = None
 
 
-@dataclass(slots=True)
-class Citation:
+class Citation(BaseModel):
     """Reference to an external source."""
 
     url: str
     title: str
     retrieved_at: str
-    licence: Optional[str] = None
+    licence: str | None = None
 
 
-@dataclass(slots=True)
-class WeaveResult:
+class WeaveResult(BaseModel):
     """Typed container mirroring the weave schema output."""
 
     title: str
-    learning_objectives: List[str]
-    activities: List[Activity]
+    learning_objectives: list[str]
+    activities: list[Activity]
     duration_min: int
-    author: Optional[str] = None
-    date: Optional[str] = None
-    version: Optional[str] = None
-    summary: Optional[str] = None
-    tags: Optional[List[str]] = None
-    prerequisites: Optional[List[str]] = None
-    slide_bullets: Optional[List[SlideBullet]] = None
-    speaker_notes: Optional[str] = None
-    assessment: Optional[List[AssessmentItem]] = None
-    references: Optional[List[Citation]] = None
+    author: str | None = None
+    date: str | None = None
+    version: str | None = None
+    summary: str | None = None
+    tags: list[str] | None = None
+    prerequisites: list[str] | None = None
+    slide_bullets: list[SlideBullet] | None = None
+    speaker_notes: str | None = None
+    assessment: list[AssessmentItem] | None = None
+    references: list[Citation] | None = None


### PR DESCRIPTION
## Summary
- switch weaving models to Pydantic BaseModel and expose WeaveResult schema
- stream LLM responses with pydantic-ai and validate with WeaveResult.model_validate_json
- update tests for new streaming and validation error handling

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /pypi/ag-ui-protocol/0.1.8/json (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)'))))*
- `PYTHONPATH=src pytest` *(fails: ImportError: cannot import name 'ActionLog' from 'core.state' (unknown location))*

------
https://chatgpt.com/codex/tasks/task_e_6893ee5320fc832bb6a945cb9a336f26