### PR TITLE
feat(frontend): virtualize log panel

### DIFF
--- a/frontend/src/components/LogPanel.tsx
+++ b/frontend/src/components/LogPanel.tsx
@@ -1,27 +1,57 @@
 import React from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { SseEvent } from "../store/useWorkspaceStore";
 
 interface Props {
   logs: SseEvent[];
 }
 
-// Display log events with type badges and timestamps.
+/**
+ * Displays log events with virtualization to handle long lists efficiently.
+ */
 const LogPanel: React.FC<Props> = ({ logs }) => {
   if (!logs?.length)
     return <p className="text-sm text-gray-500">No activity yet.</p>;
+
+  const parentRef = React.useRef<HTMLDivElement>(null);
+  const rowVirtualizer = useVirtualizer({
+    count: logs.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 32,
+  });
+
   return (
-    <ul className="space-y-2">
-      {logs.map((log, idx) => (
-        <li key={idx} className="flex items-start gap-2 text-sm">
-          <span className="inline-flex h-6 shrink-0 items-center rounded-full border px-2 capitalize">
-            {log.type}
-          </span>
-          <time className="text-gray-500">
-            {new Date(log.timestamp).toLocaleTimeString()}
-          </time>
-        </li>
-      ))}
-    </ul>
+    <div ref={parentRef} className="max-h-64 overflow-auto">
+      <ul
+        style={{
+          height: `${rowVirtualizer.getTotalSize()}px`,
+          position: "relative",
+        }}
+      >
+        {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+          const log = logs[virtualRow.index];
+          return (
+            <li
+              key={virtualRow.key}
+              ref={rowVirtualizer.measureElement}
+              data-index={virtualRow.index}
+              className="absolute right-0 left-0 flex items-start gap-2 text-sm"
+              style={{
+                transform: `translateY(${virtualRow.start}px)`,
+                top: 0,
+              }}
+            >
+              <span className="inline-flex h-6 shrink-0 items-center rounded-full border px-2 capitalize">
+                {log.type}
+              </span>
+              <time className="text-gray-500">
+                {new Date(log.timestamp).toLocaleTimeString()}
+              </time>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
   );
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
         "@opentelemetry/instrumentation-fetch": "^0.203.0",
         "@pydantic/logfire-browser": "^0.9.0",
         "@tailwindcss/vite": "^4.1.11",
+        "@tanstack/react-virtual": "^3.13.12",
         "postcss": "^8.5.6",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -2016,6 +2017,33 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.12.tgz",
+      "integrity": "sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.12.tgz",
+      "integrity": "sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@opentelemetry/instrumentation-fetch": "^0.203.0",
     "@pydantic/logfire-browser": "^0.9.0",
     "@tailwindcss/vite": "^4.1.11",
+    "@tanstack/react-virtual": "^3.13.12",
     "postcss": "^8.5.6",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",


### PR DESCRIPTION
## Summary
- virtualize workspace log panel for better performance on long streams
- depend on `@tanstack/react-virtual` for list windowing

## Testing
- `npm test`
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/` *(command not found)*
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll` *(command not found)*
- `poetry run pip-audit` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68982db0d4ec832b9bbe43493a092b39