### PR TITLE
Remove unimplemented control routes

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -46,33 +46,53 @@ This document provides a **detailed**, **explicit** reference for all backend HT
 
 ### 3.1 Start New Lecture Build
 
-#### POST `/api/run`
+#### POST `/api/workspaces/{workspace_id}/run`
 
 - **Purpose**: Begin a new lecture/workshop generation job.
 
 - **Authentication**: Required (`editor` or `admin`).
 
+- **Path Parameters**:
+
+  | Parameter      | Type   | Description                       |
+  | -------------- | ------ | --------------------------------- |
+  | `workspace_id` | String | Identifier for the workspace/job. |
+
 - **Request Body (JSON)**:
 
-  | Field     | Type   | Required | Description                               |
-  | --------- | ------ | -------- | ----------------------------------------- |
-  | `topic`   | String | Yes      | Lecture or workshop prompt string.        |
-  | `options` | Object | No       | Optional settings (e.g. model overrides). |
+  | Field   | Type   | Required | Description                        |
+  | ------- | ------ | -------- | ---------------------------------- |
+  | `topic` | String | Yes      | Lecture or workshop prompt string. |
 
 - **Response (JSON)**:
   - **201 Created**
 
     ```json
-    { "job_id": "123e4567-e89b-12d3-a456-426614174000" }
+    {
+      "job_id": "123e4567-e89b-12d3-a456-426614174000",
+      "workspace_id": "123e4567-e89b-12d3-a456-426614174000"
+    }
     ```
 
   - **400 Bad Request**: Invalid or missing `topic`.
   - **401 Unauthorized**: Missing or invalid JWT.
 
-### 3.2 Resume Existing Job
+### 3.2 Retry Existing Job
 
-The `POST /api/resume/{job_id}` endpoint is **not yet implemented** and currently
-returns `501 Not Implemented` for all requests.
+#### POST `/api/workspaces/{workspace_id}/retry`
+
+- **Purpose**: Retry the graph using the last inputs for a workspace.
+
+- **Authentication**: Required (`editor` or `admin`).
+
+- **Response (JSON)**:
+
+  ```json
+  {
+    "workspace_id": "123e4567-e89b-12d3-a456-426614174000",
+    "status": "retried"
+  }
+  ```
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -35,8 +35,8 @@ This document provides a **comprehensive** and **explicit** description of the L
 
 1. **API Layer (FastAPI)**
    - **Endpoints**:
-   - `POST /run` — start new lecture build job
-   - `POST /resume/{job_id}` — resume after crash *(not implemented)*
+   - `POST /workspaces/{workspace_id}/run` — start new lecture build job
+   - `POST /workspaces/{workspace_id}/retry` — retry using last inputs
    - `SSE /stream/messages` — token diff messages
    - `SSE /stream/updates` — citation and progress updates
    - `SSE /stream/values` — state values
@@ -89,7 +89,7 @@ This document provides a **comprehensive** and **explicit** description of the L
   - **LogPanel**: chronological action entries with filters
   - **SourcesPanel**: citation list and snippet previews
   - **QualityTab**: gauge charts for pedagogy and fact-check scores
-  - **Controls**: run, pause, retry, model selector, export dropdown
+  - **Controls**: run and retry buttons, export dropdown
 
 - **SSE Client**: `web/src/services/stream.ts` subscribes and dispatches to Redux or Zustand store
 - **Download Buttons**: trigger GET requests to `/download/...`
@@ -100,7 +100,7 @@ This document provides a **comprehensive** and **explicit** description of the L
 
 ### 3.1 Initial Job Execution
 
-1. **User submits topic** via `POST /run`.
+1. **User submits topic** via `POST /workspaces/{workspace_id}/run`.
 2. **FastAPI** enqueues job and returns `job_id`.
 3. **Orchestrator.invoke(job_id)** triggers:
    - **Planner** generates `learning_objectives`, `modules` → `stream(values)`.
@@ -111,13 +111,6 @@ This document provides a **comprehensive** and **explicit** description of the L
 4. **Frontend** receives SSE streams, updates panels in real time.
 5. **Exporter** writes final files and signals completion.
 6. **Browser** enables download buttons.
