### PR TITLE
Prompt for topic and authorize control actions

### DIFF
--- a/frontend/src/api/controlClient.ts
+++ b/frontend/src/api/controlClient.ts
@@ -1,8 +1,8 @@
 import { apiFetch } from "./http";
 
 /** Simple client for posting control commands to workspace endpoints. */
-export async function run(workspaceId: string): Promise<void> {
-  await post(`/workspaces/${workspaceId}/run`);
+export async function run(workspaceId: string, topic: string): Promise<void> {
+  await post(`/workspaces/${workspaceId}/run`, { topic });
 }
 
 /** Retry the graph using the last inputs. */

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -33,7 +33,9 @@ const CommandPalette: React.FC = () => {
       name: "Run",
       action: async () => {
         if (!workspaceId) return;
-        await controlClient.run(workspaceId);
+        const topic = window.prompt("Enter topic");
+        if (!topic) return;
+        await controlClient.run(workspaceId, topic);
         setStatus("running");
         setOpen(false);
       },

--- a/frontend/src/components/ControlsPanel.tsx
+++ b/frontend/src/components/ControlsPanel.tsx
@@ -12,8 +12,10 @@ const ControlsPanel: React.FC<Props> = ({ workspaceId }) => {
   const { status, setStatus } = useWorkspaceStore();
 
   const onRunClick = async () => {
+    const topic = window.prompt("Enter topic");
+    if (!topic) return;
     try {
-      await controlClient.run(workspaceId);
+      await controlClient.run(workspaceId, topic);
       setStatus("running");
     } catch {
       toast.error("Run failed");

--- a/frontend/src/components/DataEntryForm.tsx
+++ b/frontend/src/components/DataEntryForm.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
+import { apiFetch } from "../api/http";
 
 interface Entry {
   id: number;
@@ -16,7 +17,7 @@ const DataEntryForm: React.FC = () => {
   useEffect(() => {
     (async () => {
       try {
-        const res = await fetch("/api/entries");
+        const res = await apiFetch("/entries");
         if (res.ok) {
           const data: Entry[] = await res.json();
           setEntries(data);
@@ -31,9 +32,8 @@ const DataEntryForm: React.FC = () => {
     e.preventDefault();
     if (!topic) return;
     try {
-      const res = await fetch("/api/entries", {
+      const res = await apiFetch("/entries", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ topic }),
       });
       if (res.ok) {

--- a/tests/commandPalette.test.tsx
+++ b/tests/commandPalette.test.tsx
@@ -18,6 +18,7 @@ describe("CommandPalette", () => {
   });
 
   it("opens with Cmd+K and triggers run", async () => {
+    vi.spyOn(window, "prompt").mockReturnValue("topic");
     render(<CommandPalette />);
     await act(async () => {
       fireEvent.keyDown(window, { key: "k", metaKey: true });
@@ -26,6 +27,6 @@ describe("CommandPalette", () => {
     await act(async () => {
       fireEvent.click(runButton);
     });
-    expect((controlClient as any).run).toHaveBeenCalledWith("abc");
+    expect((controlClient as any).run).toHaveBeenCalledWith("abc", "topic");
   });
 });

--- a/tests/controlsPanel.test.tsx
+++ b/tests/controlsPanel.test.tsx
@@ -17,12 +17,13 @@ import controlClient from "@/api/controlClient";
 import { toast } from "sonner";
 
 it("shows error toast on run failure", async () => {
+  vi.spyOn(window, "prompt").mockReturnValue("topic");
   const client = controlClient as unknown as {
     run: ReturnType<typeof vi.fn>;
   };
   render(<ControlsPanel workspaceId="1" />);
   fireEvent.click(screen.getByText("Run"));
-  await waitFor(() => expect(client.run).toHaveBeenCalled());
+  await waitFor(() => expect(client.run).toHaveBeenCalledWith("1", "topic"));
   await waitFor(() =>
     expect(vi.mocked(toast.error)).toHaveBeenCalledWith("Run failed"),
   );


### PR DESCRIPTION
## Summary
- prompt user for a topic when running jobs
- send topic to run endpoint
- include authorization headers when adding topics

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: certificate verify failed)*
- `pytest` *(fails: 22 errors during collection)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899756589e4832baa1363b3c1316bb9