### PR TITLE
Fix dark mode text and theme toggle icon

### DIFF
--- a/frontend/src/components/DocumentPanel.tsx
+++ b/frontend/src/components/DocumentPanel.tsx
@@ -51,7 +51,10 @@ const DocumentPanel: React.FC<Props> = ({ text, onAcceptDiff }) => {
   }
 
   return (
-    <div className="prose dark:prose-invert max-w-none" aria-live="polite">
+    <div
+      className="prose max-w-none text-black dark:text-black"
+      aria-live="polite"
+    >
       <ReactMarkdown rehypePlugins={[rehypeRaw]}>{rendered}</ReactMarkdown>
     </div>
   );

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -34,9 +34,9 @@ const ThemeToggle: React.FC = () => {
       <DropdownMenuTrigger asChild>
         <Button variant="outline" size="icon" aria-pressed={theme === "dark"}>
           {theme === "dark" ? (
-            <Moon className="h-4 w-4" />
-          ) : (
             <Sun className="h-4 w-4" />
+          ) : (
+            <Moon className="h-4 w-4" />
           )}
           <span className="sr-only">Toggle theme</span>
         </Button>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -32,7 +32,7 @@
 
   .dark {
     --background: 240 10% 3.9%;
-    --foreground: 0 0% 98%;
+    --foreground: 240 10% 3.9%;
     --card: 240 10% 3.9%;
     --card-foreground: 0 0% 98%;
     --popover: 240 10% 3.9%;
@@ -44,7 +44,7 @@
     --muted: 240 3.7% 15.9%;
     --muted-foreground: 240 5% 64.9%;
     --accent: 240 3.7% 15.9%;
-    --accent-foreground: 0 0% 98%;
+    --accent-foreground: 240 5.9% 10%;
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 98%;
     --border: 240 3.7% 15.9%;


### PR DESCRIPTION
## Summary
- ensure dark theme text renders black by adjusting CSS variables and markdown styles
- swap theme toggle icons so current theme is reflected

## Testing
- `npm run lint`
- `npm run lint:css`
- `npm run typecheck`
- `npm test`
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSL certificate verify failed)*

------
https://chatgpt.com/codex/tasks/task_e_68998c06235c832bbb3a4e09b26976ae