### PR TITLE
Fix pedagogy critic activities handling

### DIFF
--- a/src/agents/content_weaver.py
+++ b/src/agents/content_weaver.py
@@ -108,6 +108,7 @@ async def run_content_weaver(state: State, section_id: int | None = None) -> Mod
         title=weave.title,
         duration_min=weave.duration_min,
         learning_objectives=weave.learning_objectives,
+        activities=weave.activities,
     )
     state.modules.append(module)
     return module

--- a/src/core/state.py
+++ b/src/core/state.py
@@ -9,6 +9,7 @@ from typing import Dict, List, Optional
 from pydantic import BaseModel, Field, HttpUrl
 from pydantic.dataclasses import dataclass
 
+from agents.models import Activity
 from models import CritiqueReport, FactCheckReport
 
 
@@ -29,6 +30,7 @@ class Module(BaseModel):
     title: str
     duration_min: int
     learning_objectives: List[str] = Field(default_factory=list)
+    activities: List[Activity] = Field(default_factory=list)
 
 
 class Outline(BaseModel):
@@ -43,6 +45,14 @@ class Outline(BaseModel):
     steps: List[str] = Field(default_factory=list)
     learning_objectives: List[str] = Field(default_factory=list)
     modules: List[Module] = Field(default_factory=list)
+
+    @property
+    def activities(self) -> List[Activity]:
+        """Aggregate activities from all modules."""
+        acts: List[Activity] = []
+        for module in self.modules:
+            acts.extend(module.activities)
+        return acts
 
 
 class ActionLog(BaseModel):

--- a/tests/test_pedagogy_critic.py
+++ b/tests/test_pedagogy_critic.py
@@ -1,0 +1,51 @@
+# isort: skip_file
+import sys
+import types
+
+import pytest
+
+from agents.models import Activity
+from core.state import Module, State
+
+# Provide minimal config stub before importing the critic
+config_stub = types.ModuleType("config")
+config_stub.load_settings = lambda: types.SimpleNamespace(  # type: ignore[attr-defined]
+    model_provider="openai", model_name="gpt"
+)
+sys.modules["config"] = config_stub
+
+from agents.pedagogy_critic import run_pedagogy_critic  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_run_pedagogy_critic_uses_module_activities(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pedagogy critic aggregates activities from state modules."""
+
+    monkeypatch.setattr(
+        "agents.pedagogy_critic.classify_bloom_level", lambda _text: "remember"
+    )
+
+    state = State(prompt="topic")
+    state.learning_objectives = ["List facts"]
+    state.modules.append(
+        Module(
+            id="m1",
+            title="Intro",
+            duration_min=10,
+            learning_objectives=["List facts"],
+            activities=[
+                Activity(
+                    type="Lecture",
+                    description="talk",
+                    duration_min=10,
+                    learning_objectives=["List facts"],
+                )
+            ],
+        )
+    )
+
+    report = await run_pedagogy_critic(state)
+    assert report.diversity.type_percentages["Lecture"] == 1.0
+    assert report.bloom.level_counts["remember"] == 2


### PR DESCRIPTION
## Summary
- include activities in module state and expose aggregated outline activities
- ensure content weaver saves activity data
- build pedagogy critic outline from module activities and add tests

## Testing
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy tests/test_pedagogy_critic.py`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSL: CERTIFICATE_VERIFY_FAILED)*
- `poetry run pytest tests/test_pedagogy_critic.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689975cca534832b85565ff3fc8f62cc