### PR TITLE
Skip migrations when showing CLI help

### DIFF
--- a/scripts/cli.sh
+++ b/scripts/cli.sh
@@ -21,6 +21,12 @@ if [ -f .env ]; then
   set +a
 fi
 
+# If help was requested, display it without running migrations
+if [[ "$*" == *"--help"* || "$*" == *"-h"* ]]; then
+  poetry run python -m cli.generate_lecture "$@"
+  exit 0
+fi
+
 # Run database migrations
 poetry run alembic upgrade head
 


### PR DESCRIPTION
## Summary
- avoid running Alembic migrations when CLI help is requested

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/` *(fails: Command not found: flake8)*
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll` *(fails: Command not found: bandit)*
- `poetry run pip-audit` *(fails: Command not found: pip-audit)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'jwt')*
- `./scripts/cli.sh --help` *(fails: ModuleNotFoundError: No module named 'logfire')*

------
https://chatgpt.com/codex/tasks/task_e_689933b51240832b8227445c2c44f3ea