### PR TITLE
feat(ui): add skeletons for logs and sources

### DIFF
--- a/frontend/src/components/LogPanel.tsx
+++ b/frontend/src/components/LogPanel.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { SseEvent } from "../store/useWorkspaceStore";
+import { Skeleton } from "./ui/skeleton";
 
 interface Props {
   logs: SseEvent[];
@@ -17,8 +18,14 @@ const LogPanel: React.FC<Props> = ({ logs }) => {
     estimateSize: () => 32,
   });
 
-  if (!logs?.length)
-    return <p className="text-sm text-gray-500">No activity yet.</p>;
+  if (!logs.length)
+    return (
+      <div data-testid="logs-skeleton" className="space-y-2">
+        <Skeleton className="h-4 w-3/4" />
+        <Skeleton className="h-4 w-2/3" />
+        <Skeleton className="h-4 w-1/2" />
+      </div>
+    );
 
   return (
     <div ref={parentRef} className="max-h-64 overflow-auto">

--- a/frontend/src/components/SourcesPanel.tsx
+++ b/frontend/src/components/SourcesPanel.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Skeleton } from "./ui/skeleton";
 
 interface SourceItem {
   url?: string;
@@ -11,8 +12,13 @@ interface Props {
 
 // Display source links with hostnames.
 const SourcesPanel: React.FC<Props> = ({ sources }) => {
-  if (!sources?.length)
-    return <p className="text-sm text-gray-500">No sources yet.</p>;
+  if (!sources.length)
+    return (
+      <div data-testid="sources-skeleton" className="space-y-2">
+        <Skeleton className="h-4 w-2/3" />
+        <Skeleton className="h-4 w-1/3" />
+      </div>
+    );
   return (
     <ul className="space-y-2">
       {sources.map((s, idx) => {

--- a/tests/logPanel.test.tsx
+++ b/tests/logPanel.test.tsx
@@ -1,0 +1,23 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import LogPanel from "@/components/LogPanel";
+
+describe("LogPanel", () => {
+  it("shows skeleton when empty", () => {
+    render(<LogPanel logs={[]} />);
+    expect(screen.getByTestId("logs-skeleton")).toBeInTheDocument();
+  });
+
+  it("renders log entries when provided", () => {
+    const logs = [
+      {
+        type: "info",
+        payload: {},
+        timestamp: new Date().toISOString(),
+      },
+    ];
+    render(<LogPanel logs={logs} />);
+    expect(screen.queryByTestId("logs-skeleton")).toBeNull();
+    expect(screen.getByRole("list")).toBeInTheDocument();
+  });
+});

--- a/tests/sourcesPanel.test.tsx
+++ b/tests/sourcesPanel.test.tsx
@@ -1,0 +1,17 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import SourcesPanel from "@/components/SourcesPanel";
+
+describe("SourcesPanel", () => {
+  it("shows skeleton when empty", () => {
+    render(<SourcesPanel sources={[]} />);
+    expect(screen.getByTestId("sources-skeleton")).toBeInTheDocument();
+  });
+
+  it("renders sources when provided", () => {
+    const sources = ["https://example.com"];
+    render(<SourcesPanel sources={sources} />);
+    expect(screen.queryByTestId("sources-skeleton")).toBeNull();
+    expect(screen.getByText("https://example.com")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- use shadcn Skeleton placeholders for log and sources panels during initial load
- test skeleton rendering for logs and sources panels

## Testing
- `npm test`
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/` *(fails: Command not found: flake8)*
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll` *(fails: Command not found: bandit)*
- `poetry run pip-audit` *(fails: Command not found: pip-audit)*
- `poetry run pytest` *(fails: 22 errors during collection)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68987c342a18832b802c0f057acaa0ce