### PR TITLE
Add theme toggle and responsive layout

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import SourcesPanel from "./components/SourcesPanel";
 import ControlsPanel from "./components/ControlsPanel";
 import DownloadsPanel from "./components/DownloadsPanel";
 import DataEntryForm from "./components/DataEntryForm";
+import ThemeToggle from "./components/ThemeToggle";
 import { useWorkspaceStore } from "./store/useWorkspaceStore";
 
 // Top-level layout component that connects to the workspace stream
@@ -22,30 +23,43 @@ const App: React.FC = () => {
   }, [connect]);
 
   return (
-    <div className="mx-auto max-w-4xl space-y-6 p-6">
-      <div className="card">
-        <DataEntryForm />
-      </div>
-      <div className="card">
-        <DocumentPanel text={document || ""} onAcceptDiff={() => {}} />
-      </div>
-      <div className="card">
-        <LogPanel logs={logs} />
-      </div>
-      <div className="card">
-        <SourcesPanel sources={sources} />
-      </div>
-      {workspaceId && (
-        <div className="card">
-          <ControlsPanel workspaceId={workspaceId} />
+    <>
+      <header className="sticky top-0 z-30 border-b border-black/5 backdrop-blur supports-[backdrop-filter]:bg-white/70 dark:border-white/10 dark:supports-[backdrop-filter]:bg-gray-950/70">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
+          <h1 className="text-base font-semibold tracking-tight">
+            Lecture Builder
+          </h1>
+          <ThemeToggle />
         </div>
-      )}
-      {workspaceId && exportStatus === "ready" && (
-        <div className="card">
-          <DownloadsPanel workspaceId={workspaceId} />
-        </div>
-      )}
-    </div>
+      </header>
+
+      <main className="mx-auto grid max-w-6xl gap-4 p-4 md:grid-cols-3">
+        <section className="space-y-4 md:col-span-2">
+          <div className="card">
+            <DataEntryForm />
+          </div>
+          <div className="card">
+            <DocumentPanel text={document || ""} onAcceptDiff={() => {}} />
+          </div>
+        </section>
+        <aside className="space-y-4">
+          <div className="card">
+            <ControlsPanel workspaceId={workspaceId!} />
+          </div>
+          <div className="card">
+            <LogPanel logs={logs} />
+          </div>
+          <div className="card">
+            <SourcesPanel sources={sources} />
+          </div>
+          {workspaceId && exportStatus === "ready" && (
+            <div className="card">
+              <DownloadsPanel workspaceId={workspaceId} />
+            </div>
+          )}
+        </aside>
+      </main>
+    </>
   );
 };
 

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from "react";
+
+const ThemeToggle: React.FC = () => {
+  const [dark, setDark] = useState<boolean>(() => {
+    const saved = localStorage.getItem("theme");
+    if (saved) return saved === "dark";
+    return window.matchMedia?.("(prefers-color-scheme: dark)").matches ?? false;
+  });
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", dark);
+    localStorage.setItem("theme", dark ? "dark" : "light");
+  }, [dark]);
+
+  return (
+    <button
+      type="button"
+      onClick={() => setDark((v) => !v)}
+      aria-pressed={dark}
+      className="rounded-full border border-black/10 px-3 py-2 text-sm shadow-sm transition hover:bg-black/5 dark:border-white/15 dark:hover:bg-white/10"
+    >
+      {dark ? "🌙 Dark" : "☀️ Light"}
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "strict": true,
     "skipLibCheck": true,
     "baseUrl": "frontend/src",
-    "types": ["vitest/globals", "node"],
+    "types": ["vitest/globals", "node", "vite/client"],
     "paths": { "@/*": ["./*"] }
   },
   "include": ["frontend/src", "tests"]


### PR DESCRIPTION
## Summary
- add ThemeToggle component to switch between light and dark modes
- restructure App layout with sticky header and responsive two-pane grid
- include Vite client types to satisfy TypeScript checks

## Testing
- `npm run format`
- `npm run lint:css`
- `npm run typecheck`
- `npm test`
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/` *(fails: Command not found)*
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll` *(fails: Command not found)*
- `poetry run pip-audit` *(fails: Command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898286c4670832baf2b6135979fd205