### PR TITLE
Refine LLM JSON parsing with Pydantic validation

### DIFF
--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import logging
 import re
 from dataclasses import dataclass
@@ -94,7 +93,7 @@ async def run_planner(state: State) -> PlanResult:
     try:
         data = PlannerOutput.model_validate_json(raw)
         outline = Outline(steps=[step.strip() for step in data.steps])
-    except (ValidationError, json.JSONDecodeError):
+    except ValidationError:
         outline = extract_outline(raw)
     state.outline = outline
     confidence = 0.0


### PR DESCRIPTION
## Summary
- parse pedagogy critic responses with `model_validate_json` and handle `ValidationError` fallbacks
- simplify planner fallback logic to rely on Pydantic validation errors

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: SSL certificate verify failed)*
- `pytest` *(fails: missing modules such as pydantic_settings, docx)*

------
https://chatgpt.com/codex/tasks/task_e_6893f44aada0832bb51543af2c5eb0ae