### PR TITLE
fix: synchronize theme across components

### DIFF
--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -22,8 +22,11 @@ const ThemeToggle: React.FC = () => {
   });
 
   useEffect(() => {
-    document.documentElement.classList.toggle("dark", theme === "dark");
+    const isDark = theme === "dark";
+    document.documentElement.classList.toggle("dark", isDark);
+    document.body.classList.toggle("dark", isDark);
     localStorage.setItem("theme", theme);
+    document.dispatchEvent(new CustomEvent("theme-change", { detail: theme }));
   }, [theme]);
 
   return (

--- a/frontend/src/components/ui/sonner.tsx
+++ b/frontend/src/components/ui/sonner.tsx
@@ -1,9 +1,23 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { Toaster as SonnerToaster } from "sonner";
 
 export function Toaster() {
-  return <SonnerToaster position="bottom-right" richColors />;
+  const [theme, setTheme] = useState<"light" | "dark">(
+    document.documentElement.classList.contains("dark") ? "dark" : "light",
+  );
+
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const newTheme = (e as CustomEvent<"light" | "dark">).detail;
+      setTheme(newTheme);
+    };
+    document.addEventListener("theme-change", handler);
+    return () => document.removeEventListener("theme-change", handler);
+  }, []);
+
+  return <SonnerToaster position="bottom-right" richColors theme={theme} />;
 }
 
 export default Toaster;


### PR DESCRIPTION
## Summary
- keep document and body classes in sync with selected theme
- broadcast theme change events and update Toaster styling accordingly

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLError: CERTIFICATE_VERIFY_FAILED)*
- `npm run lint`
- `npm run lint:css`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689977856f44832b87b3d192eb14b21b