### PR TITLE
Fix frontend head metadata and fonts

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,15 +2,18 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>Agentic Demo</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light dark" />
+    <meta name="theme-color" content="#0b0b0c" />
+    <title>Lecture Builder</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,400;0,700;1,400;1,700&family=Domine:ital,wght@0,400;0,700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Domine:wght@400;700&display=swap"
       rel="stylesheet"
     />
   </head>
-  <body class="bg-white p-8 pt-7 dark:bg-gray-900">
+  <body class="bg-white dark:bg-gray-950">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/src/web/auth.py
+++ b/src/web/auth.py
@@ -9,11 +9,12 @@ from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 security = HTTPBearer()
+security_dependency = Depends(security)
 
 
 def verify_jwt(
     request: Request,
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    credentials: HTTPAuthorizationCredentials = security_dependency,
 ) -> Dict[str, Any]:
     """Validate the provided JWT and return its payload.
 


### PR DESCRIPTION
## Summary
- add viewport, color scheme, and theme color metadata
- update font configuration and body classes
- declare Vite environment types and refactor auth dependency for lint compliance

## Testing
- `npx prettier --write frontend/index.html`
- `npm test`
- `npm run typecheck`
- `npm run lint:css`
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(fails: Invalid args for response field; cannot import 'app' from 'web.main')*


------
https://chatgpt.com/codex/tasks/task_e_6898284ebf20832bb160bf42d05f4aca