### PR TITLE
Scope Logfire auto tracing to repository code

### DIFF
--- a/src/observability.py
+++ b/src/observability.py
@@ -14,17 +14,17 @@ if TYPE_CHECKING:  # pragma: no cover - import for type checking only
     from fastapi import FastAPI
 
 
-PROJECT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = Path(__file__).resolve().parents[1]
+# Only trace modules that live under the repository's ``src`` directory.
+SRC_DIR = REPO_ROOT / "src"
 
 
 def install_auto_tracing() -> None:
-    """Install Logfire auto-tracing for project modules."""
+    """Install Logfire auto-tracing restricted to repository modules."""
 
     def _in_project(module: logfire.AutoTraceModule) -> bool:
         filename = module.filename
-        return filename is not None and Path(filename).resolve().is_relative_to(
-            PROJECT_ROOT
-        )
+        return filename is not None and Path(filename).resolve().is_relative_to(SRC_DIR)
 
     logfire.install_auto_tracing(
         modules=_in_project,


### PR DESCRIPTION
## Summary
- restrict Logfire's auto tracing to modules within this repo's src tree
- document scoping for clarity

## Testing
- `black src/observability.py`
- `ruff check src/observability.py`
- `mypy src/observability.py`
- `bandit -r src/observability.py -ll`
- `pip-audit` *(fails: SSL certificate verify failed)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68944e1f12c4832ba55ada625ef74fb3