### PR TITLE
Mark control endpoints as not implemented

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -71,27 +71,8 @@ This document provides a **detailed**, **explicit** reference for all backend HT
 
 ### 3.2 Resume Existing Job
 
-#### POST `/api/resume/{job_id}`
-
-- **Purpose**: Resume a previously interrupted job.
-
-- **Authentication**: Required (`editor` or `admin`).
-
-- **Path Parameter**:
-
-  | Parameter | Type   | Description                |
-  | --------- | ------ | -------------------------- |
-  | `job_id`  | String | UUID of the job to resume. |
-
-- **Response (JSON)**:
-  - **200 OK**
-
-    ```json
-    { "job_id": "<same-id>", "status": "resumed" }
-    ```
-
-  - **404 Not Found**: No job with given `job_id`.
-  - **401 Unauthorized**: Invalid JWT.
+The `POST /api/resume/{job_id}` endpoint is **not yet implemented** and currently
+returns `501 Not Implemented` for all requests.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -36,7 +36,7 @@ This document provides a **comprehensive** and **explicit** description of the L
 1. **API Layer (FastAPI)**
    - **Endpoints**:
    - `POST /run` — start new lecture build job
-   - `POST /resume/{job_id}` — resume after crash
+   - `POST /resume/{job_id}` — resume after crash *(not implemented)*
    - `SSE /stream/messages` — token diff messages
    - `SSE /stream/updates` — citation and progress updates
    - `SSE /stream/values` — state values
@@ -108,11 +108,12 @@ This document provides a **comprehensive** and **explicit** description of the L
 5. **Exporter** writes final files and signals completion.
 6. **Browser** enables download buttons.
 
-### 3.2 Resume After Crash
+### 3.2 Resume After Crash *(not implemented)*
 
-1. **User calls** `POST /resume/{job_id}`.
-2. **FastAPI** reloads latest checkpoint (`SqliteCheckpointSaver`) and re-invokes remaining agents.
-3. **SSE** streams catch up from last `state_version`.
+1. **Planned:** `POST /resume/{job_id}` would reload the latest checkpoint and
+   continue processing remaining agents.
+2. **Current state:** the endpoint returns `501 Not Implemented` and performs no
+   recovery.
 
 ### 3.3 Citation Cache Hit/Miss
 
@@ -160,7 +161,8 @@ This document provides a **comprehensive** and **explicit** description of the L
 
 | Interface                    | Protocol                               | Format         | Direction           |
 | ---------------------------- | -------------------------------------- | -------------- | ------------------- |
-| `/run`, `/resume`            | HTTP REST                              | JSON           | Client → Server     |
+| `/run`                       | HTTP REST                              | JSON           | Client → Server     |
+| `/resume` *(not implemented)* | HTTP REST                              | JSON           | Client → Server     |
 | SSE Streams                  | SSE                                    | JSON messages  | Server → Client     |
 | `/download`                  | HTTP REST                              | Binary stream  | Client ← Server     |
 | Orchestrator invocations     | In-process Call                        | Python objects | Orchestrator        |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -61,7 +61,7 @@ _These controls will be implemented in version 2._
 - **Roles:** `viewer`, `editor`, `admin`
 - **Permissions matrix:** documented in `backend/auth/permissions.yaml`
   - `viewer`: read-only access to running jobs and downloads
-  - `editor`: run/resume jobs, view logs and citations
+  - `editor`: run jobs (resume not yet implemented), view logs and citations
   - `admin`: full access including security endpoints, key rotation
 
 - **Enforcement:** FastAPI dependencies guard each endpoint

--- a/src/web/routes/control.py
+++ b/src/web/routes/control.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+from typing import NoReturn
 
-from fastapi import APIRouter, Body, Request
+from fastapi import APIRouter, Body, HTTPException, Request
 
 from core.orchestrator import GraphOrchestrator
 from core.state import State
@@ -37,10 +38,10 @@ async def run(
 
 
 @router.post("/pause")
-async def pause(workspace_id: str) -> dict[str, str]:
+async def pause(workspace_id: str) -> NoReturn:
     """Pause the graph execution for a workspace."""
 
-    return {"workspace_id": workspace_id, "status": "paused"}
+    raise HTTPException(status_code=501, detail="Not implemented")
 
 
 @router.post("/retry")
@@ -51,14 +52,14 @@ async def retry(workspace_id: str) -> dict[str, str]:
 
 
 @router.post("/resume")
-async def resume(workspace_id: str) -> dict[str, str]:
+async def resume(workspace_id: str) -> NoReturn:
     """Resume processing for a previously started job."""
 
-    return {"workspace_id": workspace_id, "status": "resumed"}
+    raise HTTPException(status_code=501, detail="Not implemented")
 
 
 @router.post("/model")
-async def model(workspace_id: str, model: str = ModelBody) -> dict[str, str]:
+async def model(workspace_id: str, model: str = ModelBody) -> NoReturn:
     """Select the model to run subsequent operations against."""
 
-    return {"workspace_id": workspace_id, "model": model}
+    raise HTTPException(status_code=501, detail="Not implemented")

--- a/tests/test_control_routes.py
+++ b/tests/test_control_routes.py
@@ -41,7 +41,7 @@ def create_app() -> FastAPI:
 
 
 def test_control_endpoints() -> None:
-    """Ensure control routes respond with placeholders."""
+    """Ensure control routes behave as expected."""
 
     client = TestClient(create_app())
 
@@ -50,17 +50,17 @@ def test_control_endpoints() -> None:
     assert resp.json() == {"job_id": "abc", "workspace_id": "abc"}
 
     resp = client.post("/api/workspaces/abc/pause")
-    assert resp.status_code == 200
-    assert resp.json() == {"workspace_id": "abc", "status": "paused"}
+    assert resp.status_code == 501
+    assert resp.json() == {"detail": "Not implemented"}
 
     resp = client.post("/api/workspaces/abc/retry")
     assert resp.status_code == 200
     assert resp.json() == {"workspace_id": "abc", "status": "retried"}
 
     resp = client.post("/api/workspaces/abc/resume")
-    assert resp.status_code == 200
-    assert resp.json() == {"workspace_id": "abc", "status": "resumed"}
+    assert resp.status_code == 501
+    assert resp.json() == {"detail": "Not implemented"}
 
     resp = client.post("/api/workspaces/abc/model", json={"model": "gpt"})
-    assert resp.status_code == 200
-    assert resp.json() == {"workspace_id": "abc", "model": "gpt"}
+    assert resp.status_code == 501
+    assert resp.json() == {"detail": "Not implemented"}


### PR DESCRIPTION
## Summary
- Return HTTP 501 for `/pause`, `/resume`, and `/model` control routes
- Update tests and documentation to reflect unimplemented control endpoints

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLError)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_6897f6f98250832b84f8295984017da9