### PR TITLE
refactor: replace LangChain search clients with HTTPX

### DIFF
--- a/src/agents/offline_cache.py
+++ b/src/agents/offline_cache.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import re
-from dataclasses import asdict
 from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional
 
@@ -35,7 +34,7 @@ def load_cached_results(query: str) -> Optional[List["RawSearchResult"]]:
     if not path.exists():
         return None
     data = json.loads(path.read_text())
-    return [RawSearchResult(**item) for item in data]
+    return [RawSearchResult.model_validate(item) for item in data]
 
 
 def save_cached_results(query: str, results: List["RawSearchResult"]) -> None:
@@ -43,5 +42,5 @@ def save_cached_results(query: str, results: List["RawSearchResult"]) -> None:
     cache_dir = _cache_dir()
     cache_dir.mkdir(parents=True, exist_ok=True)
     path = cache_dir / _cache_file(query).name
-    data = [asdict(result) for result in results]
+    data = [result.model_dump() for result in results]
     path.write_text(json.dumps(data))

--- a/tests/test_researcher_web_clients.py
+++ b/tests/test_researcher_web_clients.py
@@ -1,0 +1,42 @@
+import json
+
+import httpx
+
+from agents.researcher_web import PerplexityClient, TavilyClient
+
+
+def test_perplexity_client_parses_response():
+    def handler(
+        request: httpx.Request,
+    ) -> httpx.Response:  # pragma: no cover - simple handler
+        assert request.url.path == "/search"
+        data = {
+            "search_results": [
+                {"url": "https://example.com", "snippet": "snippet", "title": "title"}
+            ]
+        }
+        return httpx.Response(200, json=data)
+
+    transport = httpx.MockTransport(handler)
+    client = PerplexityClient("key", http=httpx.Client(transport=transport))
+    results = client.search("query")
+    assert results[0].url == "https://example.com"
+
+
+def test_tavily_client_parses_response():
+    def handler(
+        request: httpx.Request,
+    ) -> httpx.Response:  # pragma: no cover - simple handler
+        payload = json.loads(request.content.decode())
+        assert payload["query"] == "query"
+        data = {
+            "results": [
+                {"url": "https://tavily.com", "content": "info", "title": "Tavily"}
+            ]
+        }
+        return httpx.Response(200, json=data)
+
+    transport = httpx.MockTransport(handler)
+    client = TavilyClient("key", http=httpx.Client(transport=transport))
+    results = client.search("query")
+    assert results[0].title == "Tavily"


### PR DESCRIPTION
## Summary
- swap LangChain search wrappers for lightweight HTTPX clients
- validate search responses with Pydantic models and cache via model dumps
- cover Perplexity and Tavily clients with HTTPX mock tests

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /pypi/anyio/4.10.0/json (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)')))*)
- `pytest` *(fails: cannot import name 'ActionLog' from 'core.state')*

------
https://chatgpt.com/codex/tasks/task_e_689409b22688832bb3f4f84d98b70f65