### PR TITLE
Fix Alembic URL and add migration check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,5 @@ jobs:
           cache: "poetry"
           cache-dependency-path: poetry.lock
       - run: poetry install --with dev --extras test --no-interaction --no-ansi
+      - run: poetry run alembic upgrade head
       - run: poetry run pytest --maxfail=1 --disable-warnings -q

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,6 +1,6 @@
 [alembic]
 script_location = migrations
-sqlalchemy.url = sqlite:///DATA_DIR/checkpoint.db
+sqlalchemy.url = sqlite:///workspace/checkpoint.db
 
 [loggers]
 keys = root,sqlalchemy,alembic


### PR DESCRIPTION
## Summary
- point alembic.ini at the workspace SQLite checkpoint
- ensure CI runs `alembic upgrade head`

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run mypy src/ tests/`
- `poetry run flake8 src/ tests/` *(fails: Command not found)*
- `poetry run bandit -r src -ll` *(fails: Command not found)*
- `poetry run pip-audit` *(fails: Command not found)*
- `poetry install --with dev --extras test --no-interaction --no-ansi` *(fails: All attempts to connect to pypi.org failed)*
- `poetry run pytest --maxfail=1 --disable-warnings -q` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*


------
https://chatgpt.com/codex/tasks/task_e_689733d710dc832bb539e5b7c570e396