### PR TITLE
feat(frontend): support tokenized SSE streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,15 @@ The system comprises:
 ### Stream Channels
 
 Agents emit events over several orchestrator channels that the frontend can
-subscribe to:
+subscribe to via Server-Sent Events:
 
 - `messages` – token-level content such as LLM outputs.
 - `debug` – diagnostic information and warnings.
 - `values` – structured state snapshots.
 - `updates` – citation and progress updates.
+
+Connect to `/stream/<channel>` for public streams. Workspace-scoped streams
+require a token: `/stream/<channel>?token=<workspace-id>`.
 
 ---
 
@@ -232,10 +235,10 @@ All endpoints, except `/healthz` and `/readyz`, are namespaced under `/api` and
 require a JWT via the `Authorization: Bearer <token>` header. Tokens are signed
 using `JWT_SECRET` and validated with the `HS256` algorithm by default.
 
-| Code | Description                                 |
-| ---- | ------------------------------------------- |
-| 401  | Missing token or failed signature check     |
-| 403  | Token valid but caller lacks required role  |
+| Code | Description                                |
+| ---- | ------------------------------------------ |
+| 401  | Missing token or failed signature check    |
+| 403  | Token valid but caller lacks required role |
 
 ## Examples
 
@@ -310,10 +313,10 @@ been replaced by Logfire's settings.
 | `DATABASE_URL`       | SQLAlchemy connection string              | `sqlite:///${DATA_DIR}/workspace.db`     |
 | `OFFLINE_MODE`       | Run without external network calls        | `false`                                  |
 | `ENABLE_TRACING`     | Enable Logfire tracing instrumentation    | `true`                                   |
-| `ALLOWLIST_DOMAINS`  | JSON list of citation-allowed domains     | `["wikipedia.org", ".edu", ".gov"]` |
+| `ALLOWLIST_DOMAINS`  | JSON list of citation-allowed domains     | `["wikipedia.org", ".edu", ".gov"]`      |
 | `ALERT_WEBHOOK_URL`  | Optional webhook for alert notifications  |                                          |
-| `JWT_SECRET`         | HMAC secret for signing JWTs               | (required)                               |
-| `JWT_ALGORITHM`      | JWT signing algorithm                      | `HS256`                                  |
+| `JWT_SECRET`         | HMAC secret for signing JWTs              | (required)                               |
+| `JWT_ALGORITHM`      | JWT signing algorithm                     | `HS256`                                  |
 
 ---
 

--- a/frontend/src/api/sseClient.ts
+++ b/frontend/src/api/sseClient.ts
@@ -1,16 +1,18 @@
 // Utility for connecting to server-sent event streams for a workspace.
 // Includes basic reconnect logic with a fixed backoff.
 export function connectToWorkspaceStream(
-  workspaceId: string,
+  token?: string,
   channel = "state",
 ): EventSource {
-  const url = `/stream/${workspaceId}/${channel}`;
+  const url = token
+    ? `/stream/${channel}?token=${token}`
+    : `/stream/${channel}`;
   let source = new EventSource(url);
 
   source.onerror = () => {
     source.close();
     setTimeout(() => {
-      source = connectToWorkspaceStream(workspaceId, channel);
+      source = connectToWorkspaceStream(token, channel);
     }, 1000);
   };
 

--- a/frontend/sse-test.html
+++ b/frontend/sse-test.html
@@ -15,18 +15,27 @@
         <option value="debug">debug</option>
       </select>
     </label>
+    <label>
+      Token:
+      <input id="token" />
+    </label>
     <button id="connect">Connect</button>
     <pre id="log"></pre>
     <script>
-      document.getElementById('connect').onclick = function () {
-        var chan = document.getElementById('channel').value;
-        var log = document.getElementById('log');
-        var source = new EventSource('/stream/' + chan);
+      document.getElementById("connect").onclick = function () {
+        var chan = document.getElementById("channel").value;
+        var token = document.getElementById("token").value.trim();
+        var log = document.getElementById("log");
+        var url =
+          "/stream/" +
+          chan +
+          (token ? "?token=" + encodeURIComponent(token) : "");
+        var source = new EventSource(url);
         source.onmessage = function (e) {
-          log.textContent += e.data + '\n';
+          log.textContent += e.data + "\n";
         };
         source.onerror = function () {
-          log.textContent += 'error\n';
+          log.textContent += "error\n";
           source.close();
         };
       };


### PR DESCRIPTION
## Summary
- support tokenized SSE URLs in frontend client
- add token field to SSE test page
- document public vs tokenized stream channels

## Testing
- `npm test`
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLError: CERTIFICATE_VERIFY_FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_6897f70c6258832bb2b3ca95fb55a556