### PR TITLE
chore: run import sorting

### DIFF
--- a/src/agents/content_weaver.py
+++ b/src/agents/content_weaver.py
@@ -6,9 +6,10 @@ import json
 import logging
 from typing import AsyncGenerator
 
+from pydantic import ValidationError
+
 from core.state import Module, State
 from prompts import get_prompt
-from pydantic import ValidationError
 
 from .models import WeaveResult
 from .streaming import stream_debug, stream_messages

--- a/src/agents/pedagogy_critic.py
+++ b/src/agents/pedagogy_critic.py
@@ -11,6 +11,8 @@ from collections import Counter
 from dataclasses import dataclass
 from typing import Callable, Dict, List, cast
 
+from pydantic import BaseModel, ValidationError
+
 import config
 from agents.models import Activity
 from core.state import State
@@ -21,7 +23,6 @@ from models import (
     CritiqueReport,
 )
 from prompts import get_prompt
-from pydantic import BaseModel, ValidationError
 
 # Bloom's taxonomy levels used for coverage analysis
 BLOOM_LEVELS: List[str] = [

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -6,9 +6,10 @@ import logging
 import re
 from dataclasses import dataclass
 
+from pydantic import BaseModel, ValidationError
+
 from core.state import Outline, State
 from prompts import get_prompt
-from pydantic import BaseModel, ValidationError
 
 from .streaming import stream_debug, stream_messages
 

--- a/src/agents/researcher_web.py
+++ b/src/agents/researcher_web.py
@@ -9,10 +9,10 @@ from typing import List, Optional, Protocol
 from urllib.parse import urlparse
 
 import httpx
+from pydantic import BaseModel
 
 from persistence import get_db_session
 from persistence.repositories.retrieval_cache_repo import RetrievalCacheRepo
-from pydantic import BaseModel
 
 from .dense_retriever import DenseRetriever
 from .offline_cache import load_cached_results, save_cached_results

--- a/src/config.py
+++ b/src/config.py
@@ -10,9 +10,8 @@ from functools import lru_cache
 from pathlib import Path
 
 from dotenv import load_dotenv
-from pydantic_settings import BaseSettings, SettingsConfigDict
-
 from pydantic import field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # Load environment variables from a `.env` file if present.
 load_dotenv()

--- a/src/core/state.py
+++ b/src/core/state.py
@@ -6,10 +6,10 @@ from dataclasses import field as dc_field
 from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
+from pydantic import BaseModel, Field, HttpUrl
 from pydantic.dataclasses import dataclass
 
 from models import CritiqueReport, FactCheckReport
-from pydantic import BaseModel, Field, HttpUrl
 
 
 class Citation(BaseModel):

--- a/src/web/api/export_endpoints.py
+++ b/src/web/api/export_endpoints.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from pathlib import Path
 
 from fastapi import FastAPI, Request, Response
+from pydantic import BaseModel
 
 from export.docx_exporter import DocxExporter
 from export.markdown_exporter import MarkdownExporter
 from export.metadata_exporter import export_citations_json
 from export.pdf_exporter import PdfExporter
 from export.zip_exporter import ZipExporter
-from pydantic import BaseModel
 
 
 class ExportStatus(BaseModel):

--- a/src/web/routes/entries.py
+++ b/src/web/routes/entries.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from fastapi import APIRouter
-
 from pydantic import BaseModel
 
 router = APIRouter()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,10 +1,10 @@
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 from pydantic_settings import SettingsError
 
 from config import Settings, load_env
-from pydantic import ValidationError
 
 
 def test_settings_loads_env(monkeypatch, tmp_path):

--- a/tests/test_content_weaver.py
+++ b/tests/test_content_weaver.py
@@ -9,10 +9,10 @@ import types
 from typing import Any
 
 import pytest
+from pydantic import ValidationError
 
 from agents import content_weaver
 from agents.content_weaver import RetryableError, WeaveResult
-from pydantic import ValidationError
 
 
 def test_call_openai_function_supplies_schema(monkeypatch: Any) -> None:

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import pytest
+from pydantic import ValidationError
 
 from core.state import (
     ActionLog,
@@ -11,7 +12,6 @@ from core.state import (
     increment_version,
     validate_state,
 )
-from pydantic import ValidationError
 
 
 def test_increment_version():


### PR DESCRIPTION
## Summary
- sort Python imports across modules and tests

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /pypi/bandit/1.8.6/json (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)'))))*
- `poetry run pytest` *(fails: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68954b2a219c832b882dfa5dc392279b