### PR TITLE
docs: add orchestrator examples and migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ A local-first, multi-agent system that generates high‑quality, university‑gr
     - [Persistence \& Versioning](#persistence--versioning)
     - [Frontend UX](#frontend-ux)
     - [Exporters](#exporters)
+  - [Examples](#examples)
+    - [Invoking the Orchestrator](#invoking-the-orchestrator)
+    - [Working with Pydantic Models](#working-with-pydantic-models)
   - [Storage Options](#storage-options)
     - [Database Migrations](#database-migrations)
   - [Configuration \& Environment Variables](#configuration--environment-variables)
@@ -210,6 +213,32 @@ cp .env.example .env
 - DOCX: generated via `src/export/docx_exporter.py`.
 - PDF: headless WeasyPrint configured in `src/export/pdf_exporter.py`.
 
+## Examples
+
+### Invoking the Orchestrator
+
+```python
+from core.orchestrator import GraphOrchestrator, build_main_flow
+from core.state import State
+
+state = State(prompt="Explain quantum computing basics")
+orch = GraphOrchestrator(build_main_flow())
+await orch.run(state)
+```
+
+### Working with Pydantic Models
+
+```python
+from agents.models import Activity, WeaveResult
+
+model = WeaveResult(
+    title="Intro to AI",
+    learning_objectives=["Define artificial intelligence"],
+    activities=[Activity(type="lecture", description="Overview", duration_min=30)],
+    duration_min=60,
+)
+```
+
 ---
 
 ## Storage Options
@@ -317,3 +346,4 @@ This project is licensed under the [MIT License](./LICENSE).
 - **TEST_PLAN.md** — Test cases, performance benchmarks, and QA checklist
 - **GOVERNANCE.md** — SLOs, metrics dashboard configuration, and audit procedures
 - [**CLI_REFERENCE.md**](./docs/CLI_REFERENCE.md) — Commands for running, testing, and maintenance tasks
+- [**MIGRATION_GUIDE.md**](./docs/MIGRATION_GUIDE.md) — Rationale and API changes for the new orchestrator and models

--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -1,0 +1,38 @@
+# Migration Guide
+
+This guide helps contributors move to the graph-based orchestrator and typed Pydantic models.
+
+## Rationale
+
+- Strong typing via Pydantic provides clearer contracts between agents.
+- The `GraphOrchestrator` offers predictable node execution and better observability.
+- Shared models reduce duplication and ease validation across the system.
+
+## Major API Differences
+
+- `GraphOrchestrator` replaces the previous `run_workflow` helper.
+- Workflows are defined through `build_main_flow()` which returns a list of `Node` objects.
+- State is now managed by the Pydantic `State` dataclass instead of free-form dictionaries.
+- Agent inputs and outputs are expressed as Pydantic models in `src/agents/models.py`.
+
+## Migration Steps
+
+1. Import and instantiate the orchestrator:
+
+   ```python
+   from core.orchestrator import GraphOrchestrator, build_main_flow
+   orch = GraphOrchestrator(build_main_flow())
+   ```
+
+2. Replace dictionary state with the typed model:
+
+   ```python
+   from core.state import State
+   state = State(prompt=old_state["prompt"])
+   await orch.run(state)
+   ```
+
+3. Update agent calls to use the models defined in `agents.models` rather than raw dicts.
+4. When persisting data, use `.model_dump()` instead of manually constructing dictionaries.
+
+Following these steps will bring extensions and custom nodes in line with the new orchestrator and model architecture.


### PR DESCRIPTION
## Summary
- document how to invoke the GraphOrchestrator and Pydantic models
- add migration guide outlining new orchestrator and model APIs

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: Missing Authority Key Identifier SSL certificate verification failure)*

------
https://chatgpt.com/codex/tasks/task_e_68949330ea44832ba6bc846f9c9cf045