### PR TITLE
Handle critic retry limit gracefully

### DIFF
--- a/src/core/policies.py
+++ b/src/core/policies.py
@@ -55,8 +55,8 @@ def policy_retry_on_critic_failure(
     """Determine whether content must be regenerated after critic review.
 
     The retry tracker ensures the content weaver is not reinvoked more than
-    three times. Exceeding this limit raises a :class:`RuntimeError` which
-    should terminate the workflow.
+    three times. Once the limit is hit further retries are suppressed without
+    raising an exception, allowing the workflow to continue.
 
     Args:
         report: Outcome from either the pedagogy critic or fact checker.
@@ -75,7 +75,10 @@ def policy_retry_on_critic_failure(
             report.hallucination_count or report.unsupported_claims_count
         )
     if should_retry:
-        retry_tracker(state, agent_name)
+        try:
+            retry_tracker(state, agent_name)
+        except RuntimeError:
+            should_retry = False
     return should_retry
 
 

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -70,8 +70,8 @@ def test_policy_retry_on_low_confidence_retries_until_limit() -> None:
         DummyFactCheckReport(hallucination_count=1),
     ],
 )
-def test_policy_retry_on_critic_failure_raises_after_limit(report) -> None:
-    """Critic failures trigger retries and eventually raise."""
+def test_policy_retry_on_critic_failure_stops_after_limit(report) -> None:
+    """Critic failures trigger retries until the limit then continue."""
 
     state = State(prompt="topic")
 
@@ -79,5 +79,5 @@ def test_policy_retry_on_critic_failure_raises_after_limit(report) -> None:
         assert policy_retry_on_critic_failure(report, state) is True
     assert state.retries["Content-Weaver"] == 3
 
-    with pytest.raises(RuntimeError):
-        policy_retry_on_critic_failure(report, state)
+    # Fourth attempt exceeds retry limit and returns False instead of raising
+    assert policy_retry_on_critic_failure(report, state) is False

--- a/tests/test_retry_loops.py
+++ b/tests/test_retry_loops.py
@@ -95,13 +95,12 @@ async def test_content_weaver_reinvoked_until_retry_ceiling() -> None:
         ]
     )
 
-    with pytest.raises(RuntimeError):
-        while True:
-            await fake_weaver(state)
-            report = next(reports)
-            if policy_retry_on_critic_failure(report, state):
-                continue
-            break
+    while True:
+        await fake_weaver(state)
+        report = next(reports)
+        if policy_retry_on_critic_failure(report, state):
+            continue
+        break
 
     assert calls["weaver"] == 4
     assert state.retries["Content-Weaver"] == 3


### PR DESCRIPTION
## Summary
- avoid crashing when critic retry limit is exceeded by swallowing the runtime error
- adjust policy tests to expect graceful handling after retry limit

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /pypi/bandit/1.8.6/json (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)'))))*
- `poetry run pytest tests/test_policies.py tests/test_retry_loops.py` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_689990d0cf6c832b8a9a79e4633c2076