### PR TITLE
Expose SSE routes without JWT auth

### DIFF
--- a/src/web/main.py
+++ b/src/web/main.py
@@ -112,8 +112,10 @@ def register_routes(app: FastAPI) -> None:
     from .metrics_endpoint import get_metrics
     from .routes import citation, control, entries, export, stream
 
+    # SSE routes are mounted directly to avoid JWT requirements on EventSource.
+    app.include_router(stream.router)
+
     api_router = APIRouter(prefix="/api", dependencies=[Depends(verify_jwt)])
-    api_router.include_router(stream.router)
     api_router.include_router(control.router)
     api_router.include_router(export.router)
     api_router.include_router(citation.router)

--- a/tests/test_export_routes.py
+++ b/tests/test_export_routes.py
@@ -7,12 +7,12 @@ import sqlite3
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 
 from fastapi import APIRouter, Depends, FastAPI  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 
 from web.auth import verify_jwt  # noqa: E402
-from typing import Any
 
 repo_src = Path(__file__).resolve().parents[1] / "src"
 if str(repo_src) in sys.path:


### PR DESCRIPTION
## Summary
- expose streaming endpoints directly on the app so EventSource connections don't require JWT
- format imports in export route tests

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /pypi/bandit/1.8.6/json (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)')))*)
- `poetry run pytest` *(fails: 22 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6897f6d39fa0832bae78bbda1f83803f