### PR TITLE
refactor: require core dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lecture Builder Agent
 
-A local-first, multi-agent system that generates high‑quality, university‑grade lecture and workshop outlines (with supporting materials) from a single topic prompt. Agents are defined with Pydantic‑AI models and coordinated by a custom Python orchestrator. The system integrates OpenAI o4‑mini/o3 models, pluggable web search (Perplexity Sonar or Tavily), and a React‑based UX. Full state, citations, logs, and intermediates persist in SQLite (with optional Postgres fallback). Observability is handled by Logfire. Exports include Markdown, DOCX, and PDF.
+A local-first, multi-agent system that generates high‑quality, university‑grade lecture and workshop outlines (with supporting materials) from a single topic prompt. Agents are defined with Pydantic‑AI models and coordinated by a custom Python orchestrator. The system integrates OpenAI o4‑mini/o3 models, pluggable web search (Perplexity Sonar or Tavily), and a React‑based UX. Full state, citations, logs, and intermediates persist in SQLite or Postgres. Observability is handled by Logfire. Exports include Markdown, DOCX, and PDF.
 
 ---
 
@@ -44,7 +44,7 @@ A local-first, multi-agent system that generates high‑quality, university‑gr
 - **Robust Citations**: Pluggable Perplexity or Tavily search, citation metadata stored in SQLite, Creative Commons and university domain filtering.
 - **Local-First**: Operates offline using cached corpora and fallback to local dense retrieval.
 - **Flexible Exports**: Markdown (canonical), DOCX (python-docx), PDF (WeasyPrint), with cover page, TOC, and bibliography.
-- **Audit & Governance**: Immutable action logs, SHA‑256 state hashes, role‑based access, optional database encryption.
+- **Audit & Governance**: Immutable action logs, SHA‑256 state hashes, role‑based access, database encryption.
 
 ---
 
@@ -62,7 +62,7 @@ The system comprises:
    - **Exporter**: Renders final deliverables.
 
 3. **Web UX**: React + Tailwind, SSE-driven, panels for document, log, sources, and controls.
-4. **Storage Layer**: SQLite for state, logs, citations; optional Postgres via repository abstraction.
+4. **Storage Layer**: SQLite or Postgres for state, logs, citations via repository abstraction.
 5. **Export Pipeline**: Pandoc-ready Markdown, python-docx, WeasyPrint PDF.
 
 ### Stream Channels

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -51,7 +51,7 @@ This document provides a **comprehensive** and **explicit** description of the L
 3. **Retrieval Layer**
    - **ChatPerplexity (Sonar model)**: LangChain wrapper with API key support
    - **Cache Manager**: reads/writes to `retrieval_cache` table
-   - **Dense Retriever**: optional fallback using `faiss` index of CC-BY abstracts
+   - **Dense Retriever**: fallback using `faiss` index of CC-BY abstracts
 
 4. **Synthesis Layer**
    - **LangChain ChatOpenAI**: wraps chat completions with streaming
@@ -67,7 +67,7 @@ This document provides a **comprehensive** and **explicit** description of the L
    - **MarkdownRenderer**: Jinja templates
    - **DocxRenderer**: `python-docx` templates
    - **PdfRenderer**: WeasyPrint with MathJax pre-render
-   - **Signer**: optional GPG signing of ZIP manifest
+   - **Signer**: GPG signing of ZIP manifest
 
 7. **Storage Layer**
    - **SQLite / Postgres**: `state_snapshots`, `citations`, `action_log`, `documents`, `critique_report`, `factcheck_report`

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -144,7 +144,7 @@ Risk assessment assumes default deployment in a secure network.
 - **Platform:** GitHub Actions or GitLab CI in isolated runner
 - **Checks:** SAST (Bandit for Python), dependency audit (`npm audit`, `pip-audit`), container scan (Trivy)
 - **Secrets in CI:** Stored in encrypted secrets store; never printed in logs
-- **Branch Protection:** Require code review, status checks, signed commits optional
+- **Branch Protection:** Require code review, status checks, signed commits
 
 ---
 

--- a/src/agents/agent_wrapper.py
+++ b/src/agents/agent_wrapper.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 from types import SimpleNamespace
 from typing import Any, Dict, Optional
 
@@ -80,21 +79,17 @@ def init_chat_model(**overrides: Any) -> Optional[PydanticAIChatModel]:
     if model_id in _MODEL_CACHE:
         return _MODEL_CACHE[model_id]
 
-    try:
-        if provider_name == "perplexity":
-            pplx_api_key = overrides.pop("pplx_api_key", settings.perplexity_api_key)
-            provider = OpenAIProvider(
-                base_url="https://api.perplexity.ai", api_key=pplx_api_key
-            )
-        else:
-            provider = OpenAIProvider()
+    if provider_name == "perplexity":
+        pplx_api_key = overrides.pop("pplx_api_key", settings.perplexity_api_key)
+        provider = OpenAIProvider(
+            base_url="https://api.perplexity.ai", api_key=pplx_api_key
+        )
+    else:
+        provider = OpenAIProvider()
 
-        model = PydanticAIChatModel(model_name, provider)
-        _MODEL_CACHE[model_id] = model
-        return model
-    except Exception:  # pragma: no cover - optional dependencies
-        logging.exception("Failed to initialize chat model")
-        return None
+    model = PydanticAIChatModel(model_name, provider)
+    _MODEL_CACHE[model_id] = model
+    return model
 
 
 __all__ = ["init_chat_model", "clear_model_cache"]

--- a/src/agents/streaming.py
+++ b/src/agents/streaming.py
@@ -1,4 +1,4 @@
-"""Utilities for emitting LangGraph stream events with optional fallbacks."""
+"""Utilities for emitting LangGraph stream events."""
 
 from __future__ import annotations
 

