### PR TITLE
Add focus-visible rings to interactive elements

### DIFF
--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -15,7 +15,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "border-input ring-offset-background placeholder:text-muted-foreground focus:ring-ring flex h-9 w-full items-center justify-between rounded-md border bg-transparent px-3 py-2 text-sm shadow-sm focus:ring-1 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50",
+      "border-input ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-9 w-full items-center justify-between rounded-md border bg-transparent px-3 py-2 text-sm shadow-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
       className,
     )}
     {...props}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -60,6 +60,14 @@
   h6 {
     @apply font-serif;
   }
+
+  a,
+  button,
+  input,
+  textarea,
+  select {
+    @apply ring-offset-background focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
## Summary
- ensure anchors, buttons, inputs and form fields display a visible focus ring
- apply focus-visible ring styling to Select trigger component

## Testing
- `npx prettier frontend/src/index.css frontend/src/components/ui/select.tsx --write`
- `npm run lint:css`
- `npm test` *(fails: Unexpected "DocumentPanel" in tests/documentPanel.test.tsx)*
- `npm run typecheck` *(fails: tests/documentPanel.test.tsx(40,1): '}' expected)*
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLCertVerificationError: certificate verify failed)*

------
https://chatgpt.com/codex/tasks/task_e_689832649f3c832b9cb0f4881244f66a