### PR TITLE
feat: enable logfire auto tracing

### DIFF
--- a/src/cli/generate_lecture.py
+++ b/src/cli/generate_lecture.py
@@ -1,5 +1,6 @@
 """Command-line interface for generating lecture material."""
 
+# ruff: noqa: E402
 from __future__ import annotations
 
 import argparse
@@ -8,11 +9,15 @@ import json
 import logging
 from typing import Any, Dict
 
+import logfire
+from observability import install_auto_tracing
+
+install_auto_tracing()
+
 from agents.streaming import stream_messages
 from core.orchestrator import graph
 from core.state import State
 from config import load_settings
-import logfire
 
 
 def parse_args() -> argparse.Namespace:

--- a/src/observability.py
+++ b/src/observability.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import logfire
@@ -11,6 +12,25 @@ from loguru import logger as loguru_logger
 
 if TYPE_CHECKING:  # pragma: no cover - import for type checking only
     from fastapi import FastAPI
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent
+
+
+def install_auto_tracing() -> None:
+    """Install Logfire auto-tracing for project modules."""
+
+    def _in_project(module: logfire.AutoTraceModule) -> bool:
+        filename = module.filename
+        return filename is not None and Path(filename).resolve().is_relative_to(
+            PROJECT_ROOT
+        )
+
+    logfire.install_auto_tracing(
+        modules=_in_project,
+        min_duration=0,
+        check_imported_modules="warn",
+    )
 
 
 def init_observability() -> None:
@@ -22,6 +42,7 @@ def init_observability() -> None:
     token = os.getenv("LOGFIRE_API_KEY")
     project = os.getenv("LOGFIRE_PROJECT")
 
+    install_auto_tracing()
     logfire.configure(token=token, service_name=project)
     logging.getLogger().addHandler(logfire.LogfireLoggingHandler())
     logfire.instrument_pydantic()


### PR DESCRIPTION
## Summary
- install logfire auto tracing for in-repo modules
- initialize auto tracing early in CLI and web setups

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: HTTPSConnectionPool host='pypi.org' certificate verify failed)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*


------
https://chatgpt.com/codex/tasks/task_e_68942d200c90832ba19093c9bc9d5bfb