### PR TITLE
feat: add API fetch wrapper

### DIFF
--- a/frontend/src/api/citationClient.ts
+++ b/frontend/src/api/citationClient.ts
@@ -1,3 +1,5 @@
+import { apiFetch } from "./http";
+
 export interface Citation {
   url: string;
   title: string;
@@ -9,7 +11,9 @@ export async function getCitation(
   workspaceId: string,
   citationId: string,
 ): Promise<Citation> {
-  const res = await fetch(`/workspaces/${workspaceId}/citations/${citationId}`);
+  const res = await apiFetch(
+    `/workspaces/${workspaceId}/citations/${citationId}`,
+  );
   if (!res.ok) {
     throw new Error(`Failed to fetch citation ${citationId}`);
   }

--- a/frontend/src/api/controlClient.ts
+++ b/frontend/src/api/controlClient.ts
@@ -1,21 +1,23 @@
+import { apiFetch } from "./http";
+
 /** Simple client for posting control commands to workspace endpoints. */
 export async function run(workspaceId: string): Promise<void> {
-  await request(`/workspaces/${workspaceId}/run`);
+  await post(`/workspaces/${workspaceId}/run`);
 }
 
 /** Pause the graph execution for a workspace. */
 export async function pause(workspaceId: string): Promise<void> {
-  await request(`/workspaces/${workspaceId}/pause`);
+  await post(`/workspaces/${workspaceId}/pause`);
 }
 
 /** Retry the graph using the last inputs. */
 export async function retry(workspaceId: string): Promise<void> {
-  await request(`/workspaces/${workspaceId}/retry`);
+  await post(`/workspaces/${workspaceId}/retry`);
 }
 
 /** Resume a previously paused graph. */
 export async function resume(workspaceId: string): Promise<void> {
-  await request(`/workspaces/${workspaceId}/resume`);
+  await post(`/workspaces/${workspaceId}/resume`);
 }
 
 /** Select the model to run subsequent operations against. */
@@ -23,19 +25,16 @@ export async function selectModel(
   workspaceId: string,
   model: string,
 ): Promise<void> {
-  await request(`/workspaces/${workspaceId}/model`, { model });
+  await post(`/workspaces/${workspaceId}/model`, { model });
 }
 
 /** Helper performing POST requests and surfacing failures. */
-async function request(
+async function post(
   url: string,
   body?: Record<string, unknown>,
 ): Promise<void> {
-  const res = await fetch(url, {
+  const res = await apiFetch(url, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
     body: body ? JSON.stringify(body) : undefined,
   });
   if (!res.ok) {

--- a/frontend/src/api/exportClient.ts
+++ b/frontend/src/api/exportClient.ts
@@ -1,3 +1,5 @@
+import { apiFetch } from "./http";
+
 export interface ExportStatus {
   ready: boolean;
 }
@@ -6,7 +8,7 @@ export type ExportUrls = Record<"md" | "docx" | "pdf" | "zip", string>;
 
 /** Retrieve current export generation status for a workspace. */
 export async function getStatus(workspaceId: string): Promise<ExportStatus> {
-  const res = await fetch(`/workspaces/${workspaceId}/export/status`);
+  const res = await apiFetch(`/workspaces/${workspaceId}/export/status`);
   if (!res.ok) {
     throw new Error("Failed to fetch export status");
   }
@@ -15,7 +17,7 @@ export async function getStatus(workspaceId: string): Promise<ExportStatus> {
 
 /** Fetch download URLs for generated export artifacts. */
 export async function getUrls(workspaceId: string): Promise<ExportUrls> {
-  const res = await fetch(`/workspaces/${workspaceId}/export/urls`);
+  const res = await apiFetch(`/workspaces/${workspaceId}/export/urls`);
   if (!res.ok) {
     throw new Error("Failed to fetch export URLs");
   }

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -1,0 +1,12 @@
+const API_BASE = import.meta.env.VITE_API_BASE ?? "/api";
+const token = () => localStorage.getItem("jwt") ?? "";
+
+export async function apiFetch(path: string, init: RequestInit = {}) {
+  const headers = new Headers(init.headers);
+  if (!headers.has("Authorization") && token()) {
+    headers.set("Authorization", `Bearer ${token()}`);
+  }
+  if (!headers.has("Content-Type"))
+    headers.set("Content-Type", "application/json");
+  return fetch(`${API_BASE}${path}`, { ...init, headers });
+}


### PR DESCRIPTION
## Summary
- centralize API base URL and authorization header in new apiFetch helper
- update control, export, and citation clients to use apiFetch

## Testing
- `npm run lint`
- `npm test` *(fails: Unexpected "DocumentPanel" in tests/documentPanel.test.tsx)*
- `npm run typecheck` *(fails: tests/documentPanel.test.tsx(40,1): error TS1005: '}' expected)*
- `npx prettier --check frontend/src/api/http.ts frontend/src/api/controlClient.ts frontend/src/api/exportClient.ts frontend/src/api/citationClient.ts`
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLCertVerificationError)*

------
https://chatgpt.com/codex/tasks/task_e_68986c7d01c4832b8828af3e3b0d9408