-
-### 3.2 Resume After Crash *(not implemented)*
-
-1. **Planned:** `POST /resume/{job_id}` would reload the latest checkpoint and
-   continue processing remaining agents.
-2. **Current state:** the endpoint returns `501 Not Implemented` and performs no
-   recovery.
 
 ### 3.3 Citation Cache Hit/Miss
 
@@ -163,16 +156,16 @@ This document provides a **comprehensive** and **explicit** description of the L
 
 ## 5. Interfaces and Protocols
 
-| Interface                    | Protocol                               | Format         | Direction           |
-| ---------------------------- | -------------------------------------- | -------------- | ------------------- |
-| `/run`                       | HTTP REST                              | JSON           | Client → Server     |
-| `/resume` *(not implemented)* | HTTP REST                              | JSON           | Client → Server     |
-| SSE Streams                  | SSE                                    | JSON messages  | Server → Client     |
-| `/download`                  | HTTP REST                              | Binary stream  | Client ← Server     |
-| Orchestrator invocations     | In-process Call                        | Python objects | Orchestrator        |
-| Perplexity Sonar            | HTTP REST                              | JSON           | Server → Perplexity |
-| OpenAI API                   | HTTP REST                              | JSON           | Server → OpenAI     |
-| DB Access                    | SQL over TCP (PG) or File I/O (SQLite) | SQL            | Server ↔ DB        |
+| Interface                          | Protocol                               | Format         | Direction           |
+| ---------------------------------- | -------------------------------------- | -------------- | ------------------- |
+| `/workspaces/{workspace_id}/run`   | HTTP REST                              | JSON           | Client → Server     |
+| `/workspaces/{workspace_id}/retry` | HTTP REST                              | JSON           | Client → Server     |
+| SSE Streams                        | SSE                                    | JSON messages  | Server → Client     |
+| `/download`                        | HTTP REST                              | Binary stream  | Client ← Server     |
+| Orchestrator invocations           | In-process Call                        | Python objects | Orchestrator        |
+| Perplexity Sonar                   | HTTP REST                              | JSON           | Server → Perplexity |
+| OpenAI API                         | HTTP REST                              | JSON           | Server → OpenAI     |
+| DB Access                          | SQL over TCP (PG) or File I/O (SQLite) | SQL            | Server ↔ DB        |
 
 ---
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -36,14 +36,6 @@ Command-line shortcuts for running the application, executing tests, and handlin
   npm test
   ```
 
-- **Resume workflow smoke test**
-
-  ```bash
-  ./scripts/test_resume.sh "<prompt>"
-  ```
-
-  Starts the server, generates an outline for the prompt, and verifies export resume functionality.
-
 ## Maintenance
 
 - **Reset the workspace database**

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -222,7 +222,7 @@ Further ER diagrams in ARCHITECTURE.md.
 - **DocumentPanel**: displays streamed markdown with diff highlights.
 - **LogPanel**: lists `action_log` entries, filterable by agent and severity.
 - **SourcesPanel**: shows citation snippets with `license` badges.
-- **ControlsPanel**: run/pause/retry, model selector, export buttons.
+- **ControlsPanel**: run and retry buttons, export controls.
 - **QualityTab**: visual gauges for pedagogy and fact-check scores.
 
 ### 11.2 Streaming Implementation

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -895,18 +895,18 @@ def from_schema(weave: WeaveResult) -> str:
 
 ---
 
-### H5. Controls & Model Selector
+### H5. Controls
 
 1. **`frontend/src/api/controlClient.ts`**
-   - `run(topic: string)`, `resume(jobId: string)`
+   - `run(workspaceId: string)`, `retry(workspaceId: string)`
    - **Why**: wrappers for the control endpoints.
 
 1. **`frontend/src/components/ControlsPanel.tsx`**
-   - **Buttons**: Run, Resume
+   - **Buttons**: Run, Retry
    - **Handlers**:
-     - `onRunClick()`, `onResumeClick()`, invoking respective `controlClient` methods and updating store.
+     - `onRunClick()`, `onRetryClick()`, invoking respective `controlClient` methods and updating store.
 
-   - **Why**: let users start and resume lecture generation jobs.
+   - **Why**: let users start and retry lecture generation jobs.
 
 1. **`tests/frontend/components/ControlsPanel.test.tsx`**
    - Simulate clicks, verify correct API calls and disabled states.
@@ -1154,7 +1154,7 @@ def from_schema(weave: WeaveResult) -> str:
 3. **File:** `src/web/routes/*.py`
    - **Usage:**
      - In `export` routes: add `dependencies=[Depends(ensure_viewer)]`.
-     - In `run/pause/retry` routes: `dependencies=[Depends(ensure_editor)]`.
+     - In `run/retry` routes: `dependencies=[Depends(ensure_editor)]`.
      - In governance or metrics endpoints: `dependencies=[Depends(ensure_admin)]`.
 
 4. **Tests:**

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -19,16 +19,16 @@ This document defines a **comprehensive**, **explicit** Test Plan for the Lectur
 
 ## 2. Testing Levels
 
-| Level                          | Description                                                   | Tools                                     | Ownership       |
-| ------------------------------ | ------------------------------------------------------------- | ----------------------------------------- | --------------- |
-| **Unit Testing**               | Component-level tests for functions, classes, schemas         | Pytest, Jest                              | Devs            |
+| Level                          | Description                                                      | Tools                                     | Ownership       |
+| ------------------------------ | ---------------------------------------------------------------- | ----------------------------------------- | --------------- |
+| **Unit Testing**               | Component-level tests for functions, classes, schemas            | Pytest, Jest                              | Devs            |
 | **Integration Testing**        | Interaction between backend services, orchestrator workflows, DB | Pytest, Postman, Docker Compose           | Devs            |
-| **End-to-End (E2E)**           | Simulate user flows from prompt to download                   | Playwright, Cypress                       | QA              |
-| **Performance Testing**        | Throughput, latency, resource utilization under load          | k6, Locust                                | SRE/QoS Team    |
-| **Security Testing**           | SAST, DAST, dependency scans, penetration tests               | Bandit, OWASP ZAP, Trivy, custom pen-test | DevSecOps       |
-| **Accessibility Testing**      | WCAG 2.1 AA compliance, keyboard navigation                   | Lighthouse CI, axe-core                   | UX/QA           |
-| **Compliance Testing**         | GDPR, Privacy Act, FERPA export/delete flows                  | Manual test scripts, policy checklists    | Compliance Team |
-| **Chaos & Resilience Testing** | Fault injection, crash recovery                               | Gremlin, Chaos Monkey                     | SRE             |
+| **End-to-End (E2E)**           | Simulate user flows from prompt to download                      | Playwright, Cypress                       | QA              |
+| **Performance Testing**        | Throughput, latency, resource utilization under load             | k6, Locust                                | SRE/QoS Team    |
+| **Security Testing**           | SAST, DAST, dependency scans, penetration tests                  | Bandit, OWASP ZAP, Trivy, custom pen-test | DevSecOps       |
+| **Accessibility Testing**      | WCAG 2.1 AA compliance, keyboard navigation                      | Lighthouse CI, axe-core                   | UX/QA           |
+| **Compliance Testing**         | GDPR, Privacy Act, FERPA export/delete flows                     | Manual test scripts, policy checklists    | Compliance Team |
+| **Chaos & Resilience Testing** | Fault injection, crash recovery                                  | Gremlin, Chaos Monkey                     | SRE             |
 
 ---
 
@@ -163,7 +163,7 @@ All test data stored in `tests/fixtures/` with version control.
 ### 9.1 E2E Test Scenarios
 
 1. **Happy Path**: User submits topic, watches streaming, downloads all formats.
-2. **Resume Path**: Interrupt job mid-stream, resume, and complete.
+2. **Retry Path**: Interrupt job mid-stream, retry, and complete.
 3. **Error Path**: Researcher API failure triggers retry logic, then fallback to cache.
 4. **RBAC Enforcement**: `viewer` cannot start jobs; `editor` can.
 5. **Invalid Input**: Empty or malicious prompt yields validation error.

--- a/frontend/src/api/controlClient.ts
+++ b/frontend/src/api/controlClient.ts
@@ -5,27 +5,9 @@ export async function run(workspaceId: string): Promise<void> {
   await post(`/workspaces/${workspaceId}/run`);
 }
 
-/** Pause the graph execution for a workspace. */
-export async function pause(workspaceId: string): Promise<void> {
-  await post(`/workspaces/${workspaceId}/pause`);
-}
-
 /** Retry the graph using the last inputs. */
 export async function retry(workspaceId: string): Promise<void> {
   await post(`/workspaces/${workspaceId}/retry`);
-}
-
-/** Resume a previously paused graph. */
-export async function resume(workspaceId: string): Promise<void> {
-  await post(`/workspaces/${workspaceId}/resume`);
-}
-
-/** Select the model to run subsequent operations against. */
-export async function selectModel(
-  workspaceId: string,
-  model: string,
-): Promise<void> {
-  await post(`/workspaces/${workspaceId}/model`, { model });
 }
 
 /** Helper performing POST requests and surfacing failures. */
