### PR TITLE
Secure SSE streams with JWT

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,9 @@ subscribe to via Server-Sent Events:
 - `values` – structured state snapshots.
 - `updates` – citation and progress updates.
 
-Connect to `/stream/<channel>` for public streams. Workspace-scoped streams
-require a token: `/stream/<channel>?token=<workspace-id>`.
+All stream connections require a short-lived JWT passed as a query parameter.
+Fetch a token from `GET /stream/token` and connect using
+`/stream/<channel>?token=<JWT>` or `/stream/<workspace>/<channel>?token=<JWT>`.
 
 ---
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -81,11 +81,12 @@ returns `501 Not Implemented` for all requests.
 Clients subscribe to four SSE endpoints to receive real-time updates. Each
 stream sends newline-delimited JSON messages where the `event` field indicates
 the channel and the payload conforms to the `SseEvent` schema (`type`,
-`payload`, `timestamp`).
+`payload`, `timestamp`). A short-lived JWT is required on the query string and
+can be obtained from `GET /stream/token`.
 
 ### 4.1 Token Messages
 
-#### GET `/api/stream/messages`
+#### GET `/stream/messages`
 
 - **Purpose**: Stream token-level diff messages from LLMs.
 - **Authentication**: Required (`viewer`, `editor`, or `admin`).