--- a/src/config.py
+++ b/src/config.py
@@ -8,21 +8,10 @@ from __future__ import annotations
 import json
 from functools import lru_cache
 from pathlib import Path
-from typing import Any
 
 from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
-
-try:  # pragma: no cover - optional dependency
-    from dotenv import load_dotenv as _load_dotenv
-except Exception:  # pragma: no cover - when python-dotenv is not installed
-
-    def _load_dotenv(*_args: Any, **_kwargs: Any) -> bool:  # type: ignore[misc]
-        """Fallback ``load_dotenv`` that does nothing when dependency missing."""
-        return False
-
-
-load_dotenv = _load_dotenv
+from dotenv import load_dotenv
 
 # Load environment variables from a `.env` file if present.
 load_dotenv()

--- a/src/export/pdf_exporter.py
+++ b/src/export/pdf_exporter.py
@@ -6,10 +6,7 @@ from html import escape
 from pathlib import Path
 from typing import Optional
 
-try:  # pragma: no cover - optional dependency may be missing
-    from weasyprint import HTML  # type: ignore
-except Exception:  # pragma: no cover - fallback when WeasyPrint isn't available
-    HTML = None  # type: ignore
+from weasyprint import HTML  # type: ignore
 
 from .markdown_exporter import MarkdownExporter
 
@@ -89,14 +86,7 @@ class PdfExporter:
     def render_pdf(html: str) -> bytes:
         """Render HTML content into PDF bytes.
 
-        The original implementation depends on :mod:`weasyprint`, which in turn
-        requires native libraries such as ``gobject`` that are not available in
-        the execution environment of these kata-style tests.  Importing
-        WeasyPrint in such an environment raises an :class:`OSError` during
-        module import.  To keep the exporter usable and the tests hermetic we
-        provide a tiny pure-Python fallback that generates a minimal PDF
-        document.  The resulting bytes still begin with ``%PDF`` so existing
-        callers continue to work, albeit without full PDF rendering.
+        Relies on :mod:`weasyprint` to render a styled PDF document.
 
         Args:
             html: The HTML representation of the document.
@@ -104,9 +94,5 @@ class PdfExporter:
         Returns:
             The binary PDF data.
         """
-
-        if HTML is None:
-            body = html.encode("utf-8")
-            return b"%PDF-1.4\n%" + body + b"\n%%EOF"
 
         return HTML(string=html).write_pdf()

--- a/src/observability.py
+++ b/src/observability.py
@@ -7,6 +7,7 @@ import os
 from typing import TYPE_CHECKING
 
 import logfire
+from loguru import logger as loguru_logger
 
 if TYPE_CHECKING:  # pragma: no cover - import for type checking only
     from fastapi import FastAPI
@@ -28,13 +29,7 @@ def init_observability() -> None:
     logfire.instrument_sqlalchemy()
     logfire.instrument_sqlite3()
     logfire.instrument_system_metrics()
-
-    try:  # pragma: no cover - loguru is optional at runtime
-        from loguru import logger as loguru_logger
-    except Exception:  # pragma: no cover - dependency missing
-        pass
-    else:
-        loguru_logger.add(logfire.loguru_handler())
+    loguru_logger.add(logfire.loguru_handler())
 
 
 def instrument_app(app: "FastAPI") -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 """Pytest configuration and lightweight dependency stubs.
 
 Adds the project's ``src`` directory to ``sys.path`` and provides small
-stand-ins for optional third-party packages so tests can execute without
+stand-ins for selected third-party packages so tests can execute without
 network access or heavyweight installations.
 """
 
@@ -23,7 +23,7 @@ if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
 
 # ---------------------------------------------------------------------------
-# Lightweight stubs for optional third-party dependencies
+# Lightweight stubs for third-party dependencies
 # ---------------------------------------------------------------------------
 
 # Provide dummy environment keys expected by the settings module.
@@ -60,29 +60,6 @@ run_helpers_stub = types.ModuleType("langsmith.run_helpers")
 run_helpers_stub.trace = lambda *a, **k: contextlib.nullcontext()  # type: ignore[attr-defined]
 sys.modules.setdefault("langsmith.run_helpers", run_helpers_stub)
 
-# Minimal loguru stub to satisfy the logging module.
-
-
-class _Logger:
-    def remove(self, *a, **k) -> None:  # pragma: no cover - simple stub
-        pass
-
-    def add(self, *a, **k) -> None:  # pragma: no cover - simple stub
-        pass
-
-    def bind(self, **_k):  # pragma: no cover - simple stub
-        return self
-
-    def info(self, *a, **k) -> None:  # pragma: no cover - simple stub
-        pass
-
-    def exception(self, *a, **k) -> None:  # pragma: no cover - simple stub
-        pass
-
-
-loguru_stub = types.ModuleType("loguru")
-loguru_stub.logger = _Logger()  # type: ignore[attr-defined]
-sys.modules.setdefault("loguru", loguru_stub)
 
 # Provide an ``opentelemetry`` tracer that acts as a no-op context manager.
 


### PR DESCRIPTION
## Summary
- remove conditional imports so loguru, python-dotenv and WeasyPrint are always required
- drop loguru test stub and optional wording from documentation
- clarify docs to describe Postgres, faiss and GPG features as standard components

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` (fails: SSLCertVerificationError)
- `pytest` (fails: ImportError: cannot import name 'policy_retry_on_low_confidence' from 'core.policies')


------
https://chatgpt.com/codex/tasks/task_e_68942a3ebff0832bbb082ff9603f3b55