### PR TITLE
fix: configure tailwind theme colors

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,8 +11,35 @@ export default {
         serif: ["Domine", "serif"],
       },
       colors: {
-        primary: "#000000",
-        accent: "#00ffc6",
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
       },
       boxShadow: {
         card: "0 4px 8px rgba(0, 0, 0, 0.05)",


### PR DESCRIPTION
## Summary
- define theme color variables for Tailwind so utilities like `ring-offset-background` work

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/` *(fails: Command not found: flake8)*
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll` *(fails: Command not found: bandit)*
- `poetry run pip-audit` *(fails: Command not found: pip-audit)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'jwt')*
- `npm run lint`
- `npm run lint:css`
- `npm run typecheck`
- `npm test`
- `./scripts/build_frontend.sh`


------
https://chatgpt.com/codex/tasks/task_e_68993375f52c832bb3c10052fadb57a3