### PR TITLE
feat: run orchestrator and return identifiers

### DIFF
--- a/tests/test_control_routes.py
+++ b/tests/test_control_routes.py
@@ -25,7 +25,12 @@ spec.loader.exec_module(control_routes)
 def create_app() -> FastAPI:
     """Create a FastAPI app with the control router."""
 
+    class DummyGraph:
+        async def run(self, _state):
+            return _state
+
     app = FastAPI()
+    app.state.graph = DummyGraph()
     app.include_router(control_routes.router)
     return app
 
@@ -37,7 +42,7 @@ def test_control_endpoints() -> None:
 
     resp = client.post("/workspaces/abc/run", json={"topic": "unit"})
     assert resp.status_code == 201
-    assert "job_id" in resp.json()
+    assert resp.json() == {"job_id": "abc", "workspace_id": "abc"}
 
     resp = client.post("/workspaces/abc/pause")
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- start orchestration in `/workspaces/{workspace_id}/run`
- return workspace and job identifiers from run endpoint
- adjust control route tests with dummy orchestrator

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type src/web/routes/control.py`
- `poetry run isort --float-to-top --combine-star --order-by-type tests/test_control_routes.py`
- `poetry run black --preview --enable-unstable-feature string_processing src/web/routes/control.py`
- `poetry run black --preview --enable-unstable-feature string_processing tests/test_control_routes.py`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /pypi/bandit/1.8.6/json (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)')))*)
- `poetry run pytest` *(fails: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6897313a8a94832ba3967459862816c6