### PR TITLE
feat: improve log and source panels

### DIFF
--- a/frontend/src/components/LogPanel.tsx
+++ b/frontend/src/components/LogPanel.tsx
@@ -5,12 +5,21 @@ interface Props {
   logs: SseEvent[];
 }
 
-// Stub component rendering log events.
+// Display log events with type badges and timestamps.
 const LogPanel: React.FC<Props> = ({ logs }) => {
+  if (!logs?.length)
+    return <p className="text-sm text-gray-500">No activity yet.</p>;
   return (
-    <ul className="space-y-1 text-sm">
+    <ul className="space-y-2">
       {logs.map((log, idx) => (
-        <li key={idx}>{log.type}</li>
+        <li key={idx} className="flex items-start gap-2 text-sm">
+          <span className="inline-flex h-6 shrink-0 items-center rounded-full border px-2 capitalize">
+            {log.type}
+          </span>
+          <time className="text-gray-500">
+            {new Date(log.timestamp).toLocaleTimeString()}
+          </time>
+        </li>
       ))}
     </ul>
   );

--- a/frontend/src/components/SourcesPanel.tsx
+++ b/frontend/src/components/SourcesPanel.tsx
@@ -4,13 +4,30 @@ interface Props {
   sources: unknown[];
 }
 
-// Stub component showing sources related to the workspace.
+// Display source links with hostnames.
 const SourcesPanel: React.FC<Props> = ({ sources }) => {
+  if (!sources?.length)
+    return <p className="text-sm text-gray-500">No sources yet.</p>;
   return (
-    <ul className="list-disc space-y-1 pl-5 text-sm">
-      {sources.map((s, idx) => (
-        <li key={idx}>{String(s)}</li>
-      ))}
+    <ul className="space-y-2">
+      {sources.map((s: any, idx) => {
+        const url = typeof s === "string" ? s : s?.url;
+        const title = typeof s === "string" ? s : (s?.title ?? s?.url);
+        const host = url ? new URL(url).host : "";
+        return (
+          <li key={idx} className="text-sm">
+            <a
+              href={url}
+              target="_blank"
+              rel="noreferrer"
+              className="underline decoration-black/30 hover:decoration-black dark:decoration-white/30"
+            >
+              {title}
+            </a>
+            {host && <span className="text-gray-500"> — {host}</span>}
+          </li>
+        );
+      })}
     </ul>
   );
 };


### PR DESCRIPTION
## Summary
- render logs with type badges and timestamps and add empty state
- show sources as clickable links with hostnames and empty state

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /pypi/bandit/1.8.6/json (Caused by SSLError))*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898290644e8832b9a63799295422371