@@ -42,4 +24,4 @@ async function post(
   }
 }
 
-export default { run, pause, retry, resume, selectModel };
+export default { run, retry };

--- a/frontend/src/components/ControlsPanel.tsx
+++ b/frontend/src/components/ControlsPanel.tsx
@@ -6,34 +6,18 @@ interface Props {
   workspaceId: string;
 }
 
-// Renders basic graph controls and a model selector.
+// Renders basic graph controls.
 const ControlsPanel: React.FC<Props> = ({ workspaceId }) => {
-  const { status, model, setStatus, setModel } = useWorkspaceStore();
+  const { status, setStatus } = useWorkspaceStore();
 
   const onRunClick = async () => {
     await controlClient.run(workspaceId);
     setStatus("running");
   };
 
-  const onPauseClick = async () => {
-    await controlClient.pause(workspaceId);
-    setStatus("paused");
-  };
-
   const onRetryClick = async () => {
     await controlClient.retry(workspaceId);
     setStatus("running");
-  };
-
-  const onResumeClick = async () => {
-    await controlClient.resume(workspaceId);
-    setStatus("running");
-  };
-
-  const onModelChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const m = e.target.value;
-    await controlClient.selectModel(workspaceId, m);
-    setModel(m);
   };
 
   return (
@@ -46,38 +30,12 @@ const ControlsPanel: React.FC<Props> = ({ workspaceId }) => {
         {status === "running" ? "Running…" : "Run"}
       </button>
       <button
-        onClick={onPauseClick}
-        disabled={status !== "running"}
-        className="btn disabled:opacity-50"
-      >
-        Pause
-      </button>
-      <button
         onClick={onRetryClick}
         disabled={status === "running"}
         className="btn disabled:opacity-50"
       >
         Retry
       </button>
-      <button
-        onClick={onResumeClick}
-        disabled={status !== "paused"}
-        className="btn disabled:opacity-50"
-      >
-        Resume
-      </button>
-      <label className="text-sm" htmlFor="model">
-        Model
-      </label>
-      <select
-        id="model"
-        value={model}
-        onChange={onModelChange}
-        className="rounded-lg border border-black/10 bg-white/80 px-3 py-2 text-sm shadow-sm dark:border-white/15 dark:bg-gray-900/80"
-      >
-        <option value="o4-mini">o4-mini</option>
-        <option value="o3">o3</option>
-      </select>
     </div>
   );
 };

