### PR TITLE
Fix CLI help requiring full configuration

### DIFF
--- a/src/cli/generate_lecture.py
+++ b/src/cli/generate_lecture.py
@@ -13,11 +13,6 @@ import logfire
 
 from agents.streaming import stream_messages
 from config import load_settings
-from core.orchestrator import graph_orchestrator
-from core.state import State
-from observability import install_auto_tracing
-
-install_auto_tracing()
 
 
 def parse_args() -> argparse.Namespace:
@@ -37,6 +32,9 @@ def parse_args() -> argparse.Namespace:
 async def _generate(topic: str) -> Dict[str, Any]:
     """Run the full graph for ``topic`` and return the final state."""
 
+    from core.orchestrator import graph_orchestrator
+    from core.state import State
+
     state = State(prompt=topic)
     await graph_orchestrator.run(state)
     return state.to_dict()
@@ -45,6 +43,9 @@ async def _generate(topic: str) -> Dict[str, Any]:
 def main() -> None:
     """Entry point for console scripts."""
     args = parse_args()
+    from observability import install_auto_tracing
+
+    install_auto_tracing()
     settings = load_settings()
     if settings.enable_tracing:
         logfire.configure(


### PR DESCRIPTION
## Summary
- avoid eager settings validation by lazily loading configuration
- defer heavy imports in CLI entrypoint so `--help` works without full stack

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'jwt')*
- `./scripts/cli.sh --help`


------
https://chatgpt.com/codex/tasks/task_e_689936aed428832b8db7f95857eee47b