### PR TITLE
docs: document logfire config and drop langsmith stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,11 @@ The command reads `alembic.ini` and writes migration scripts to
 
 ## Configuration & Environment Variables
 
+All runtime configuration is supplied via environment variables or a `.env`
+file. Secret tokens (API keys, project identifiers, etc.) must be sourced from
+your secret manager and never hard-coded. The legacy LangSmith variables have
+been replaced by Logfire's settings.
+
 | Variable             | Description                               | Default                                  |
 | -------------------- | ----------------------------------------- | ---------------------------------------- |
 | `OPENAI_API_KEY`     | API key for OpenAI                        | (required)                               |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ network access or heavyweight installations.
 
 from __future__ import annotations
 
-import contextlib
 import importlib
 import os
 import sys
@@ -43,22 +42,6 @@ setattr(
     lambda _name: types.SimpleNamespace(encode=lambda s: []),
 )  # type: ignore[attr-defined]
 sys.modules.setdefault("tiktoken", tiktoken_stub)
-
-# Basic LangSmith client and tracing helpers used for instrumentation.
-
-
-class _Client:  # pragma: no cover - simple placeholder
-    def __init__(self, *args, **kwargs) -> None:
-        pass
-
-
-langsmith_stub = types.ModuleType("langsmith")
-langsmith_stub.Client = _Client  # type: ignore[attr-defined]
-sys.modules.setdefault("langsmith", langsmith_stub)
-
-run_helpers_stub = types.ModuleType("langsmith.run_helpers")
-run_helpers_stub.trace = lambda *a, **k: contextlib.nullcontext()  # type: ignore[attr-defined]
-sys.modules.setdefault("langsmith.run_helpers", run_helpers_stub)
 
 
 # Provide an ``opentelemetry`` tracer that acts as a no-op context manager.


### PR DESCRIPTION
## Summary
- document environment variable usage and Logfire settings
- drop obsolete LangSmith stub from test setup

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: SSLCertVerificationError)*
- `pytest` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68948b8db21c832bac6883ad71cab08c