### PR TITLE
refactor: simplify SSE connection

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -213,7 +213,6 @@ Each node module defines a single `async` handler function and its input/output 
 
 - **File:** `src/core/orchestrator.py`
 - **Class `GraphOrchestrator`**
-
   - `run(state: State) -> State` — execute the pipeline for a given state.
   - `stream(state: State)` — yield progress events for each executed node.
 
@@ -813,7 +812,7 @@ def from_schema(weave: WeaveResult) -> str:
 
      ```python
      @app.get("/stream/{workspace}", response_model=None)
-    async def stream_events(workspace: str):
+     async def stream_events(workspace: str):
         return EventSourceResponse(stream_workspace_events(workspace, "state"))
      ```
 
@@ -845,7 +844,7 @@ def from_schema(weave: WeaveResult) -> str:
    - **Why**: single source of truth; panels subscribe here.
 
 1. **`frontend/src/api/sseClient.ts`**
-   - `connectToWorkspaceStream(workspaceId: string): EventSource`
+   - `connectToWorkspaceStream(token?: string, channel = "messages"): EventSource`
    - **Why**: encapsulates browser SSE setup (reconnect logic, backoff).
 
 1. **Directory `frontend/src/components/`**

--- a/frontend/src/api/sseClient.ts
+++ b/frontend/src/api/sseClient.ts
@@ -1,17 +1,18 @@
-// Utility for connecting to server-sent event streams for a workspace.
+// Utility for connecting to server-sent event streams.
 // Includes basic reconnect logic with a fixed backoff.
 export function connectToWorkspaceStream(
-  workspaceId: string,
-  token: string,
+  token?: string,
   channel = "messages",
 ): EventSource {
-  const url = `/stream/${workspaceId}/${channel}?token=${token}`;
+  const url = token
+    ? `/stream/${channel}?token=${encodeURIComponent(token)}`
+    : `/stream/${channel}`;
   let source = new EventSource(url);
 
   source.onerror = () => {
     source.close();
     setTimeout(() => {
-      source = connectToWorkspaceStream(workspaceId, token, channel);
+      source = connectToWorkspaceStream(token, channel);
     }, 1000);
   };
 

--- a/frontend/src/store/useWorkspaceStore.ts
+++ b/frontend/src/store/useWorkspaceStore.ts
@@ -39,7 +39,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
       try {
         const resp = await fetch("/stream/token");
         const { token } = (await resp.json()) as { token: string };
-        const es = connectToWorkspaceStream(workspaceId, token);
+        const es = connectToWorkspaceStream(token);
         es.onmessage = (e: MessageEvent) => {
           try {
             const event: SseEvent = JSON.parse(e.data);


### PR DESCRIPTION
## Summary
- use "messages" as the default SSE channel
- connect using optional token rather than workspace-id path
- update docs to reflect new SSE client signature

## Testing
- `npx prettier --write frontend/src/api/sseClient.ts frontend/src/store/useWorkspaceStore.ts docs/IMPLEMENTATION_PLAN.md`
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/` *(failed: Command not found)*
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll` *(failed: Command not found)*
- `poetry run pip-audit` *(failed: Command not found)*
- `npm run lint`
- `npm test` *(failed: Unexpected "DocumentPanel" error)*
- `npm run typecheck` *(failed: tests/documentPanel.test.tsx(40,1): error TS1005: '}' expected.)*

------
https://chatgpt.com/codex/tasks/task_e_68986ed2c858832bbdd8bce8052d1703