### PR TITLE
feat(web): add workspace-scoped stream routes

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -134,6 +134,36 @@ the channel and the payload conforms to the `SseEvent` schema (`type`,
 - **Authentication**: Required (`viewer`, `editor`, or `admin`).
 - **Event Format**: `event: debug` followed by an `SseEvent`.
 
+### 4.5 Workspace-Scoped Streams
+
+Every channel above also supports a workspace-scoped variant that isolates
+events to a single workspace.
+
+#### GET `/api/stream/{workspace_id}/messages`
+
+- **Purpose**: Stream token-level diff messages for a specific workspace.
+- **Authentication**: Required (`viewer`, `editor`, or `admin`).
+- **Event Format**: `event: messages` with an `SseEvent` payload.
+
+#### GET `/api/stream/{workspace_id}/updates`
+
+- **Purpose**: Stream citation additions and workflow progress updates for a
+  workspace.
+- **Authentication**: Required (`viewer`, `editor`, or `admin`).
+- **Event Format**: `event: updates` with an `SseEvent` payload.
+
+#### GET `/api/stream/{workspace_id}/values`
+
+- **Purpose**: Stream structured state values for a workspace.
+- **Authentication**: Required (`viewer`, `editor`, or `admin`).
+- **Event Format**: `event: values` followed by an `SseEvent`.
+
+#### GET `/api/stream/{workspace_id}/debug`
+
+- **Purpose**: Stream diagnostic messages for a workspace.
+- **Authentication**: Required (`viewer`, `editor`, or `admin`).
+- **Event Format**: `event: debug` followed by an `SseEvent`.
+
 ---
 
 ## 5. Downloads

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,6 +41,10 @@ This document provides a **comprehensive** and **explicit** description of the L
    - `SSE /stream/updates` — citation and progress updates
    - `SSE /stream/values` — state values
    - `SSE /stream/debug` — diagnostics
+   - `SSE /stream/{workspace_id}/messages` — workspace token messages
+   - `SSE /stream/{workspace_id}/updates` — workspace citation updates
+   - `SSE /stream/{workspace_id}/values` — workspace state values
+   - `SSE /stream/{workspace_id}/debug` — workspace diagnostics
    - `GET /download/{job_id}/{format}` — retrieve final artifact
 
 2. **Graph Orchestrator**

--- a/src/web/routes/stream.py
+++ b/src/web/routes/stream.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from fastapi import APIRouter, Request  # type: ignore[import-not-found]
 from sse_starlette.sse import EventSourceResponse  # type: ignore[import-not-found]
 
-from web.sse import stream_events  # type: ignore[import-not-found]
+from web.sse import (  # type: ignore[import-not-found]
+    stream_events,
+    stream_workspace_events,
+)
 
 router = APIRouter()
 
@@ -36,3 +39,49 @@ async def stream_debug(request: Request) -> EventSourceResponse:
     """Stream debug and diagnostic messages."""
 
     return EventSourceResponse(stream_events("debug", request))
+
+
+def _workspace_event_response(
+    workspace_id: str, event_type: str, request: Request
+) -> EventSourceResponse:
+    """Return an SSE response for workspace ``event_type`` events."""
+
+    return EventSourceResponse(
+        stream_workspace_events(workspace_id, event_type, request)
+    )
+
+
+@router.get("/stream/{workspace_id}/messages", response_model=None)
+async def stream_workspace_messages(
+    workspace_id: str, request: Request
+) -> EventSourceResponse:
+    """Stream token diff messages for a workspace."""
+
+    return _workspace_event_response(workspace_id, "messages", request)
+
+
+@router.get("/stream/{workspace_id}/updates", response_model=None)
+async def stream_workspace_updates(
+    workspace_id: str, request: Request
+) -> EventSourceResponse:
+    """Stream citation and progress updates for a workspace."""
+
+    return _workspace_event_response(workspace_id, "updates", request)
+
+
+@router.get("/stream/{workspace_id}/values", response_model=None)
+async def stream_workspace_values(
+    workspace_id: str, request: Request
+) -> EventSourceResponse:
+    """Stream structured state values for a workspace."""
+
+    return _workspace_event_response(workspace_id, "values", request)
+
+
+@router.get("/stream/{workspace_id}/debug", response_model=None)
+async def stream_workspace_debug(
+    workspace_id: str, request: Request
+) -> EventSourceResponse:
+    """Stream diagnostic messages for a workspace."""
+
+    return _workspace_event_response(workspace_id, "debug", request)


### PR DESCRIPTION
## Summary
- add SSE endpoints scoped to workspaces
- document workspace stream routes
- test per-workspace messages stream

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/ --statistics`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: certificate verify failed)*
- `poetry run pytest tests/test_stream_endpoints.py` *(fails: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6897f7032eb8832b94d681fe8c98eda5