### PR TITLE
refactor: streamline regeneration pipeline

### DIFF
--- a/src/web/sse.py
+++ b/src/web/sse.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from fastapi import Request  # type: ignore[import-not-found]
 
-from core.orchestrator import Graph
+from core.orchestrator import GraphOrchestrator
 from core.state import State
 from web.schemas.sse import SseEvent  # type: ignore[import-not-found]
 
@@ -16,7 +16,7 @@ from web.schemas.sse import SseEvent  # type: ignore[import-not-found]
 async def stream_workspace_events(
     workspace_id: str,
     event_type: str,
-    graph: Graph | None = None,
+    graph: GraphOrchestrator | None = None,
     request: Request | None = None,
 ) -> AsyncGenerator[dict[str, Any], None]:
     """Yield filtered graph updates as SSE events."""


### PR DESCRIPTION
## Summary
- call Content Weaver directly during regeneration without Graph invocation
- assemble regeneration flow using `build_main_flow` and `GraphOrchestrator`
- drop deprecated `Graph` imports in web SSE utilities

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: Missing Authority Key Identifier)*
- `pytest` *(fails: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6894801ffc84832b8f9411f607e45f62