### PR TITLE
Log run command attempts and errors

### DIFF
--- a/frontend/src/components/ControlsPanel.tsx
+++ b/frontend/src/components/ControlsPanel.tsx
@@ -14,10 +14,12 @@ const ControlsPanel: React.FC<Props> = ({ workspaceId }) => {
   const onRunClick = async () => {
     const topic = window.prompt("Enter topic");
     if (!topic) return;
+    console.info(`Running workspace ${workspaceId} with topic "${topic}"`);
     try {
       await controlClient.run(workspaceId, topic);
       setStatus("running");
-    } catch {
+    } catch (err) {
+      console.error("Run failed", err);
       toast.error("Run failed");
     }
   };

--- a/tests/controlsPanel.test.tsx
+++ b/tests/controlsPanel.test.tsx
@@ -18,12 +18,22 @@ import { toast } from "sonner";
 
 it("shows error toast on run failure", async () => {
   vi.spyOn(window, "prompt").mockReturnValue("topic");
+  const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+  const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   const client = controlClient as unknown as {
     run: ReturnType<typeof vi.fn>;
   };
   render(<ControlsPanel workspaceId="1" />);
   fireEvent.click(screen.getByText("Run"));
   await waitFor(() => expect(client.run).toHaveBeenCalledWith("1", "topic"));
+  await waitFor(() =>
+    expect(infoSpy).toHaveBeenCalledWith(
+      'Running workspace 1 with topic "topic"',
+    ),
+  );
+  await waitFor(() =>
+    expect(errorSpy).toHaveBeenCalledWith("Run failed", expect.any(Error)),
+  );
   await waitFor(() =>
     expect(vi.mocked(toast.error)).toHaveBeenCalledWith("Run failed"),
   );


### PR DESCRIPTION
## Summary
- log run command invocation and failures in ControlsPanel
- test console logging on run errors

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/ --count`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url)*
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68998cdd91ac832bbc1b3d67d46657ae