@@ -93,7 +94,7 @@ the channel and the payload conforms to the `SseEvent` schema (`type`,
 
 ### 4.2 Updates
 
-#### GET `/api/stream/updates`
+#### GET `/stream/updates`
 
 - **Purpose**: Stream citation additions and workflow progress updates.
 - **Authentication**: Required (`viewer`, `editor`, or `admin`).
@@ -101,7 +102,7 @@ the channel and the payload conforms to the `SseEvent` schema (`type`,
 
 ### 4.3 Values
 
-#### GET `/api/stream/values`
+#### GET `/stream/values`
 
 - **Purpose**: Stream structured state values as they change.
 - **Authentication**: Required (`viewer`, `editor`, or `admin`).
@@ -109,7 +110,7 @@ the channel and the payload conforms to the `SseEvent` schema (`type`,
 
 ### 4.4 Debug
 
-#### GET `/api/stream/debug`
+#### GET `/stream/debug`
 
 - **Purpose**: Stream diagnostic or debug messages.
 - **Authentication**: Required (`viewer`, `editor`, or `admin`).
@@ -120,26 +121,26 @@ the channel and the payload conforms to the `SseEvent` schema (`type`,
 Every channel above also supports a workspace-scoped variant that isolates
 events to a single workspace.
 
-#### GET `/api/stream/{workspace_id}/messages`
+#### GET `/stream/{workspace_id}/messages`
 
 - **Purpose**: Stream token-level diff messages for a specific workspace.
 - **Authentication**: Required (`viewer`, `editor`, or `admin`).
 - **Event Format**: `event: messages` with an `SseEvent` payload.
 
-#### GET `/api/stream/{workspace_id}/updates`
+#### GET `/stream/{workspace_id}/updates`
 
 - **Purpose**: Stream citation additions and workflow progress updates for a
   workspace.
 - **Authentication**: Required (`viewer`, `editor`, or `admin`).
 - **Event Format**: `event: updates` with an `SseEvent` payload.
 
-#### GET `/api/stream/{workspace_id}/values`
+#### GET `/stream/{workspace_id}/values`
 
 - **Purpose**: Stream structured state values for a workspace.
 - **Authentication**: Required (`viewer`, `editor`, or `admin`).
 - **Event Format**: `event: values` followed by an `SseEvent`.
 
-#### GET `/api/stream/{workspace_id}/debug`
+#### GET `/stream/{workspace_id}/debug`
 
 - **Purpose**: Stream diagnostic messages for a workspace.
 - **Authentication**: Required (`viewer`, `editor`, or `admin`).

--- a/frontend/src/api/sseClient.ts
+++ b/frontend/src/api/sseClient.ts
@@ -1,18 +1,17 @@
 // Utility for connecting to server-sent event streams for a workspace.
 // Includes basic reconnect logic with a fixed backoff.
 export function connectToWorkspaceStream(
-  token?: string,
-  channel = "state",
+  workspaceId: string,
+  token: string,
+  channel = "messages",
 ): EventSource {
-  const url = token
-    ? `/stream/${channel}?token=${token}`
-    : `/stream/${channel}`;
+  const url = `/stream/${workspaceId}/${channel}?token=${token}`;
   let source = new EventSource(url);
 
   source.onerror = () => {
     source.close();
     setTimeout(() => {
-      source = connectToWorkspaceStream(token, channel);
+      source = connectToWorkspaceStream(workspaceId, token, channel);
     }, 1000);
   };
 

--- a/src/web/routes/stream.py
+++ b/src/web/routes/stream.py
@@ -2,9 +2,20 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Request  # type: ignore[import-not-found]
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict
+
+import jwt
+from fastapi import (  # type: ignore[import-not-found]
+    APIRouter,
+    Depends,
+    HTTPException,
+    Request,
+    status,
+)
 from sse_starlette.sse import EventSourceResponse  # type: ignore[import-not-found]
 
+from web.auth import verify_jwt  # type: ignore[import-not-found]
 from web.sse import (  # type: ignore[import-not-found]
     stream_events,
     stream_workspace_events,
@@ -13,28 +24,72 @@ from web.sse import (  # type: ignore[import-not-found]
 router = APIRouter()
 
 
-@router.get("/stream/messages", response_model=None)
+def verify_stream_token(request: Request) -> Dict[str, Any]:
+    """Validate the short-lived JWT passed as a query parameter."""
+
+    token = request.query_params.get("token")
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing token"
+        )
+    secret = request.app.state.settings.jwt_secret
+    algorithm = request.app.state.settings.jwt_algorithm
+    try:
+        payload = jwt.decode(token, secret, algorithms=[algorithm])
+    except jwt.PyJWTError as exc:  # pragma: no cover - defensive
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+        ) from exc
+    if payload.get("role") != "user":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+    return payload
+
+
+@router.get("/stream/token")
+async def issue_stream_token(
+    request: Request, payload: Dict[str, Any] = Depends(verify_jwt)
+) -> Dict[str, str]:
+    """Return a short-lived JWT for authenticating SSE connections."""
+
+    exp = datetime.now(tz=timezone.utc) + timedelta(minutes=1)
+    token = jwt.encode(
+        {"role": payload.get("role", "user"), "exp": exp},
+        request.app.state.settings.jwt_secret,
+        algorithm=request.app.state.settings.jwt_algorithm,
+    )
+    return {"token": token}
+
+
+@router.get(
+    "/stream/messages", response_model=None, dependencies=[Depends(verify_stream_token)]
+)
 async def stream_messages(request: Request) -> EventSourceResponse:
     """Stream token diff messages."""
 
     return EventSourceResponse(stream_events("messages", request))
 
 
-@router.get("/stream/updates", response_model=None)
+@router.get(
+    "/stream/updates", response_model=None, dependencies=[Depends(verify_stream_token)]
+)
 async def stream_updates(request: Request) -> EventSourceResponse:
     """Stream citation and progress updates."""
 
     return EventSourceResponse(stream_events("updates", request))
 
 
-@router.get("/stream/values", response_model=None)
+@router.get(
+    "/stream/values", response_model=None, dependencies=[Depends(verify_stream_token)]
+)
 async def stream_values(request: Request) -> EventSourceResponse:
     """Stream structured state values."""
 
     return EventSourceResponse(stream_events("values", request))
 
 
-@router.get("/stream/debug", response_model=None)
+@router.get(
+    "/stream/debug", response_model=None, dependencies=[Depends(verify_stream_token)]
+)
 async def stream_debug(request: Request) -> EventSourceResponse:
     """Stream debug and diagnostic messages."""
 
@@ -51,7 +106,11 @@ def _workspace_event_response(
     )
 
 
-@router.get("/stream/{workspace_id}/messages", response_model=None)
+@router.get(
+    "/stream/{workspace_id}/messages",
+    response_model=None,
+    dependencies=[Depends(verify_stream_token)],
+)
 async def stream_workspace_messages(
     workspace_id: str, request: Request
 ) -> EventSourceResponse:
@@ -60,7 +119,11 @@ async def stream_workspace_messages(
     return _workspace_event_response(workspace_id, "messages", request)
 
 
-@router.get("/stream/{workspace_id}/updates", response_model=None)
+@router.get(
+    "/stream/{workspace_id}/updates",
+    response_model=None,
+    dependencies=[Depends(verify_stream_token)],
+)
 async def stream_workspace_updates(
     workspace_id: str, request: Request
 ) -> EventSourceResponse:
@@ -69,7 +132,11 @@ async def stream_workspace_updates(
     return _workspace_event_response(workspace_id, "updates", request)
 
 
-@router.get("/stream/{workspace_id}/values", response_model=None)
+@router.get(
+    "/stream/{workspace_id}/values",
+    response_model=None,
+    dependencies=[Depends(verify_stream_token)],
+)
 async def stream_workspace_values(
     workspace_id: str, request: Request
 ) -> EventSourceResponse:
@@ -78,7 +145,11 @@ async def stream_workspace_values(
     return _workspace_event_response(workspace_id, "values", request)
 
 
-@router.get("/stream/{workspace_id}/debug", response_model=None)
+@router.get(
+    "/stream/{workspace_id}/debug",
+    response_model=None,
+    dependencies=[Depends(verify_stream_token)],
+)
 async def stream_workspace_debug(
     workspace_id: str, request: Request
 ) -> EventSourceResponse:

--- a/tests/test_stream_endpoints.py
+++ b/tests/test_stream_endpoints.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import os
+from datetime import datetime, timedelta
 
+import jwt
 import pytest
 from httpx import ASGITransport, AsyncClient
 
@@ -17,7 +20,15 @@ async def test_stream_messages_endpoint() -> None:
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        async with client.stream("GET", "/stream/messages") as response:
+        token = jwt.encode(
+            {
+                "role": "user",
+                "exp": datetime.utcnow() + timedelta(minutes=1),
+            },
+            os.environ["JWT_SECRET"],
+            algorithm="HS256",
+        )
+        async with client.stream("GET", f"/stream/messages?token={token}") as response:
             await asyncio.sleep(0)
             stream_messages("hello")
             async for line in response.aiter_lines():
@@ -33,7 +44,17 @@ async def test_stream_workspace_messages_endpoint() -> None:
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         workspace_id = "abc123"
-        async with client.stream("GET", f"/stream/{workspace_id}/messages") as response:
+        token = jwt.encode(
+            {
+                "role": "user",
+                "exp": datetime.utcnow() + timedelta(minutes=1),
+            },
+            os.environ["JWT_SECRET"],
+            algorithm="HS256",
+        )
+        async with client.stream(
+            "GET", f"/stream/{workspace_id}/messages?token={token}"
+        ) as response:
             await asyncio.sleep(0)
             stream(f"{workspace_id}:messages", "world")
             async for line in response.aiter_lines():


### PR DESCRIPTION
## Summary
- add short-lived JWT issuance and validation for SSE endpoints
- pass SSE token query parameter from frontend
- document tokenized SSE streams

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(failed: CERTIFICATE_VERIFY_FAILED)*
- `npm run typecheck`
- `npm test`
- `poetry run pytest` *(failed: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_68982dceb8a4832ba228312e98676d4f