### PR TITLE
Add model_dump support for critique and fact-check reports

### DIFF
--- a/src/models/critique_report.py
+++ b/src/models/critique_report.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import field
-from typing import Dict, List, Optional
+from dataclasses import asdict, field
+from typing import Any, Dict, List, Optional
 
 from pydantic.dataclasses import dataclass
 
@@ -48,6 +48,10 @@ class CritiqueReport:
         """List of actionable recommendations for remediation."""
 
         return self.recommendations
+
+    def model_dump(self) -> Dict[str, Any]:
+        """Return a serializable representation of the report."""
+        return asdict(self)  # type: ignore[arg-type, call-overload]
 
 
 __all__ = [

--- a/src/models/fact_check_report.py
+++ b/src/models/fact_check_report.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import field
-from typing import List, Union
+from dataclasses import asdict, field
+from typing import Any, Dict, List, Union
 
 from pydantic.dataclasses import dataclass
 
@@ -39,6 +39,10 @@ class FactCheckReport:
         """Combined list of detected factual issues."""
 
         return [*self.hallucinations, *self.unsupported_claims]
+
+    def model_dump(self) -> Dict[str, Any]:
+        """Return a serializable representation of the report."""
+        return asdict(self)  # type: ignore[arg-type, call-overload]
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- add `model_dump` implementations for `CritiqueReport` and `FactCheckReport`
- leverage `dataclasses.asdict` for serialization to fix lecture generation

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/` *(fails: Command not found: flake8)*
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll` *(fails: Command not found: bandit)*
- `poetry run pip-audit` *(fails: Command not found: pip-audit)*
- `poetry run pytest` *(fails: 23 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_68998e19d110832b9dd42bd285bb9772