### PR TITLE
feat: add streaming broker and state SSE

### DIFF
--- a/src/web/sse.py
+++ b/src/web/sse.py
@@ -6,41 +6,20 @@ from collections.abc import AsyncGenerator
 from datetime import datetime, timezone
 from typing import Any
 
-from core.orchestrator import build_main_flow
-from core.state import State
+from agents.streaming import subscribe
 from web.schemas.sse import SseEvent  # type: ignore[import-not-found]
 
 
 async def stream_workspace_events(
     workspace_id: str, event_type: str
 ) -> AsyncGenerator[dict[str, Any], None]:
-    """Yield filtered pipeline updates as SSE events."""
+    """Yield workspace ``event_type`` updates as SSE events."""
 
-    state = State(workspace_id=workspace_id)
-
-    async def _generate() -> AsyncGenerator[dict[str, Any], None]:
-        flow = build_main_flow()
-        lookup = {n.name: n for n in flow}
-        current = flow[0]
-        while current:
-            action_event = {"type": "action", "payload": current.name}
-            if action_event["type"] == event_type:
-                yield action_event
-            result = await current.fn(state)
-            state_event = {"type": "state", "payload": state.to_dict()}
-            if state_event["type"] == event_type:
-                yield state_event
-            next_name = current.next
-            if current.condition is not None:
-                next_name = current.condition(result, state)
-            if next_name is None:
-                break
-            current = lookup[next_name]
-
-    async for update in _generate():
+    channel = f"{workspace_id}:{event_type}"
+    async for payload in subscribe(channel):
         event = SseEvent(
             type=event_type,
-            payload=update.get("payload", update),
+            payload=payload,
             timestamp=datetime.now(timezone.utc),
         )
         yield {"event": event_type, "data": event.model_dump_json()}

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,4 +1,7 @@
+import asyncio
 import logging
+
+import pytest
 
 from agents import streaming
 
@@ -18,3 +21,16 @@ def test_stream_uses_fallback(caplog):
         streaming.stream("messages", "hi", fallback=fallback)
 
     assert "[messages] hi" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_stream_broadcasts_to_subscribers() -> None:
+    async def reader():
+        async for payload in streaming.subscribe("test"):
+            return payload
+
+    task = asyncio.create_task(reader())
+    await asyncio.sleep(0)
+    streaming.stream("test", "payload")
+    result = await asyncio.wait_for(task, 1)
+    assert result == "payload"


### PR DESCRIPTION
## Summary
- add in-memory pub/sub for agent streaming
- publish orchestrator action and state events
- stream workspace events over SSE

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLCertVerificationError)*
- `poetry run pytest` *(fails: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689731494c34832ba7609251af8f41f1