### PR TITLE
fix: adapt pedagogy critic to pydantic-ai API change

### DIFF
--- a/src/agents/pedagogy_critic.py
+++ b/src/agents/pedagogy_critic.py
@@ -98,12 +98,8 @@ def classify_bloom_level(text: str) -> str:
         else:
             provider = OpenAIProvider()
         model = OpenAIModel(settings.model_name, provider=provider)
-        agent = Agent(
-            model=model,
-            result_type=BloomResult,
-            instructions=instructions,
-        )  # type: ignore[call-overload]
-        result = agent.run_sync(text)
+        agent = Agent(model=model, instructions=instructions)
+        result = agent.run_sync(text, result_type=BloomResult)
         level = result.data.level.strip().lower()
         if level in BLOOM_LEVELS:
             return level


### PR DESCRIPTION
## Summary
- fix Bloom level classification by passing `result_type` to `Agent.run_sync`

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/` *(fails: Command not found)*
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll` *(fails: Command not found)*
- `poetry run pip-audit` *(fails: Command not found)*
- `poetry run pytest` *(fails: 23 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689990aef1bc832b94bb508b5e095705