### PR TITLE
Type workspace document store

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,7 +12,7 @@ import { useWorkspaceStore } from "./store/useWorkspaceStore";
 // and renders the various panels bound to the global workspace store.
 const App: React.FC = () => {
   const connect = useWorkspaceStore((s) => s.connect);
-  const document = useWorkspaceStore((s) => s.document) as string;
+  const document = useWorkspaceStore((s) => s.document);
   const logs = useWorkspaceStore((s) => s.logs);
   const sources = useWorkspaceStore((s) => s.sources);
   const workspaceId = useWorkspaceStore((s) => s.workspaceId);
@@ -39,7 +39,7 @@ const App: React.FC = () => {
             <DataEntryForm />
           </div>
           <div className="card">
-            <DocumentPanel text={document || ""} onAcceptDiff={() => {}} />
+            <DocumentPanel text={document} onAcceptDiff={() => {}} />
           </div>
         </section>
         <aside className="space-y-4">

--- a/frontend/src/store/useWorkspaceStore.ts
+++ b/frontend/src/store/useWorkspaceStore.ts
@@ -7,9 +7,11 @@ export interface SseEvent {
   timestamp: string;
 }
 
+export type DocState = string;
+
 interface WorkspaceStore {
   workspaceId: string | null;
-  document: unknown;
+  document: DocState;
   logs: SseEvent[];
   sources: unknown[];
   exportStatus: string;
@@ -25,7 +27,7 @@ interface WorkspaceStore {
 // Global workspace state accessed throughout the UI.
 export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
   workspaceId: null,
-  document: null,
+  document: "",
   logs: [],
   sources: [],
   exportStatus: "idle",
@@ -55,7 +57,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
   updateState: (event: SseEvent) => {
     switch (event.type) {
       case "document":
-        set({ document: event.payload });
+        set({ document: String(event.payload) });
         break;
       case "log":
         set((state) => ({ logs: [...state.logs, event] }));


### PR DESCRIPTION
## Summary
- type `document` state as a string via `DocState`
- update consumers to treat `document` as a string

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: certificate verify failed)*
- `npm run typecheck` *(fails: tests/documentPanel.test.tsx:40 '}' expected)*
- `npm test` *(fails: transform error in tests/documentPanel.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6898325b44bc832b82497615d522b9b4