### PR TITLE
refactor: replace langgraph with custom orchestrator

### DIFF
--- a/src/cli/generate_lecture.py
+++ b/src/cli/generate_lecture.py
@@ -9,7 +9,8 @@ import logging
 from typing import Any, Dict
 
 from agents.streaming import stream_messages
-from core.orchestrator import create_checkpoint_saver, graph
+from core.orchestrator import graph
+from core.state import State
 
 
 def parse_args() -> argparse.Namespace:
@@ -27,24 +28,11 @@ def parse_args() -> argparse.Namespace:
 
 
 async def _generate(topic: str) -> Dict[str, Any]:
-    """Run the full LangGraph for ``topic``.
+    """Run the full graph for ``topic`` and return the final state."""
 
-    Args:
-        topic: Subject matter to base the lecture on.
-
-    Returns:
-        Dict[str, Any]: Final graph state serialized to a plain dictionary.
-    """
-
-    async with create_checkpoint_saver() as saver:
-        return await graph.ainvoke(
-            {"prompt": topic},
-            config={
-                "checkpoint": saver,
-                "resume": True,
-                "configurable": {"thread_id": "cli"},
-            },
-        )
+    state = State(prompt=topic)
+    await graph.run(state)
+    return state.to_dict()
 
 
 def main() -> None:

--- a/src/core/document_dag.py
+++ b/src/core/document_dag.py
@@ -1,73 +1,50 @@
-"""Section-wise document generation using nested StateGraphs."""
+"""Section-wise document generation using a simple DAG."""
 
 from __future__ import annotations
-
-from langgraph.graph import END, START, StateGraph
-from langgraph.graph.state import CompiledStateGraph
 
 from agents.content_weaver import run_content_weaver
 from agents.pedagogy_critic import run_pedagogy_critic
 from agents.planner import run_planner
 from agents.researcher_web_node import run_researcher_web
+from core.orchestrator import END, START, Graph
 from core.policies import policy_retry_on_critic_failure
 from core.state import State
 
 
-def _build_section_graph(section_id: int) -> CompiledStateGraph[State]:
-    """Construct a graph to process a single outline section.
-
-    The graph executes the Research → Draft → Critic loop for the specified
-    ``section_id``. Critic failures trigger retries of the drafting step via
-    :func:`policy_retry_on_critic_failure`.
-
-    Args:
-        section_id: Index of the outline section to process.
-
-    Returns:
-        CompiledStateGraph[State]: Ready-to-run graph for the section.
-    """
-
-    graph = StateGraph(State)
-    graph.add_node("Researcher-Web", run_researcher_web)
+def _build_section_graph(section_id: int) -> Graph:
+    """Construct a small graph to process a single outline section."""
 
     async def _draft(state: State) -> None:
         await run_content_weaver(state, section_id=section_id)
 
-    graph.add_node("Content-Weaver", _draft)
-    graph.add_node("Pedagogy-Critic", run_pedagogy_critic)
-    graph.add_edge(START, "Researcher-Web")
-    graph.add_edge("Researcher-Web", "Content-Weaver")
-    graph.add_edge("Content-Weaver", "Pedagogy-Critic")
-    graph.add_conditional_edges(
-        "Pedagogy-Critic",
-        policy_retry_on_critic_failure,
-        {True: "Content-Weaver", False: END},
-    )
-    return graph.compile()
+    nodes = {
+        "Researcher-Web": run_researcher_web,
+        "Content-Weaver": _draft,
+        "Pedagogy-Critic": run_pedagogy_critic,
+    }
+    edges = {
+        START: ["Researcher-Web"],
+        "Researcher-Web": ["Content-Weaver"],
+        "Content-Weaver": ["Pedagogy-Critic"],
+    }
+    conditionals = {
+        "Pedagogy-Critic": (
+            policy_retry_on_critic_failure,
+            {True: "Content-Weaver", False: END},
+        )
+    }
+    return Graph(nodes, edges, conditionals)
 
 
 async def run_document_dag(state: State, skip_plan: bool = False) -> State:
