### PR TITLE
docs: mention auth planned for v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,8 @@ been replaced by Logfire's settings.
 
 ## Roadmap & Next Steps
 
+Authentication and authorization support is planned for v2.
+
 Refer to [ROADMAP.md](./docs/ROADMAP.md) for sprint plans and milestones.
 
 ---

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -48,6 +48,8 @@ Risk assessment assumes default deployment in a secure network.
 
 ## 3. Authentication & Authorization
 
+_These controls will be implemented in version 2._
+
 ### 3.1 API Authentication
 
 - **Mechanism:** JSON Web Tokens (JWT) signed with RS256


### PR DESCRIPTION
## Summary
- clarify roadmap with note that auth/authorization support is coming in v2
- annotate security guide that auth controls land in version 2

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLCertVerificationError)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_68972f6806cc832bbfb9e1b3727b9b8d