### PR TITLE
feat: seed dev jwt for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,18 @@ docker compose up --build
 
 Then open your browser at `http://localhost:8000`.
 
+The frontend seeds a development JWT (`role: user`) in `localStorage` so API
+requests work without a login flow:
+
+```js
+localStorage.setItem(
+  "jwt",
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoidXNlciJ9.hM2ErG_O2e4d9YiCeVoTbiRDoo4ziDiIPfDFE40GUlg",
+);
+```
+
+Replace the token with one signed using your `JWT_SECRET` for custom setups.
+
 To run the services directly on your host for development:
 
 1. **Start the backend** (FastAPI + custom orchestrator):

--- a/frontend/src/components/DocumentPanel.tsx
+++ b/frontend/src/components/DocumentPanel.tsx
@@ -37,7 +37,7 @@ const DocumentPanel: React.FC<Props> = ({ text, onAcceptDiff }) => {
     }
   }, [text, onAcceptDiff]);
 
-  if (tokens.length === 0) {
+  if (text.length === 0) {
     return (
       <div
         data-testid="document-skeleton"

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -14,6 +14,15 @@ if (traceUrl) {
   });
 }
 
+// Seed a development JWT so API requests succeed without a login flow.
+// Token payload: {"role":"user"}
+if (import.meta.env.DEV && !localStorage.getItem("jwt")) {
+  localStorage.setItem(
+    "jwt",
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoidXNlciJ9.hM2ErG_O2e4d9YiCeVoTbiRDoo4ziDiIPfDFE40GUlg",
+  );
+}
+
 // Bootstraps the React application and mounts it to the DOM root element.
 const container = document.getElementById("root");
 if (container) {

--- a/frontend/src/store/useWorkspaceStore.ts
+++ b/frontend/src/store/useWorkspaceStore.ts
@@ -9,11 +9,16 @@ export interface SseEvent {
 
 export type DocState = string;
 
+interface SourceItem {
+  url?: string;
+  title?: string;
+}
+
 interface WorkspaceStore {
   workspaceId: string | null;
   document: DocState;
   logs: SseEvent[];
-  sources: unknown[];
+  sources: (string | SourceItem)[];
   exportStatus: string;
   status: "idle" | "running" | "paused";
   model: string;
@@ -65,7 +70,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
       case "source":
         set({
           sources: Array.isArray(event.payload)
-            ? (event.payload as unknown[])
+            ? (event.payload as (string | SourceItem)[])
             : [],
         });
         break;

--- a/tests/documentPanel.test.tsx
+++ b/tests/documentPanel.test.tsx
@@ -1,6 +1,5 @@
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
-
 import { vi } from "vitest";
 import DocumentPanel from "@/components/DocumentPanel";
 
@@ -22,10 +21,8 @@ describe("DocumentPanel", () => {
       expect(m.tagName).toBe("MARK");
       expect(m).toHaveClass("bg-yellow-200");
     });
+  });
 
-import DocumentPanel from "@/components/DocumentPanel";
-
-describe("DocumentPanel", () => {
   it("shows skeleton when empty", () => {
     render(<DocumentPanel text="" onAcceptDiff={() => {}} />);
     expect(screen.getByTestId("document-skeleton")).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- seed a development JWT so the frontend can call APIs without a login flow
- clean up workspace store and document panel tests to satisfy type checks

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLCertVerificationError)*

------
https://chatgpt.com/codex/tasks/task_e_6898720f2dc0832b87ed1ce332b8bcf2