### PR TITLE
refactor: remove auto tracing

### DIFF
--- a/src/cli/generate_lecture.py
+++ b/src/cli/generate_lecture.py
@@ -13,6 +13,7 @@ import logfire
 
 from agents.streaming import stream_messages
 from config import load_settings
+from observability import trace
 
 
 def parse_args() -> argparse.Namespace:
@@ -29,6 +30,7 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+@trace
 async def _generate(topic: str) -> Dict[str, Any]:
     """Run the full graph for ``topic`` and return the final state."""
 
@@ -40,12 +42,10 @@ async def _generate(topic: str) -> Dict[str, Any]:
     return state.to_dict()
 
 
+@trace
 def main() -> None:
     """Entry point for console scripts."""
     args = parse_args()
-    from observability import install_auto_tracing
-
-    install_auto_tracing()
     settings = load_settings()
     if settings.enable_tracing:
         logfire.configure(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,7 +81,6 @@ def _span(*_a, **_k):  # pragma: no cover - simple stub
 logfire_stub.span = _span  # type: ignore[attr-defined]
 logfire_stub.trace = lambda *a, **k: None  # type: ignore[attr-defined]
 logfire_stub.get_logger = lambda *a, **k: None  # type: ignore[attr-defined]
-logfire_stub.install_auto_tracing = lambda *a, **k: None  # type: ignore[attr-defined]
 logfire_stub.configure = lambda *a, **k: None  # type: ignore[attr-defined]
 logfire_stub.instrument_pydantic = lambda *a, **k: None  # type: ignore[attr-defined]
 logfire_stub.instrument_httpx = lambda *a, **k: None  # type: ignore[attr-defined]

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -34,7 +34,6 @@ def test_init_observability_enabled(monkeypatch):
 
     monkeypatch.setenv("ENABLE_TRACING", "1")
     monkeypatch.setattr(logfire, "configure", fake_configure)
-    monkeypatch.setattr("observability.install_auto_tracing", lambda: None)
     for name in [
         "instrument_pydantic",
         "instrument_httpx",


### PR DESCRIPTION
## Summary
- drop logfire auto tracing in favor of explicit decorator-based spans
- decorate key CLI and observability functions to instrument execution
- update tests and stubs to reflect new tracing approach

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLError: certificate verify failed)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'jwt', aiosqlite, fastapi, pydantic, dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_68993afddbcc832bbab771532ab5fd63