--- a/frontend/src/store/useWorkspaceStore.ts
+++ b/frontend/src/store/useWorkspaceStore.ts
@@ -20,13 +20,11 @@ interface WorkspaceStore {
   logs: SseEvent[];
   sources: (string | SourceItem)[];
   exportStatus: string;
-  status: "idle" | "running" | "paused";
-  model: string;
+  status: "idle" | "running";
   connect: (workspaceId: string) => void;
   setWorkspaceId: (workspaceId: string | null) => void;
   updateState: (event: SseEvent) => void;
-  setStatus: (status: "idle" | "running" | "paused") => void;
-  setModel: (model: string) => void;
+  setStatus: (status: "idle" | "running") => void;
 }
 
 // Global workspace state accessed throughout the UI.
@@ -37,7 +35,6 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
   sources: [],
   exportStatus: "idle",
   status: "idle",
-  model: "o4-mini",
   connect: (workspaceId: string) => {
     set({ workspaceId });
     (async () => {
@@ -82,7 +79,6 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
     }
   },
   setStatus: (status) => set({ status }),
-  setModel: (model) => set({ model }),
 }));
 
 // Selectors provide convenient accessors to slices of the workspace state.
@@ -91,6 +87,5 @@ export const logEvents = () => useWorkspaceStore.getState().logs;
 export const sources = () => useWorkspaceStore.getState().sources;
 export const exportStatus = () => useWorkspaceStore.getState().exportStatus;
 export const runStatus = () => useWorkspaceStore.getState().status;
