### PR TITLE
test: stub RetryableError for content weaver

### DIFF
--- a/tests/test_document_dag.py
+++ b/tests/test_document_dag.py
@@ -36,6 +36,13 @@ a_research.run_researcher_web = _run_researcher_web  # type: ignore[attr-defined
 sys.modules["agents.researcher_web_node"] = a_research
 
 a_weaver = types.ModuleType("agents.content_weaver")
+
+
+class _RetryableError(RuntimeError):
+    """Lightweight stand-in for the real RetryableError class."""
+
+
+a_weaver.RetryableError = _RetryableError
 a_weaver.run_content_weaver = _run_content_weaver  # type: ignore[attr-defined]
 sys.modules["agents.content_weaver"] = a_weaver
 

--- a/tests/test_orchestrator_flow.py
+++ b/tests/test_orchestrator_flow.py
@@ -56,6 +56,12 @@ for name in [
 ]:
     mod = types.ModuleType(name)
     mod.__dict__["run_" + name.split(".")[-1]] = _noop
+    if name == "agents.content_weaver":
+
+        class _RetryableError(RuntimeError):
+            """Stubbed RetryableError to satisfy downstream imports."""
+
+        mod.RetryableError = _RetryableError
     sys.modules[name] = mod
 
 


### PR DESCRIPTION
## Summary
- ensure test stubs for agents.content_weaver provide a `RetryableError` class so later tests can import it without failing

## Testing
- `pytest tests/test_orchestrator_integration.py::test_full_flow_execution -q`
- `poetry run isort --float-to-top --combine-star --order-by-type tests/test_document_dag.py tests/test_orchestrator_flow.py`
- `poetry run black --preview --enable-unstable-feature string_processing tests/test_document_dag.py tests/test_orchestrator_flow.py`
- `poetry run ruff check tests/test_document_dag.py tests/test_orchestrator_flow.py`
- `poetry run flake8 tests/test_document_dag.py tests/test_orchestrator_flow.py` *(fails: Command not found)*
- `poetry run mypy src/ tests/` *(fails: Module has no attribute "RetryableError" and config error)*
- `poetry run bandit -r src -ll` *(fails: Command not found)*
- `poetry run pip-audit` *(fails: Command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68973c9f5d98832ba73454f91a9957c1