### PR TITLE
log config at startup and respect tracing flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,9 @@ been replaced by Logfire's settings.
 | `DATA_DIR`           | Path for SQLite DB, cache, logs           | (required)                               |
 | `DATABASE_URL`       | SQLAlchemy connection string              | `sqlite:///${DATA_DIR}/workspace.db`     |
 | `OFFLINE_MODE`       | Run without external network calls        | `false`                                  |
+| `ENABLE_TRACING`     | Enable Logfire tracing instrumentation    | `true`                                   |
+| `ALLOWLIST_DOMAINS`  | JSON list of citation-allowed domains     | `["wikipedia.org", ".edu", ".gov"]` |
+| `ALERT_WEBHOOK_URL`  | Optional webhook for alert notifications  |                                          |
 | `JWT_SECRET`         | HMAC secret for signing JWTs               | (required)                               |
 | `JWT_ALGORITHM`      | JWT signing algorithm                      | `HS256`                                  |
 

--- a/src/observability.py
+++ b/src/observability.py
@@ -38,8 +38,12 @@ def init_observability() -> None:
     """Configure Logfire and instrument global libraries.
 
     Reads configuration from environment variables so that instrumentation
-    occurs before the application's settings module is imported.
+    occurs before the application's settings module is imported. Behaviour is
+    gated by the ``ENABLE_TRACING`` environment variable.
     """
+    if os.getenv("ENABLE_TRACING", "").lower() not in {"1", "true", "yes", "on"}:
+        return
+
     token = os.getenv("LOGFIRE_API_KEY")
     project = os.getenv("LOGFIRE_PROJECT")
 

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -29,7 +29,8 @@ def create_app() -> FastAPI:
     app = FastAPI()
     app.state.settings = settings
 
-    instrument_app(app)
+    if settings.enable_tracing:
+        instrument_app(app)
 
     # Bind search and fact-checking behaviour depending on offline mode.
     if settings.offline_mode:

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,49 @@
+"""Tests for the observability module's tracing toggles."""
+
+from __future__ import annotations
+
+import logfire
+from loguru import logger as loguru_logger
+
+from observability import init_observability
+
+
+def test_init_observability_disabled(monkeypatch):
+    """Tracing is skipped when ENABLE_TRACING is false."""
+
+    called = False
+
+    def fake_configure(*args, **kwargs):  # pragma: no cover - patched
+        nonlocal called
+        called = True
+
+    monkeypatch.setenv("ENABLE_TRACING", "0")
+    monkeypatch.setattr(logfire, "configure", fake_configure)
+    init_observability()
+    assert called is False
+
+
+def test_init_observability_enabled(monkeypatch):
+    """Tracing is configured when ENABLE_TRACING is true."""
+
+    called = False
+
+    def fake_configure(*args, **kwargs):  # pragma: no cover - patched
+        nonlocal called
+        called = True
+
+    monkeypatch.setenv("ENABLE_TRACING", "1")
+    monkeypatch.setattr(logfire, "configure", fake_configure)
+    monkeypatch.setattr("observability.install_auto_tracing", lambda: None)
+    for name in [
+        "instrument_pydantic",
+        "instrument_httpx",
+        "instrument_sqlalchemy",
+        "instrument_sqlite3",
+        "instrument_system_metrics",
+    ]:
+        monkeypatch.setattr(logfire, name, lambda *a, **k: None)
+    monkeypatch.setattr(logfire, "loguru_handler", lambda: None)
+    monkeypatch.setattr(loguru_logger, "add", lambda *a, **k: None)
+    init_observability()
+    assert called is True


### PR DESCRIPTION
## Summary
- log configuration without secrets and exit if required keys are missing
- gate observability on ENABLE_TRACING and reflect config variables in docs
- test tracing toggle behaviour

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSL certificate verify failed)*
- `OPENAI_API_KEY=x PERPLEXITY_API_KEY=y JWT_SECRET=z DATA_DIR=/tmp poetry run pytest` *(fails: missing dependencies like jwt, aiosqlite, fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6897507c88ec832b9045d24e07cf4f4f