### PR TITLE
feat: add document skeleton and export toast

### DIFF
--- a/frontend/src/components/DocumentPanel.tsx
+++ b/frontend/src/components/DocumentPanel.tsx
@@ -61,6 +61,19 @@ const DocumentPanel: React.FC<Props> = ({ text, onAcceptDiff }) => {
     });
   };
 
+  if (tokens.length === 0) {
+    return (
+      <div
+        data-testid="document-skeleton"
+        className="max-w-none animate-pulse space-y-2"
+      >
+        <div className="h-4 rounded bg-gray-300" />
+        <div className="h-4 rounded bg-gray-300" />
+        <div className="h-4 w-2/3 rounded bg-gray-300" />
+      </div>
+    );
+  }
+
   return (
     <div className="prose dark:prose-invert max-w-none" aria-live="polite">
       {tokens.map((t, i) => (

--- a/frontend/src/components/DownloadsPanel.tsx
+++ b/frontend/src/components/DownloadsPanel.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import exportClient, { ExportUrls } from "../api/exportClient";
+import Toast from "./Toast";
 
 interface Props {
   workspaceId: string;
@@ -8,6 +9,7 @@ interface Props {
 // Polls export status and renders download links when ready.
 const DownloadsPanel: React.FC<Props> = ({ workspaceId }) => {
   const [urls, setUrls] = useState<ExportUrls | null>(null);
+  const [showToast, setShowToast] = useState(false);
 
   useEffect(() => {
     let interval: number;
@@ -20,6 +22,7 @@ const DownloadsPanel: React.FC<Props> = ({ workspaceId }) => {
           const u = await exportClient.getUrls(workspaceId);
           if (!cancelled) {
             setUrls(u);
+            setShowToast(true);
           }
           clearInterval(interval);
         }
@@ -41,20 +44,25 @@ const DownloadsPanel: React.FC<Props> = ({ workspaceId }) => {
   }
 
   return (
-    <div className="flex gap-4">
-      <a className="text-blue-600 hover:underline" href={urls.md}>
-        Markdown
-      </a>
-      <a className="text-blue-600 hover:underline" href={urls.docx}>
-        DOCX
-      </a>
-      <a className="text-blue-600 hover:underline" href={urls.pdf}>
-        PDF
-      </a>
-      <a className="text-blue-600 hover:underline" href={urls.zip}>
-        ZIP
-      </a>
-    </div>
+    <>
+      {showToast && (
+        <Toast message="Export ready!" onClose={() => setShowToast(false)} />
+      )}
+      <div className="flex gap-4">
+        <a className="text-blue-600 hover:underline" href={urls.md}>
+          Markdown
+        </a>
+        <a className="text-blue-600 hover:underline" href={urls.docx}>
+          DOCX
+        </a>
+        <a className="text-blue-600 hover:underline" href={urls.pdf}>
+          PDF
+        </a>
+        <a className="text-blue-600 hover:underline" href={urls.zip}>
+          ZIP
+        </a>
+      </div>
+    </>
   );
 };
 

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect } from "react";
+
+interface Props {
+  /** Message to display inside the toast. */
+  message: string;
+  /** Callback fired when the toast is dismissed. */
+  onClose: () => void;
+  /** How long the toast stays visible in milliseconds. */
+  duration?: number;
+}
+
+/**
+ * Simple toast notification that auto-dismisses after a delay.
+ */
+const Toast: React.FC<Props> = ({ message, onClose, duration = 3000 }) => {
+  useEffect(() => {
+    const id = window.setTimeout(onClose, duration);
+    return () => window.clearTimeout(id);
+  }, [duration, onClose]);
+
+  return (
+    <div
+      data-testid="toast"
+      className="fixed right-4 bottom-4 rounded bg-gray-800 px-4 py-2 text-white shadow"
+      role="status"
+    >
+      {message}
+    </div>
+  );
+};
+
+export default Toast;

--- a/tests/documentPanel.test.tsx
+++ b/tests/documentPanel.test.tsx
@@ -1,0 +1,16 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import DocumentPanel from "@/components/DocumentPanel";
+
+describe("DocumentPanel", () => {
+  it("shows skeleton when empty", () => {
+    render(<DocumentPanel text="" onAcceptDiff={() => {}} />);
+    expect(screen.getByTestId("document-skeleton")).toBeInTheDocument();
+  });
+
+  it("renders tokens when text provided", () => {
+    render(<DocumentPanel text="Hello" onAcceptDiff={() => {}} />);
+    expect(screen.queryByTestId("document-skeleton")).toBeNull();
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+  });
+});

--- a/tests/downloadsPanel.test.tsx
+++ b/tests/downloadsPanel.test.tsx
@@ -1,0 +1,39 @@
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import { vi } from "vitest";
+
+vi.mock("@/api/exportClient", () => {
+  const getStatus = vi.fn().mockResolvedValue({ ready: true });
+  const getUrls = vi.fn().mockResolvedValue({
+    md: "/md",
+    docx: "/docx",
+    pdf: "/pdf",
+    zip: "/zip",
+  });
+  return {
+    __esModule: true,
+    default: { getStatus, getUrls },
+    getStatus,
+    getUrls,
+  };
+});
+
+import DownloadsPanel from "@/components/DownloadsPanel";
+import exportClient from "@/api/exportClient";
+
+describe("DownloadsPanel", () => {
+  it("shows toast when export completes", async () => {
+    const client = exportClient as unknown as {
+      getStatus: ReturnType<typeof vi.fn>;
+      getUrls: ReturnType<typeof vi.fn>;
+    };
+
+    render(<DownloadsPanel workspaceId="1" />);
+
+    await waitFor(() => expect(client.getStatus).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(screen.getByText("Markdown")).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/export ready/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- show skeleton placeholders in DocumentPanel until content arrives
- display toast notification when exports are ready
- cover skeleton and toast behaviors with tests

## Testing
- `npm test`
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/` *(fails: Command not found)*
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll` *(fails: Command not found)*
- `poetry run pip-audit` *(fails: Command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68982da79c84832b9887a1ad20e316ab