-    """Generate content for each outline section and merge into ``state``.
-
-    Args:
-        state: Current application state used across nodes.
-        skip_plan: When ``True``, assumes planning has already populated
-            ``state.outline`` and therefore skips the planner.
-
-    Returns:
-        State: Updated state with ``outline.modules`` reflecting generated
-        sections.
-    """
+    """Generate content for each outline section and merge into ``state``."""
 
     if not skip_plan:
         await run_planner(state)
 
     for idx, _ in enumerate(state.outline.steps):
         section_graph = _build_section_graph(idx)
-        invoke = getattr(section_graph, "ainvoke", None)
-        if invoke is None:
-            invoke = getattr(section_graph, "invoke")
-        await invoke(state)  # type: ignore[func-returns-value]
+        await section_graph.run(state)
         if state.modules:
             state.outline.steps[idx] = (
                 state.modules[-1].title or state.outline.steps[idx]

--- a/src/web/sse.py
+++ b/src/web/sse.py
@@ -4,37 +4,22 @@ from __future__ import annotations
 
 from collections.abc import AsyncGenerator
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any
 
 from fastapi import Request  # type: ignore[import-not-found]
 
+from core.orchestrator import Graph
+from core.state import State
 from web.schemas.sse import SseEvent  # type: ignore[import-not-found]
-from core.orchestrator import create_checkpoint_saver
-from langchain_core.runnables import RunnableConfig
-
-if TYPE_CHECKING:  # pragma: no cover - only for type checking
-    from langgraph.graph.state import (  # type: ignore[import-not-found]
-        CompiledStateGraph,
-    )
-else:  # pragma: no cover - dependency optional at runtime
-    CompiledStateGraph = Any  # type: ignore[misc, assignment]
 
 
 async def stream_workspace_events(
     workspace_id: str,
     event_type: str,
-    graph: CompiledStateGraph | None = None,
+    graph: Graph | None = None,
     request: Request | None = None,
 ) -> AsyncGenerator[dict[str, Any], None]:
-    """Yield filtered LangGraph updates as SSE events.
-
-    Parameters
-    ----------
-    workspace_id:
-        Identifier for the workspace whose events should be streamed.
-    event_type:
-        The event category to forward (``"state"``, ``"action"`` or ``"citation"``).
-    """
+    """Yield filtered graph updates as SSE events."""
 
     if graph is None and request is not None:
         graph = getattr(request.app.state, "graph", None)
@@ -42,26 +27,16 @@ async def stream_workspace_events(
     if graph is None:  # pragma: no cover - sanity guard
         return
 
-    async with create_checkpoint_saver() as saver:
-        async for update in graph.astream(
-            {},
-            cast(
-                RunnableConfig,
-                {
-                    "checkpoint": saver,
-                    "resume": True,
-                    "configurable": {"thread_id": workspace_id},
-                },
-            ),
-        ):
-            if update.get("type") != event_type:
-                # Only forward updates matching the requested channel.
-                continue
+    state = State(workspace_id=workspace_id)
+    async for update in graph.stream(state):
+        if update.get("type") != event_type:
+            continue
+        event = SseEvent(
+            type=event_type,
+            payload=update.get("payload", update),
+            timestamp=datetime.now(timezone.utc),
+        )
+        yield {"event": event_type, "data": event.model_dump_json()}
 
-            event = SseEvent(
-                type=event_type,
-                payload=update.get("payload", update),
-                timestamp=datetime.now(timezone.utc),
-            )
-            # ``event`` field allows clients to subscribe to specific SSE types.
-            yield {"event": event_type, "data": event.model_dump_json()}
+
+__all__ = ["stream_workspace_events"]

--- a/tests/test_cli_logging.py
+++ b/tests/test_cli_logging.py
@@ -1,6 +1,5 @@
 import logging
 import sys
-from contextlib import asynccontextmanager
 from types import ModuleType, SimpleNamespace
 
 
@@ -14,15 +13,7 @@ def test_main_logs_stream_boundaries(monkeypatch, caplog):
     sys.modules["agents.streaming"] = fake_streaming
 
     fake_orchestrator = ModuleType("core.orchestrator")
-    fake_orchestrator.graph = SimpleNamespace(
-        ainvoke=lambda *_a, **_k: {"result": "ok"}
-    )
-
-    @asynccontextmanager
-    async def fake_saver():
-        yield object()
-
-    fake_orchestrator.create_checkpoint_saver = fake_saver
+    fake_orchestrator.graph = SimpleNamespace(run=lambda *_a, **_k: {"result": "ok"})
     sys.modules["core.orchestrator"] = fake_orchestrator
 
     from cli import generate_lecture

--- a/tests/test_document_dag.py
+++ b/tests/test_document_dag.py
@@ -8,45 +8,24 @@ import os
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("PERPLEXITY_API_KEY", "test")
 
-# Stub langgraph modules before importing document_dag
-langgraph_graph = types.ModuleType("langgraph.graph")
+# Stub core.orchestrator before importing document_dag
+orchestrator = types.ModuleType("core.orchestrator")
 
 
-class _CompiledGraph:
-    def __init__(self, nodes):
+class _Graph:
+    def __init__(self, nodes, edges, conditionals):
         self.nodes = nodes
 
-    async def ainvoke(self, state):
+    async def run(self, state):
         await self.nodes["Researcher-Web"](state)
         await self.nodes["Content-Weaver"](state)
         await self.nodes["Pedagogy-Critic"](state)
 
 
-class _StateGraph:
-    def __init__(self, _state):
-        self.nodes: dict[str, callable] = {}
-
-    def add_node(self, name, fn, streams=None):  # noqa: D401 - stub
-        self.nodes[name] = fn
-
-    def add_edge(self, *_args, **_kwargs):
-        pass
-
-    def add_conditional_edges(self, *_args, **_kwargs):
-        pass
-
-    def compile(self):
-        return _CompiledGraph(self.nodes)
-
-
-langgraph_graph.StateGraph = _StateGraph
-langgraph_graph.START = "START"
-langgraph_graph.END = "END"
-langgraph_state = types.ModuleType("langgraph.graph.state")
-langgraph_state.CompiledStateGraph = _CompiledGraph
-sys.modules["langgraph"] = types.ModuleType("langgraph")
-sys.modules["langgraph.graph"] = langgraph_graph
-sys.modules["langgraph.graph.state"] = langgraph_state
+orchestrator.Graph = _Graph
+orchestrator.START = "START"
+orchestrator.END = "END"
+sys.modules["core.orchestrator"] = orchestrator
 
 
 # Stub policy

--- a/tests/test_generate_lecture.py
+++ b/tests/test_generate_lecture.py
@@ -5,26 +5,20 @@ from __future__ import annotations
 import asyncio
 import sys
 import types
-from contextlib import asynccontextmanager
 
 
 def test_generate(monkeypatch):
     """_generate returns final graph state."""
 
-    async def fake_ainvoke(payload, config=None):  # type: ignore[unused-argument]
-        assert payload["prompt"] == "topic"
-        return {"title": "Test"}
+    async def fake_run(state):  # type: ignore[unused-argument]
+        state.title = "Test"
 
-    fake_graph = types.SimpleNamespace(ainvoke=fake_ainvoke)
-
-    @asynccontextmanager
-    async def fake_saver():
-        yield object()
+    fake_graph = types.SimpleNamespace(run=fake_run)
 
     monkeypatch.setitem(
         sys.modules,
         "core.orchestrator",
-        types.SimpleNamespace(graph=fake_graph, create_checkpoint_saver=fake_saver),
+        types.SimpleNamespace(graph=fake_graph),
     )
 
     from cli.generate_lecture import _generate


### PR DESCRIPTION
## Summary
- implement lightweight DAG-based orchestrator and graph runner
- adapt document DAG, regeneration, CLI and SSE to new orchestrator
- adjust tests for custom orchestration and remove checkpoint saver

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(failed: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /pypi/aiosqlite/0.21.0/json (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)'))))*
- `pytest` *(errors: ModuleNotFoundError: No module named 'pydantic_settings', ...)*

------
https://chatgpt.com/codex/tasks/task_e_6894118829bc832bb2136cdfad22fa1d