### PR TITLE
Refactor SSE streaming to iterate workflow directly

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -807,8 +807,8 @@ def from_schema(weave: WeaveResult) -> str:
 ### H1. SSE Backend
 
 1. **`src/web/sse.py`**
-   - `stream_workspace_events(workspace_id: str) -> AsyncGenerator[SseEvent]`
-     • **What**: connect to the orchestrator's async event stream for the given workspace, wrap each update in an `SseEvent` namedtuple/dict (`type`, `payload`, `timestamp`).
+   - `stream_workspace_events(workspace_id: str, event_type: str) -> AsyncGenerator[SseEvent]`
+     • **What**: iterate over the main workflow and emit filtered `SseEvent` messages (`type`, `payload`, `timestamp`).
      • **Why**: centralises SSE logic so routes stay thin.
 
 1. **`src/web/schemas/sse.py`**
@@ -822,8 +822,8 @@ def from_schema(weave: WeaveResult) -> str:
 
      ```python
      @app.get("/stream/{workspace}", response_model=None)
-     async def stream_events(workspace: str):
-         return EventSourceResponse(stream_workspace_events(workspace))
+    async def stream_events(workspace: str):
+        return EventSourceResponse(stream_workspace_events(workspace, "state"))
      ```
 
      • **Why**: binds SSE generator to HTTP endpoint.

--- a/src/web/routes/stream.py
+++ b/src/web/routes/stream.py
@@ -1,8 +1,8 @@
-"""Streaming endpoints exposing LangGraph updates by channel."""
+"""Streaming endpoints exposing workflow updates by channel."""
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Request  # type: ignore[import-not-found]
+from fastapi import APIRouter  # type: ignore[import-not-found]
 from sse_starlette.sse import EventSourceResponse  # type: ignore[import-not-found]
 
 from web.sse import stream_workspace_events  # type: ignore[import-not-found]
@@ -11,27 +11,21 @@ router = APIRouter()
 
 
 @router.get("/stream/{workspace}/state", response_model=None)
-async def stream_state(request: Request, workspace: str) -> EventSourceResponse:
+async def stream_state(workspace: str) -> EventSourceResponse:
     """Stream state snapshot events for ``workspace``."""
 
-    return EventSourceResponse(
-        stream_workspace_events(workspace, "state", graph=request.app.state.graph)
-    )
+    return EventSourceResponse(stream_workspace_events(workspace, "state"))
 
 
 @router.get("/stream/{workspace}/actions", response_model=None)
-async def stream_actions(request: Request, workspace: str) -> EventSourceResponse:
+async def stream_actions(workspace: str) -> EventSourceResponse:
     """Stream action log events for ``workspace``."""
 
-    return EventSourceResponse(
-        stream_workspace_events(workspace, "action", graph=request.app.state.graph)
-    )
+    return EventSourceResponse(stream_workspace_events(workspace, "action"))
 
 
 @router.get("/stream/{workspace}/citations", response_model=None)
-async def stream_citations(request: Request, workspace: str) -> EventSourceResponse:
+async def stream_citations(workspace: str) -> EventSourceResponse:
     """Stream citation events for ``workspace``."""
 
-    return EventSourceResponse(
-        stream_workspace_events(workspace, "citation", graph=request.app.state.graph)
-    )
+    return EventSourceResponse(stream_workspace_events(workspace, "citation"))

--- a/src/web/sse.py
+++ b/src/web/sse.py
@@ -6,31 +6,38 @@ from collections.abc import AsyncGenerator
 from datetime import datetime, timezone
 from typing import Any
 
-from fastapi import Request  # type: ignore[import-not-found]
-
-from core.orchestrator import GraphOrchestrator
+from core.orchestrator import build_main_flow
 from core.state import State
 from web.schemas.sse import SseEvent  # type: ignore[import-not-found]
 
 
 async def stream_workspace_events(
-    workspace_id: str,
-    event_type: str,
-    graph: GraphOrchestrator | None = None,
-    request: Request | None = None,
+    workspace_id: str, event_type: str
 ) -> AsyncGenerator[dict[str, Any], None]:
-    """Yield filtered graph updates as SSE events."""
-
-    if graph is None and request is not None:
-        graph = getattr(request.app.state, "graph", None)
-
-    if graph is None:  # pragma: no cover - sanity guard
-        return
+    """Yield filtered pipeline updates as SSE events."""
 
     state = State(workspace_id=workspace_id)
-    async for update in graph.stream(state):
-        if update.get("type") != event_type:
-            continue
+
+    async def _generate() -> AsyncGenerator[dict[str, Any], None]:
+        flow = build_main_flow()
+        lookup = {n.name: n for n in flow}
+        current = flow[0]
+        while current:
+            action_event = {"type": "action", "payload": current.name}
+            if action_event["type"] == event_type:
+                yield action_event
+            result = await current.fn(state)
+            state_event = {"type": "state", "payload": state.to_dict()}
+            if state_event["type"] == event_type:
+                yield state_event
+            next_name = current.next
+            if current.condition is not None:
+                next_name = current.condition(result, state)
+            if next_name is None:
+                break
+            current = lookup[next_name]
+
+    async for update in _generate():
         event = SseEvent(
             type=event_type,
             payload=update.get("payload", update),


### PR DESCRIPTION
## Summary
- generate SSE events directly from `build_main_flow` and filter inside the stream
- drop graph parameter from SSE endpoint routes and update docs

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: SSL certificate verify failed)*
- `pytest` *(fails: missing modules agents.researcher_web_node, persistence)*

------
https://chatgpt.com/codex/tasks/task_e_689482e80eb8832b81d40437dfbd6e6e