### PR TITLE
Complete StateRepo methods and update SQLite migrations

### DIFF
--- a/src/persistence/repos/state_repo.py
+++ b/src/persistence/repos/state_repo.py
@@ -53,7 +53,8 @@ class StateRepo:
     async def get_state_by_version(self, version: int) -> State:
         """Load a specific state version."""
         cur = await self._conn.execute(
-            "SELECT payload_json FROM state WHERE id = ?", (version,)
+            "SELECT payload_json FROM state WHERE version = ?",
+            (version,),
         )
         row = await cur.fetchone()
         await cur.close()
@@ -61,3 +62,10 @@ class StateRepo:
             raise ValueError(f"state version {version} not found")
         data = json.loads(row[0])
         return State.from_dict(data)
+
+    async def list_versions(self) -> list[int]:
+        """Return all persisted state versions sorted ascending."""
+        cur = await self._conn.execute("SELECT version FROM state ORDER BY version")
+        rows = await cur.fetchall()
+        await cur.close()
+        return [row[0] for row in rows]

--- a/src/persistence/sqlite.py
+++ b/src/persistence/sqlite.py
@@ -19,29 +19,49 @@ class AsyncSqliteSaver:
     _MIGRATIONS: tuple[str, ...] = (
         """
         CREATE TABLE IF NOT EXISTS state (
-            id TEXT PRIMARY KEY,
-            value TEXT NOT NULL
+            id INTEGER PRIMARY KEY,
+            payload_json TEXT NOT NULL,
+            version INTEGER NOT NULL,
+            updated_at TEXT NOT NULL
         );
         """,
         """
         CREATE TABLE IF NOT EXISTS documents (
-            id TEXT PRIMARY KEY,
-            content TEXT NOT NULL
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            state_id INTEGER NOT NULL,
+            parquet_blob BLOB NOT NULL,
+            created_at TEXT NOT NULL,
+            FOREIGN KEY(state_id) REFERENCES state(id)
         );
         """,
         """
         CREATE TABLE IF NOT EXISTS citations (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            document_id TEXT NOT NULL,
-            citation TEXT NOT NULL,
-            FOREIGN KEY(document_id) REFERENCES documents(id)
+            workspace_id TEXT NOT NULL,
+            url TEXT NOT NULL,
+            title TEXT NOT NULL,
+            retrieved_at TEXT NOT NULL,
+            licence TEXT NOT NULL,
+            PRIMARY KEY (workspace_id, url)
         );
         """,
         """
-        CREATE TABLE IF NOT EXISTS logs (
+        CREATE TABLE IF NOT EXISTS retrieval_cache (
+            query TEXT PRIMARY KEY,
+            results TEXT NOT NULL,
+            hit_count INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL
+        );
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS action_logs (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
-            message TEXT NOT NULL,
-            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            workspace_id TEXT NOT NULL,
+            agent_name TEXT NOT NULL,
+            input_hash TEXT NOT NULL,
+            output_hash TEXT NOT NULL,
+            tokens INTEGER NOT NULL,
+            cost REAL NOT NULL,
+            timestamp TEXT NOT NULL
         );
         """,
     )


### PR DESCRIPTION
## Summary
- add version listing helper and correct version-based lookups in `StateRepo`
- overhaul SQLite migrations with schemas for state, document blobs, citations, caches and action logs

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLError certificate verify failed)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'weasyprint')*


------
https://chatgpt.com/codex/tasks/task_e_689731587358832ba3189901d1536abd