### PR TITLE
feat: add health and readiness checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,14 +289,10 @@ been replaced by Logfire's settings.
 
 ## Logging & Tracing
 
-- **Logging:** JSON-formatted logs are emitted via Loguru. The helper
-  `core.logging.get_logger(job_id, user_id)` binds contextual identifiers so
-  downstream systems can correlate events.
-- **Tracing:** Logfire spans capture node execution details, including token
-  counts. OpenTelemetry instrumentation remains enabled for FastAPI and
+- **Logfire:** Handles structured JSON logs, spans, and metrics. Use
+  `core.logging.get_logger(job_id, user_id)` to bind contextual identifiers for
+  correlation. OpenTelemetry instrumentation remains enabled for FastAPI and
   outbound HTTP requests.
-- **Metrics:** High-volume nodes record token usage and latency through
-  Logfire and the in-memory metrics collector for proactive monitoring.
 
 ---
 

--- a/src/web/health_endpoint.py
+++ b/src/web/health_endpoint.py
@@ -1,0 +1,32 @@
+"""Health and readiness endpoints."""
+
+from __future__ import annotations
+
+import importlib.util
+
+from fastapi import HTTPException, Request
+from sqlalchemy import text
+
+
+async def healthz(request: Request) -> dict[str, str]:
+    """Verify the database connection is available."""
+
+    try:
+        async with request.app.state.db() as conn:
+            await conn.execute(text("SELECT 1"))
+    except Exception as exc:  # pragma: no cover - error path
+        raise HTTPException(status_code=500, detail="database unavailable") from exc
+    return {"status": "ok"}
+
+
+async def readyz(request: Request) -> dict[str, str]:
+    """Check that critical dependencies are ready."""
+
+    missing: list[str] = []
+    if importlib.util.find_spec("logfire") is None:
+        missing.append("logfire")
+    if getattr(request.app.state, "research_client", None) is None:
+        missing.append("research_client")
+    if missing:
+        raise HTTPException(status_code=500, detail={"missing": missing})
+    return {"status": "ready"}

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -99,6 +99,7 @@ def register_routes(app: FastAPI) -> None:
     """Include API routers."""
 
     from .alert_endpoint import post_alerts
+    from .health_endpoint import healthz, readyz
     from .metrics_endpoint import get_metrics
     from .routes import citation, control, entries, export, stream
 
@@ -109,6 +110,8 @@ def register_routes(app: FastAPI) -> None:
     app.include_router(entries.router)
     app.add_api_route("/metrics", get_metrics, methods=["GET"])
     app.add_api_route("/alerts/{workspace_id}", post_alerts, methods=["POST"])
+    app.add_api_route("/healthz", healthz, methods=["GET"], include_in_schema=False)
+    app.add_api_route("/readyz", readyz, methods=["GET"], include_in_schema=False)
 
 
 def main() -> None:

--- a/tests/test_health_endpoints.py
+++ b/tests/test_health_endpoints.py
@@ -1,0 +1,56 @@
+"""Tests for health and readiness endpoints."""
+
+import importlib.util  # noqa: E402
+import sys
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+repo_src = Path(__file__).resolve().parents[1] / "src"
+if str(repo_src) in sys.path:
+    sys.path.remove(str(repo_src))
+
+sys.path.insert(0, str(repo_src))
+
+spec = importlib.util.spec_from_file_location(
+    "health_endpoint", repo_src / "web" / "health_endpoint.py"
+)
+assert spec and spec.loader
+health_endpoint = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(health_endpoint)
+
+
+@asynccontextmanager
+async def dummy_db():
+    class Conn:
+        async def execute(self, *_a, **_k):
+            return None
+
+    yield Conn()
+
+
+def create_app() -> FastAPI:
+    """Create a FastAPI app with health routes."""
+
+    app = FastAPI()
+    app.state.db = dummy_db
+    app.state.research_client = object()
+    app.add_api_route("/healthz", health_endpoint.healthz, methods=["GET"])
+    app.add_api_route("/readyz", health_endpoint.readyz, methods=["GET"])
+    return app
+
+
+def test_health_and_ready() -> None:
+    """Ensure health and readiness endpoints succeed."""
+
+    client = TestClient(create_app())
+
+    resp = client.get("/healthz")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+    resp = client.get("/readyz")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ready"}


### PR DESCRIPTION
## Summary
- add `/healthz` and `/readyz` FastAPI endpoints with DB and dependency checks
- document Logfire-only observability
- cover endpoints with basic tests

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type tests/test_health_endpoints.py src/web/health_endpoint.py src/web/main.py README.md -v`
- `poetry run black --preview --enable-unstable-feature string_processing src/web/health_endpoint.py src/web/main.py tests/test_health_endpoints.py`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/ -v`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: certificate verify failed)*
- `poetry run pytest` *(fails: ImportError: cannot import name 'RetryableError' from 'agents.content_weaver')*

------
https://chatgpt.com/codex/tasks/task_e_689734c69100832bae0efe88f29758de