### PR TITLE
Refactor document DAG to sequential execution

### DIFF
--- a/src/core/document_dag.py
+++ b/src/core/document_dag.py
@@ -1,39 +1,27 @@
-"""Section-wise document generation using a simple DAG."""
+"""Section-wise document generation using sequential nodes."""
 
 from __future__ import annotations
+
+from typing import Awaitable, Callable
 
 from agents.content_weaver import run_content_weaver
 from agents.pedagogy_critic import run_pedagogy_critic
 from agents.planner import run_planner
 from agents.researcher_web_node import run_researcher_web
-from core.orchestrator import END, START, Graph
 from core.policies import policy_retry_on_critic_failure
 from core.state import State
 
 
-def _build_section_graph(section_id: int) -> Graph:
-    """Construct a small graph to process a single outline section."""
+NodeCallable = Callable[[State], Awaitable[object]]
+
+
+def _build_section_graph(section_id: int) -> list[NodeCallable]:
+    """Return the callables needed to process a single outline section."""
 
     async def _draft(state: State) -> None:
         await run_content_weaver(state, section_id=section_id)
 
-    nodes = {
-        "Researcher-Web": run_researcher_web,
-        "Content-Weaver": _draft,
-        "Pedagogy-Critic": run_pedagogy_critic,
-    }
-    edges = {
-        START: ["Researcher-Web"],
-        "Researcher-Web": ["Content-Weaver"],
-        "Content-Weaver": ["Pedagogy-Critic"],
-    }
-    conditionals = {
-        "Pedagogy-Critic": (
-            policy_retry_on_critic_failure,
-            {True: "Content-Weaver", False: END},
-        )
-    }
-    return Graph(nodes, edges, conditionals)
+    return [run_researcher_web, _draft, run_pedagogy_critic]
 
 
 async def run_document_dag(state: State, skip_plan: bool = False) -> State:
@@ -43,8 +31,13 @@ async def run_document_dag(state: State, skip_plan: bool = False) -> State:
         await run_planner(state)
 
     for idx, _ in enumerate(state.outline.steps):
-        section_graph = _build_section_graph(idx)
-        await section_graph.run(state)
+        researcher, draft, critic = _build_section_graph(idx)
+        await researcher(state)
+        while True:
+            await draft(state)
+            report = await critic(state)
+            if not policy_retry_on_critic_failure(report, state):
+                break
         if state.modules:
             state.outline.steps[idx] = (
                 state.modules[-1].title or state.outline.steps[idx]


### PR DESCRIPTION
## Summary
- replace per-section graphs with a simple list of node callables
- execute document generation sequentially with retry logic
- add tests for section processing and critic-triggered retries

## Testing
- `ruff check src/core/document_dag.py tests/test_document_dag.py`
- `mypy src/core/document_dag.py tests/test_document_dag.py`
- `bandit -r src/core/document_dag.py -ll`
- `pytest tests/test_document_dag.py`
- `pip-audit` *(fails: SSLCertVerificationError: certificate verify failed: Missing Authority Key Identifier)*

------
https://chatgpt.com/codex/tasks/task_e_68947d812c70832b94303f9a9fc72794