### PR TITLE
Add export route integration tests and streaming responses

### DIFF
--- a/src/export/pdf_exporter.py
+++ b/src/export/pdf_exporter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from html import escape
 from pathlib import Path
 from typing import Optional
@@ -10,9 +11,13 @@ from weasyprint import HTML  # type: ignore
 
 from .markdown_exporter import MarkdownExporter
 
+os.environ.setdefault("WEASYPRINT_HEADLESS", "1")
+
 
 class PdfExporter:
     """Render a persisted workspace to a styled PDF document."""
+
+    DEFAULT_CSS = "@page { size: A4; margin: 1cm } body { font-family: sans-serif; }"
 
     def __init__(self, db_path: str, css_path: Optional[str] | None = None) -> None:
         """Create a new exporter.
@@ -72,14 +77,14 @@ class PdfExporter:
         return f"<html><head></head><body>{body}</body></html>"
 
     def apply_css(self, html: str) -> str:
-        """Embed CSS into the HTML document if ``css_path`` was provided."""
+        """Embed CSS into the HTML document."""
 
-        if not self._css_path:
-            return html
-        try:
-            css = Path(self._css_path).read_text(encoding="utf-8")
-        except OSError:
-            return html
+        css = self.DEFAULT_CSS
+        if self._css_path:
+            try:
+                css = Path(self._css_path).read_text(encoding="utf-8")
+            except OSError:
+                pass
         return html.replace("</head>", f"<style>{css}</style></head>", 1)
 
     @staticmethod

--- a/tests/test_export_routes.py
+++ b/tests/test_export_routes.py
@@ -1,6 +1,9 @@
 """Tests for export API routes."""
 
+import importlib
 import importlib.util  # noqa: E402
+import json
+import sqlite3
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -9,6 +12,7 @@ from fastapi import APIRouter, Depends, FastAPI  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 
 from web.auth import verify_jwt  # noqa: E402
+from typing import Any
 
 repo_src = Path(__file__).resolve().parents[1] / "src"
 if str(repo_src) in sys.path:
@@ -17,19 +21,28 @@ if str(repo_src) in sys.path:
 sys.path.insert(0, str(repo_src))
 
 
-spec = importlib.util.spec_from_file_location(
-    "export", repo_src / "web" / "routes" / "export.py"
-)
-assert spec and spec.loader
-export_routes = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(export_routes)
+def reload_routes() -> None:
+    """Load export routes module into ``export_routes``."""
+
+    spec = importlib.util.spec_from_file_location(
+        "export", repo_src / "web" / "routes" / "export.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    globals()["export_routes"] = module
 
 
-def create_app(tmp_path: Path) -> FastAPI:
+export_routes: Any = None
+reload_routes()
+
+
+def create_app(tmp_path: Path, db_path: Path | None = None) -> FastAPI:
     """Create a FastAPI app with the export router."""
 
     app = FastAPI()
     app.state.settings = SimpleNamespace(data_dir=tmp_path)
+    app.state.db_path = str(db_path or tmp_path / "lecture.db")
     api = APIRouter(prefix="/api", dependencies=[Depends(verify_jwt)])
     api.include_router(export_routes.router)
     app.include_router(api)
@@ -64,3 +77,60 @@ def test_export_status_and_urls(tmp_path: Path) -> None:
         "pdf": "/export/ws/pdf",
         "zip": "/export/ws/all",
     }
+
+
+def test_download_routes_return_content(tmp_path: Path) -> None:
+    """Export routes return non-empty Markdown, DOCX and PDF files."""
+
+    for mod in [
+        "docx",
+        "docx.document",
+        "weasyprint",
+        "export.docx_exporter",
+        "export.pdf_exporter",
+        "web.api.export_endpoints",
+    ]:
+        sys.modules.pop(mod, None)
+    import docx  # noqa: F401  # pylint: disable=unused-import
+    import weasyprint  # noqa: F401  # pylint: disable=unused-import
+
+    reload_routes()
+
+    db_path = tmp_path / "lecture.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE lectures (workspace_id TEXT, lecture_json TEXT, created_at TEXT)"
+    )
+    lecture = {
+        "title": "Demo",
+        "learning_objectives": ["lo"],
+        "activities": [{"type": "Lecture", "description": "desc", "duration_min": 5}],
+        "duration_min": 5,
+        "references": [
+            {
+                "url": "http://x",
+                "title": "X",
+                "retrieved_at": "2024-01-01",
+            }
+        ],
+    }
+    conn.execute(
+        "INSERT INTO lectures VALUES (?,?,datetime('now'))",
+        ("ws", json.dumps(lecture)),
+    )
+    conn.commit()
+    conn.close()
+
+    client = TestClient(create_app(tmp_path, db_path))
+
+    md = client.get("/api/export/ws/md")
+    assert md.status_code == 200
+    assert md.text.strip()
+
+    docx_resp = client.get("/api/export/ws/docx")
+    assert docx_resp.status_code == 200
+    assert docx_resp.content.startswith(b"PK")
+
+    pdf = client.get("/api/export/ws/pdf")
+    assert pdf.status_code == 200
+    assert pdf.content.startswith(b"%PDF")


### PR DESCRIPTION
## Summary
- stream DOCX, PDF and ZIP exports with `StreamingResponse`
- embed default CSS and enable headless mode for WeasyPrint PDF exporter
- add integration tests verifying export downloads return content

## Testing
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/` *(no output)*
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pytest tests/test_export_routes.py`
- `poetry run pip-audit` *(fails: SSLCertVerificationError)*

------
https://chatgpt.com/codex/tasks/task_e_68975025ca44832b80cd8269f4a2408a