### PR TITLE
feat: add command palette for quick actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ To run the services directly on your host for development:
 - Diff highlighting via `diff-match-patch`.
 - Tailwind CSS enhanced with `@tailwindcss/forms` and `@tailwindcss/typography`; utility
   classes are auto-sorted via `prettier-plugin-tailwindcss`.
+- Command palette (Cmd/Ctrl+K) for quick Run, Retry, and Export actions.
 
 ### Exporters
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import ControlsPanel from "./components/ControlsPanel";
 import DownloadsPanel from "./components/DownloadsPanel";
 import DataEntryForm from "./components/DataEntryForm";
 import ThemeToggle from "./components/ThemeToggle";
+import CommandPalette from "./components/CommandPalette";
 import { useWorkspaceStore } from "./store/useWorkspaceStore";
 
 // Top-level layout component that connects to the workspace stream
@@ -24,6 +25,7 @@ const App: React.FC = () => {
 
   return (
     <>
+      <CommandPalette />
       <header className="sticky top-0 z-30 border-b border-black/5 backdrop-blur supports-[backdrop-filter]:bg-white/70 dark:border-white/10 dark:supports-[backdrop-filter]:bg-gray-950/70">
         <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
           <h1 className="text-base font-semibold tracking-tight">

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -1,0 +1,90 @@
+import React, { useEffect, useState } from "react";
+import controlClient from "../api/controlClient";
+import exportClient from "../api/exportClient";
+import { useWorkspaceStore } from "../store/useWorkspaceStore";
+
+interface Command {
+  name: string;
+  action: () => Promise<void> | void;
+}
+
+/**
+ * Command palette component bound to Cmd/Ctrl+K.
+ * Provides quick actions for running, retrying and exporting a workspace.
+ */
+const CommandPalette: React.FC = () => {
+  const workspaceId = useWorkspaceStore((s) => s.workspaceId);
+  const setStatus = useWorkspaceStore((s) => s.setStatus);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        setOpen((o) => !o);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
+  const commands: Command[] = [
+    {
+      name: "Run",
+      action: async () => {
+        if (!workspaceId) return;
+        await controlClient.run(workspaceId);
+        setStatus("running");
+        setOpen(false);
+      },
+    },
+    {
+      name: "Retry",
+      action: async () => {
+        if (!workspaceId) return;
+        await controlClient.retry(workspaceId);
+        setStatus("running");
+        setOpen(false);
+      },
+    },
+    {
+      name: "Export",
+      action: async () => {
+        if (!workspaceId) return;
+        try {
+          const urls = await exportClient.getUrls(workspaceId);
+          window.open(urls.md, "_blank");
+        } catch (err) {
+          console.error("Failed to fetch export URLs", err);
+        }
+        setOpen(false);
+      },
+    },
+  ];
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-24"
+      role="dialog"
+    >
+      <div className="w-full max-w-md rounded-md bg-white p-2 shadow-lg">
+        <ul>
+          {commands.map((cmd) => (
+            <li key={cmd.name}>
+              <button
+                className="w-full rounded p-2 text-left hover:bg-gray-100"
+                onClick={() => cmd.action()}
+              >
+                {cmd.name}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default CommandPalette;

--- a/tests/commandPalette.test.tsx
+++ b/tests/commandPalette.test.tsx
@@ -1,0 +1,31 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+import CommandPalette from "../frontend/src/components/CommandPalette";
+import { useWorkspaceStore } from "../frontend/src/store/useWorkspaceStore";
+import controlClient from "../frontend/src/api/controlClient";
+
+vi.mock("../frontend/src/api/controlClient", () => ({
+  default: { run: vi.fn(), retry: vi.fn() },
+}));
+
+vi.mock("../frontend/src/api/exportClient", () => ({
+  default: { getUrls: vi.fn() },
+}));
+
+describe("CommandPalette", () => {
+  beforeEach(() => {
+    useWorkspaceStore.setState({ workspaceId: "abc", status: "idle" });
+  });
+
+  it("opens with Cmd+K and triggers run", async () => {
+    render(<CommandPalette />);
+    await act(async () => {
+      fireEvent.keyDown(window, { key: "k", metaKey: true });
+    });
+    const runButton = await screen.findByText("Run");
+    await act(async () => {
+      fireEvent.click(runButton);
+    });
+    expect((controlClient as any).run).toHaveBeenCalledWith("abc");
+  });
+});


### PR DESCRIPTION
## Summary
- add a Cmd/Ctrl+K command palette with Run, Retry, and Export actions
- render palette in the main app layout and document feature
- cover command palette with a basic unit test

## Testing
- `npm run lint`
- `npm run lint:css`
- `npm run typecheck`
- `npm test`
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/` *(fails: Command not found: flake8)*
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll` *(fails: Command not found: bandit)*
- `poetry run pip-audit` *(fails: Command not found: pip-audit)*


------
https://chatgpt.com/codex/tasks/task_e_68987c4b68dc832bb969f4b5e871974e