### PR TITLE
Expose metrics endpoint without JWT

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ been replaced by Logfire's settings.
 - **Logfire:** Handles structured JSON logs and spans. Use
   `core.logging.get_logger(job_id, user_id)` to bind contextual identifiers for
   correlation. OpenTelemetry metrics track request counts, active SSE clients,
-  and export durations, exposed at `/api/metrics` for Prometheus scraping.
+  and export durations, exposed at `/metrics` for Prometheus scraping.
 
 ---
 
@@ -339,7 +339,7 @@ been replaced by Logfire's settings.
 
 ## Operational Governance
 
-- Metrics exposed via OpenTelemetry at `/api/metrics`.
+- Metrics exposed via OpenTelemetry at `/metrics`.
 - Alerts: configurable thresholds for latency, error rates, unsupported-claim rate.
 - Audit: verify hash chain integrity using CLI tools.
 

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -7,7 +7,6 @@ import argparse
 import os
 from pathlib import Path
 
-import uvicorn
 from fastapi import APIRouter, Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
@@ -118,9 +117,9 @@ def register_routes(app: FastAPI) -> None:
     api_router.include_router(export.router)
     api_router.include_router(citation.router)
     api_router.include_router(entries.router)
-    api_router.add_api_route("/metrics", get_metrics, methods=["GET"])
     api_router.add_api_route("/alerts/{workspace_id}", post_alerts, methods=["POST"])
     app.include_router(api_router)
+    app.add_api_route("/metrics", get_metrics, methods=["GET"])
     app.add_api_route("/healthz", healthz, methods=["GET"], include_in_schema=False)
     app.add_api_route("/readyz", readyz, methods=["GET"], include_in_schema=False)
 
@@ -137,6 +136,7 @@ def main() -> None:
 
     # Ensure settings reflect any environment overrides before app creation.
     load_settings()
+    import uvicorn
 
     uvicorn.run(create_app())
 

--- a/tests/test_metrics_endpoint.py
+++ b/tests/test_metrics_endpoint.py
@@ -9,6 +9,6 @@ async def test_metrics_endpoint_exposes_counters() -> None:
     app = create_app()
     async with AsyncClient(app=app, base_url="http://test") as client:  # type: ignore[call-arg]
         await client.get("/healthz")
-        resp = await client.get("/api/metrics")
+        resp = await client.get("/metrics")
     assert resp.status_code == 200
     assert "requests_total" in resp.text


### PR DESCRIPTION
## Summary
- register `/metrics` directly on the FastAPI app so metrics are public
- update metrics endpoint test and docs to use `/metrics`

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: CERTIFICATE_VERIFY_FAILED)*
- `poetry run pytest tests/test_metrics_endpoint.py` *(fails: No module named 'opentelemetry.exporter')*

------
https://chatgpt.com/codex/tasks/task_e_6897f6dff918832b915fdfbeda97f2bd