### PR TITLE
chore: generate jwt secret in run script

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -18,6 +18,12 @@ if [ -f .env ]; then
   set +a
 fi
 
+# Generate a temporary JWT secret if one is not provided
+if [ -z "${JWT_SECRET:-}" ]; then
+  JWT_SECRET=$(python -c 'import secrets; print(secrets.token_hex(32))')
+  export JWT_SECRET
+fi
+
 # Run database migrations
 poetry run alembic upgrade head
 


### PR DESCRIPTION
## Summary
- generate ephemeral JWT secret in run.sh when none provided

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/` *(fails: Command not found: flake8)*
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll` *(fails: Command not found: bandit)*
- `poetry run pip-audit` *(fails: Command not found: pip-audit)*
- `OPENAI_API_KEY=dummy PERPLEXITY_API_KEY=dummy ./scripts/run.sh --help` *(fails: Command not found: alembic)*

------
https://chatgpt.com/codex/tasks/task_e_68993b8eec74832b860925b96176779f