-export const selectedModel = () => useWorkspaceStore.getState().model;
 export const currentWorkspaceId = () =>
   useWorkspaceStore.getState().workspaceId;

--- a/src/web/routes/control.py
+++ b/src/web/routes/control.py
@@ -3,15 +3,13 @@
 from __future__ import annotations
 
 import asyncio
-from typing import NoReturn
 
-from fastapi import APIRouter, Body, HTTPException, Request
+from fastapi import APIRouter, Body, Request
 
 from core.orchestrator import GraphOrchestrator
 from core.state import State
 
 TopicBody = Body(..., embed=True)
-ModelBody = Body(..., embed=True)
 router = APIRouter(prefix="/workspaces/{workspace_id}")
 
 
@@ -37,29 +35,8 @@ async def run(
     return {"job_id": workspace_id, "workspace_id": workspace_id}
 
 
-@router.post("/pause")
-async def pause(workspace_id: str) -> NoReturn:
-    """Pause the graph execution for a workspace."""
-
-    raise HTTPException(status_code=501, detail="Not implemented")
-
-
 @router.post("/retry")
 async def retry(workspace_id: str) -> dict[str, str]:
     """Retry the graph using the last inputs for a workspace."""
 
     return {"workspace_id": workspace_id, "status": "retried"}
-
-
-@router.post("/resume")
-async def resume(workspace_id: str) -> NoReturn:
-    """Resume processing for a previously started job."""
-
-    raise HTTPException(status_code=501, detail="Not implemented")
-
-
-@router.post("/model")
-async def model(workspace_id: str, model: str = ModelBody) -> NoReturn:
-    """Select the model to run subsequent operations against."""
-
-    raise HTTPException(status_code=501, detail="Not implemented")

--- a/tests/test_control_routes.py
+++ b/tests/test_control_routes.py
@@ -49,18 +49,6 @@ def test_control_endpoints() -> None:
     assert resp.status_code == 201
     assert resp.json() == {"job_id": "abc", "workspace_id": "abc"}
 
-    resp = client.post("/api/workspaces/abc/pause")
-    assert resp.status_code == 501
-    assert resp.json() == {"detail": "Not implemented"}
-
     resp = client.post("/api/workspaces/abc/retry")
     assert resp.status_code == 200
     assert resp.json() == {"workspace_id": "abc", "status": "retried"}
-
-    resp = client.post("/api/workspaces/abc/resume")
-    assert resp.status_code == 501
-    assert resp.json() == {"detail": "Not implemented"}
-
-    resp = client.post("/api/workspaces/abc/model", json={"model": "gpt"})
-    assert resp.status_code == 501
-    assert resp.json() == {"detail": "Not implemented"}


### PR DESCRIPTION
## Summary
- drop pause, resume, and model selection endpoints
- simplify frontend controls and state to only support run and retry
- update API and architecture docs to match available routes

## Testing
- `npx prettier frontend/src/api/controlClient.ts frontend/src/components/ControlsPanel.tsx frontend/src/store/useWorkspaceStore.ts docs/API_REFERENCE.md docs/ARCHITECTURE.md docs/DESIGN.md docs/IMPLEMENTATION_PLAN.md docs/CLI_REFERENCE.md docs/TEST_PLAN.md --write`
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/` *(fails: src/web/routes/stream.py:50:49: B008 Do not perform function calls in argument defaults)*
- `poetry run flake8 src/web/routes/control.py tests/test_control_routes.py`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLCertVerificationError missing Authority Key Identifier)*
- `poetry run pytest` *(fails: 22 errors during collection)*
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68987727f5e8832ba3015683df292252