### PR TITLE
Add dev proxy for FastAPI backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ To run the services directly on your host for development:
    npm run dev
    ```
 
+   The Vite dev server proxies `/api` and `/stream` requests to `http://localhost:8000`,
+   allowing the frontend to call those paths without specifying a host.
+
 3. Open your browser at `http://localhost:3000` and enter a topic to begin.
 
 ---

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,16 @@ import tailwindcss from "@tailwindcss/vite";
 export default defineConfig({
   root: "frontend",
   plugins: [react(), tailwindcss()],
+  server: {
+    proxy: {
+      "/api": "http://localhost:8000",
+      "/stream": {
+        target: "http://localhost:8000",
+        ws: false,
+        changeOrigin: true,
+      },
+    },
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "frontend/src"),


### PR DESCRIPTION
## Summary
- route `/api` and `/stream` through Vite dev server to FastAPI on port 8000
- document proxy behavior in README

## Testing
- `npx prettier --write vite.config.ts README.md`
- `npm run lint` (warnings)
- `npm run typecheck` (failed: tests/documentPanel.test.tsx:40:1 - error TS1005: '}' expected.)
- `npm test` (failed: Unexpected "DocumentPanel" in tests/documentPanel.test.tsx)
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` (failed: SSLError)


------
https://chatgpt.com/codex/tasks/task_e_6898705c3318832b8a55e11ffdc776b3