### PR TITLE
refactor: remove Perplexity integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,5 @@
 OPENAI_API_KEY=your-openai-key
-PERPLEXITY_API_KEY=your-perplexity-key
 TAVILY_API_KEY=your-tavily-key
-SEARCH_PROVIDER=perplexity
 LOGFIRE_API_KEY=your-logfire-key
 LOGFIRE_PROJECT=your-logfire-project
 MODEL=openai:o4-mini

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lecture Builder Agent
 
-A local-first, multi-agent system that generates high‑quality, university‑grade lecture and workshop outlines (with supporting materials) from a single topic prompt. Agents are defined with Pydantic‑AI models and coordinated by a custom Python orchestrator. The system integrates OpenAI o4‑mini/o3 models, pluggable web search (Perplexity Sonar or Tavily), and a React‑based UX. Full state, citations, logs, and intermediates persist in SQLite or Postgres. Observability is handled by Logfire. Exports include Markdown, DOCX, and PDF.
+A local-first, multi-agent system that generates high‑quality, university‑grade lecture and workshop outlines (with supporting materials) from a single topic prompt. Agents are defined with Pydantic‑AI models and coordinated by a custom Python orchestrator. The system integrates OpenAI o4‑mini/o3 models, web search via Tavily, and a React‑based UX. Full state, citations, logs, and intermediates persist in SQLite or Postgres. Observability is handled by Logfire. Exports include Markdown, DOCX, and PDF.
 
 ---
 
@@ -44,7 +44,7 @@ A local-first, multi-agent system that generates high‑quality, university‑gr
 
 - **Multi-Agent Workflow**: Planner, Researcher, Synthesiser, Pedagogy Critic, Fact Checker, Human-in-Loop, and Exporter nodes coordinated by a lightweight custom orchestrator.
 - **Streaming UI**: Token-level draft streaming with diff highlights; action/reasoning log streaming via SSE.
-- **Robust Citations**: Pluggable Perplexity or Tavily search, citation metadata stored in SQLite, Creative Commons and university domain filtering.
+- **Robust Citations**: Tavily search, citation metadata stored in SQLite, Creative Commons and university domain filtering.
 - **Local-First**: Operates offline using cached corpora and fallback to local dense retrieval.
 - **Flexible Exports**: Markdown (canonical), DOCX (python-docx), PDF (WeasyPrint), with cover page, TOC, and bibliography.
 - **Audit & Governance**: Immutable action logs, SHA‑256 state hashes, role‑based access, database encryption.
@@ -58,7 +58,7 @@ The system comprises:
 1. **Custom Orchestrator**: Manages typed `State` objects through nodes and edges defined with Pydantic models. Handles checkpointing in SQLite.
 2. **Agents**:
    - **Curriculum Planner**: Defines learning objectives and module structure.
-   - **Researcher-Web**: Executes parallel Perplexity Sonar/OpenAI searches, dedupes and ranks sources.
+   - **Researcher-Web**: Executes parallel Tavily searches, dedupes and ranks sources.
    - **Content Weaver**: Generates Markdown outline, speaker notes, slide bullets.
    - **Pedagogy Critic**: Verifies Bloom taxonomy coverage, activity diversity, cognitive load.
    - **Fact Checker**: Scans for hallucinations via Cleanlab/regex.
@@ -92,7 +92,7 @@ Fetch a token from `GET /stream/token` and connect using
 - Node.js 18+ (for frontend)
 - `poetry` (recommended) or `pipenv`
 - OpenAI API key
-- Perplexity or Tavily API key
+- Tavily API key (optional)
 
 ### Installation
 
@@ -135,9 +135,7 @@ variables (e.g. a `.env` file):
 cp .env.example .env
 # Edit .env:
 # OPENAI_API_KEY=sk-...
-# PERPLEXITY_API_KEY=...
 # TAVILY_API_KEY=...
-# SEARCH_PROVIDER=perplexity  # or 'tavily'
 # LOGFIRE_API_KEY=...
 # LOGFIRE_PROJECT=...
 # MODEL=openai:o4-mini
@@ -209,7 +207,7 @@ To run the services directly on your host for development:
 
 ### Retrieval & Citation
 
-- **SearchClient** abstraction in `src/agents/researcher_web.py` supporting Perplexity and Tavily
+- **SearchClient** abstraction in `src/agents/researcher_web.py` supporting Tavily
 - Citation objects stored in `state.citations` table.
 - Filtering by domain allowlist and SPDX license checks.
 
@@ -320,9 +318,7 @@ been replaced by Logfire's settings.
 | Variable             | Description                               | Default                                  |
 | -------------------- | ----------------------------------------- | ---------------------------------------- |
 | `OPENAI_API_KEY`     | API key for OpenAI                        | (required)                               |
-| `PERPLEXITY_API_KEY` | API key for Perplexity Sonar              | Required if `SEARCH_PROVIDER=perplexity` |
-| `TAVILY_API_KEY`     | API key for Tavily search                 | Required if `SEARCH_PROVIDER=tavily`     |
-| `SEARCH_PROVIDER`    | `perplexity` or `tavily`                  | `perplexity`                             |
+| `TAVILY_API_KEY`     | API key for Tavily search                 |                                          |
 | `LOGFIRE_API_KEY`    | API key for Logfire                       |                                          |
 | `LOGFIRE_PROJECT`    | Logfire project identifier                |                                          |
 | `MODEL`              | LLM provider and model (`openai:o4-mini`) | `openai:o4-mini`                         |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,15 +15,15 @@ This document provides a **comprehensive** and **explicit** description of the L
          │ HTTP Websocket / REST       │ HTTP / gRPC                        │ HTTP
          ▼                             ▼                                    ▼
 ┌──────────────────┐        ┌─────────────────────────┐        ┌─────────────────┐
-│ Downloads API    │        │ Perplexity Sonar LLM    │        │ Local Dense     │
-│ (Markdown/DOCX/PDF)│        │ (LLM Client)           │        │ Retrieval Index │
+│ Downloads API    │        │ Tavily Search API       │        │ Local Dense     │
+│ (Markdown/DOCX/PDF)│        │ (Search Client)        │        │ Retrieval Index │
 └──────────────────┘        └─────────────────────────┘        └─────────────────┘
 ```
 
 - **FastAPI Server**: exposes REST endpoints, SSE streams, websocket connections. Hosts the graph orchestrator.
 - **Graph Orchestrator**: coordinates multi-agent workflows as a directed graph of nodes and edges. Maintains in-memory and persisted `State` snapshots.
 - **SQLite/Postgres**: checkpoint storage for graph state, citations, logs, and document versions.
-- **Perplexity Sonar LLM**: external source for research; fallback to local dense retrieval index.
+- **Tavily Search API**: external source for research; fallback to local dense retrieval index.
 - **Downloads API**: on-demand generation of final outputs in Markdown, DOCX, PDF.
 - **Browser Client**: subscribes to SSE streams for document updates, citations, and action logs.
 
@@ -54,7 +54,7 @@ This document provides a **comprehensive** and **explicit** description of the L
    - **Edge Policies**: confidence thresholds, retry loops
 
 3. **Retrieval Layer**
-   - **ChatPerplexity (Sonar model)**: client with API key support
+   - **TavilyClient**: client with API key support
    - **Cache Manager**: reads/writes to `retrieval_cache` table
    - **Dense Retriever**: fallback using `faiss` index of CC-BY abstracts
 
@@ -104,7 +104,7 @@ This document provides a **comprehensive** and **explicit** description of the L
 2. **FastAPI** enqueues job and returns `job_id`.
 3. **Orchestrator.invoke(job_id)** triggers:
    - **Planner** generates `learning_objectives`, `modules` → `stream(values)`.
-   - **Researcher-Web** fans out N parallel queries to Perplexity Sonar → `stream(updates)`.
+   - **Researcher-Web** fans out N parallel queries to Tavily search → `stream(updates)`.
    - **Content Weaver** streams token messages → `stream(messages)`.
    - **Critics** emit `stream(debug)` warnings.
 
@@ -116,7 +116,7 @@ This document provides a **comprehensive** and **explicit** description of the L
 
 1. **Researcher-Web** checks `retrieval_cache` table for query key.
 2. If **hit**, returns cached response, marks `retrieval_cache.hit_count++`.
-3. If **miss**, calls Perplexity Sonar, writes response to cache & timestamp.
+3. If **miss**, calls Tavily search, writes response to cache & timestamp.
 4. **Citation objects** created and written to `citations` table.
 
 ---
@@ -163,7 +163,7 @@ This document provides a **comprehensive** and **explicit** description of the L
 | SSE Streams                        | SSE                                    | JSON messages  | Server → Client     |
 | `/download`                        | HTTP REST                              | Binary stream  | Client ← Server     |
 | Orchestrator invocations           | In-process Call                        | Python objects | Orchestrator        |
-| Perplexity Sonar                   | HTTP REST                              | JSON           | Server → Perplexity |
+| Tavily Search                      | HTTP REST                              | JSON           | Server → Tavily     |
 | OpenAI API                         | HTTP REST                              | JSON           | Server → OpenAI     |
 | DB Access                          | SQL over TCP (PG) or File I/O (SQLite) | SQL            | Server ↔ DB        |
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -110,7 +110,7 @@ Further ER diagrams in ARCHITECTURE.md.
 
 ### 6.1 Web Search Providers
 
-- **Clients**: Pydantic‑AI wrappers for Perplexity Sonar and Tavily search, exposed via the `SearchClient` abstraction.
+- **Clients**: HTTP client for Tavily search, exposed via the `SearchClient` abstraction.
   - **Query templates**: Include objective keywords, `--QDF=3` for recency boost.
   - **Rate limiting**: Token bucket, configurable via env var.
 
@@ -256,9 +256,7 @@ Further ER diagrams in ARCHITECTURE.md.
 | Name                 | Purpose                                    | Required?                     |
 | -------------------- | ------------------------------------------ | ----------------------------- |
 | `OPENAI_API_KEY`     | OpenAI authentication                      | Yes                           |
-| `PERPLEXITY_API_KEY` | Perplexity Sonar authentication            | No (if using Tavily)          |
-| `TAVILY_API_KEY`     | Tavily search authentication               | No (if using Perplexity)      |
-| `SEARCH_PROVIDER`    | `perplexity` or `tavily`                   | No (default `perplexity`)     |
+| `TAVILY_API_KEY`     | Tavily search authentication               | No                            |
 | `MODEL`              | Provider and model (`openai:o4-mini`)      | No (default `openai:o4-mini`) |
 | `DATA_DIR`           | Path for SQLite DB, cache, workspace files | No (default `./data`)         |
 | `DATABASE_URL`       | Postgres connection string (optional)      | No                            |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -22,7 +22,7 @@ This document provides a **comprehensive**, **explicit** security specification 
 ### 2.1 Assets
 
 - **User Data:** Prompts, generated lecture content, citations
-- **Service Secrets:** API keys (OpenAI, Perplexity Sonar), vault tokens
+- **Service Secrets:** API keys (OpenAI, Tavily), vault tokens
 - **Persistent Data:** SQLite/Postgres databases, cache, logs, document versions
 - **Infrastructure:** Compute resources, container images, network endpoints
 
@@ -80,7 +80,7 @@ _These controls will be implemented in version 2._
 
 - **HashiCorp Vault** as primary secrets store
   - Mounted via Kubernetes CSI driver or Vault Agent injector
-  - Secrets (OpenAI_API_KEY, PERPLEXITY_API_KEY, GPG_SIGN_KEY) injected at container runtime
+  - Secrets (OPENAI_API_KEY, TAVILY_API_KEY, GPG_SIGN_KEY) injected at container runtime
 
 - **Local Development:** `dotenv` files only; CI pipeline rejects commits with `.env` containing real credentials
 

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -67,7 +67,7 @@ This document defines a **comprehensive**, **explicit** Test Plan for the Lectur
 ### 4.2 Test Data
 
 - **Prompt Samples**: Variety of topics, lengths, edge cases (empty, special characters).
-- **Citation Fixtures**: Mock Perplexity Sonar responses with valid/invalid licenses.
+- **Citation Fixtures**: Mock Tavily search responses with valid/invalid licenses.
 - **State Snapshots**: Pre-generated snapshots for resume tests.
 - **User Roles**: Token sets for `viewer`, `editor`, `admin` to test RBAC.
 
@@ -172,7 +172,7 @@ All test data stored in `tests/fixtures/` with version control.
 
 - **Orchestrator nodes**: unit test each node and mock downstream calls.
 - **DB Integration**: Use ephemeral Postgres for SQL queries, checkpoint writes and reads.
-- **External APIs**: Mock ChatPerplexity and OpenAI via local stub server in tests.
+- **External APIs**: Mock Tavily and OpenAI via local stub server in tests.
 
 ---
 

--- a/src/agents/model_utils.py
+++ b/src/agents/model_utils.py
@@ -23,18 +23,12 @@ def init_model(**overrides: Any) -> OpenAIModel | None:
 
     settings = config.load_settings()
     model_id: str = overrides.pop("model", settings.model)
-    provider_name, model_name = model_id.split(":", 1)
+    _, model_name = model_id.split(":", 1)
 
     if model_id in _MODEL_CACHE:
         return _MODEL_CACHE[model_id]
 
-    if provider_name == "perplexity":
-        pplx_api_key = overrides.pop("pplx_api_key", settings.perplexity_api_key)
-        provider = OpenAIProvider(
-            base_url="https://api.perplexity.ai", api_key=pplx_api_key
-        )
-    else:
-        provider = OpenAIProvider()
+    provider = OpenAIProvider()
 
     model = OpenAIModel(model_name, provider=provider)
     _MODEL_CACHE[model_id] = model

--- a/src/agents/pedagogy_critic.py
+++ b/src/agents/pedagogy_critic.py
@@ -90,13 +90,7 @@ def classify_bloom_level(text: str) -> str:
         from pydantic_ai.providers.openai import OpenAIProvider
 
         settings = config.load_settings()
-        if settings.model_provider == "perplexity":
-            provider = OpenAIProvider(
-                base_url="https://api.perplexity.ai",
-                api_key=settings.perplexity_api_key,
-            )
-        else:
-            provider = OpenAIProvider()
+        provider = OpenAIProvider()
         model = OpenAIModel(settings.model_name, provider=provider)
         agent = Agent(
             model=model,

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -42,8 +42,6 @@ async def call_planner_llm(topic: str) -> str:
 
     try:  # pragma: no cover - exercised via monkeypatch in tests
         from pydantic_ai import Agent
-        from pydantic_ai.models.openai import OpenAIModel
-        from pydantic_ai.providers.openai import OpenAIProvider
 
         import config
     except Exception:  # dependency missing
@@ -53,18 +51,10 @@ async def call_planner_llm(topic: str) -> str:
     settings = config.load_settings()
     provider_name = settings.model_provider
     model_name = settings.model_name
-    if provider_name == "perplexity":
-        provider = OpenAIProvider(
-            base_url="https://api.perplexity.ai",
-            api_key=settings.perplexity_api_key,
-        )
-        model = OpenAIModel(model_name, provider=provider)
-        agent = Agent(model, system_prompt=get_prompt("planner_system"))
-    else:
-        agent = Agent(
-            f"{provider_name}:{model_name}",
-            system_prompt=get_prompt("planner_system"),
-        )
+    agent = Agent(
+        f"{provider_name}:{model_name}",
+        system_prompt=get_prompt("planner_system"),
+    )
     response = await agent.run(topic)
     return response.output or ""
 

--- a/src/agents/researcher_web_runner.py
+++ b/src/agents/researcher_web_runner.py
@@ -10,7 +10,6 @@ from core.state import State
 from .cache_backed_researcher import CacheBackedResearcher
 from .researcher_web import (
     CitationDraft,
-    PerplexityClient,
     RawSearchResult,
     SearchClient,
     TavilyClient,
@@ -26,9 +25,7 @@ def run_web_search(state: State) -> List[CitationDraft]:
     settings = Settings()
     if settings.offline_mode:
         client: SearchClient = CacheBackedResearcher()
-    elif settings.search_provider == "tavily":
-        client = TavilyClient(settings.tavily_api_key or "")
     else:
-        client = PerplexityClient(settings.perplexity_api_key)
+        client = TavilyClient(settings.tavily_api_key or "")
     results = client.search(state.prompt)
     return [_to_draft(r) for r in results]

--- a/src/config.py
+++ b/src/config.py
@@ -26,7 +26,6 @@ DEFAULT_MODEL_NAME = MODEL.split(":", 1)[1]
 
 SENSITIVE_FIELDS = {
     "openai_api_key",
-    "perplexity_api_key",
     "tavily_api_key",
     "logfire_api_key",
     "jwt_secret",
@@ -50,11 +49,9 @@ class Settings(BaseSettings):
     """
 
     openai_api_key: str
-    perplexity_api_key: str
     data_dir: Path = Path("./workspace")
     database_url: str | None = None
     tavily_api_key: str | None = None
-    search_provider: str = "perplexity"
     model: str = MODEL
     offline_mode: bool = False
     enable_tracing: bool = True

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -12,7 +12,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
 from agents.cache_backed_researcher import CacheBackedResearcher
-from agents.researcher_web import PerplexityClient, TavilyClient
+from agents.researcher_web import TavilyClient
 from config import Settings, load_settings
 from core.orchestrator import graph_orchestrator
 from observability import init_observability, instrument_app
@@ -43,10 +43,7 @@ def create_app() -> FastAPI:
         app.state.research_client = CacheBackedResearcher()
         app.state.fact_check_offline = True
     else:
-        if settings.search_provider == "tavily":
-            app.state.research_client = TavilyClient(settings.tavily_api_key or "")
-        else:
-            app.state.research_client = PerplexityClient(settings.perplexity_api_key)
+        app.state.research_client = TavilyClient(settings.tavily_api_key or "")
         app.state.fact_check_offline = False
 
     app.add_middleware(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,6 @@ if str(SRC_DIR) not in sys.path:
 
 # Provide dummy environment keys expected by the settings module.
 os.environ.setdefault("OPENAI_API_KEY", "test")
-os.environ.setdefault("PERPLEXITY_API_KEY", "test")
 os.environ.setdefault("JWT_SECRET", "test-secret")
 
 # Minimal ``tiktoken`` replacement used by the orchestrator token counter.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,17 +9,16 @@ from config import MODEL, Settings, load_env
 
 def test_settings_loads_env(monkeypatch, tmp_path):
     monkeypatch.setenv("OPENAI_API_KEY", "key1")
-    monkeypatch.setenv("PERPLEXITY_API_KEY", "key2")
+    monkeypatch.setenv("TAVILY_API_KEY", "key2")
     monkeypatch.setenv("DATA_DIR", str(tmp_path))
     settings = Settings()
     assert settings.openai_api_key == "key1"
-    assert settings.perplexity_api_key == "key2"
+    assert settings.tavily_api_key == "key2"
     assert settings.data_dir == tmp_path
 
 
 def test_settings_missing_required(monkeypatch):
-    for name in ["OPENAI_API_KEY", "PERPLEXITY_API_KEY"]:
-        monkeypatch.delenv(name, raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("DATA_DIR", raising=False)
     with pytest.raises(ValidationError):
         Settings()
@@ -27,7 +26,6 @@ def test_settings_missing_required(monkeypatch):
 
 def test_settings_uses_default_data_dir(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "key1")
-    monkeypatch.setenv("PERPLEXITY_API_KEY", "key2")
     monkeypatch.delenv("DATA_DIR", raising=False)
     settings = Settings()
     assert settings.data_dir == Path("./workspace")
@@ -35,7 +33,6 @@ def test_settings_uses_default_data_dir(monkeypatch):
 
 def test_settings_parses_allowlist_json(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "key1")
-    monkeypatch.setenv("PERPLEXITY_API_KEY", "key2")
     monkeypatch.setenv("ALLOWLIST_DOMAINS", '["example.com"]')
     settings = Settings()
     assert settings.allowlist_domains == ["example.com"]
@@ -43,7 +40,6 @@ def test_settings_parses_allowlist_json(monkeypatch):
 
 def test_settings_rejects_invalid_allowlist(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "key1")
-    monkeypatch.setenv("PERPLEXITY_API_KEY", "key2")
     monkeypatch.setenv("ALLOWLIST_DOMAINS", "not-json")
     with pytest.raises(SettingsError):
         Settings()
@@ -51,7 +47,6 @@ def test_settings_rejects_invalid_allowlist(monkeypatch):
 
 def test_settings_defaults_allowlist(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "key1")
-    monkeypatch.setenv("PERPLEXITY_API_KEY", "key2")
     monkeypatch.delenv("ALLOWLIST_DOMAINS", raising=False)
     settings = Settings()
     assert settings.allowlist_domains == ["wikipedia.org", ".edu", ".gov"]
@@ -59,7 +54,6 @@ def test_settings_defaults_allowlist(monkeypatch):
 
 def test_model_falls_back_to_default(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "key1")
-    monkeypatch.setenv("PERPLEXITY_API_KEY", "key2")
     monkeypatch.delenv("MODEL", raising=False)
     settings = Settings()
     assert settings.model == MODEL
@@ -70,7 +64,6 @@ def test_model_falls_back_to_default(monkeypatch):
 
 def test_offline_mode_toggle(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "key1")
-    monkeypatch.setenv("PERPLEXITY_API_KEY", "key2")
     monkeypatch.setenv("OFFLINE_MODE", "1")
     assert Settings().offline_mode is True
     monkeypatch.setenv("OFFLINE_MODE", "false")
@@ -79,7 +72,6 @@ def test_offline_mode_toggle(monkeypatch):
 
 def test_tracing_toggle(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "key1")
-    monkeypatch.setenv("PERPLEXITY_API_KEY", "key2")
     monkeypatch.setenv("ENABLE_TRACING", "0")
     assert Settings().enable_tracing is False
     monkeypatch.setenv("ENABLE_TRACING", "true")
@@ -88,8 +80,7 @@ def test_tracing_toggle(monkeypatch):
 
 def test_load_env_reads_file(tmp_path):
     env_file = tmp_path / ".env"
-    env_file.write_text("OPENAI_API_KEY=a\nPERPLEXITY_API_KEY=b\nDATA_DIR=/tmp\n")
+    env_file.write_text("OPENAI_API_KEY=a\nDATA_DIR=/tmp\n")
     settings = load_env(env_file)
     assert settings.openai_api_key == "a"
-    assert settings.perplexity_api_key == "b"
     assert settings.data_dir == Path("/tmp")

--- a/tests/test_markdown_export.py
+++ b/tests/test_markdown_export.py
@@ -16,7 +16,6 @@ from export.markdown import embed_citations, from_weave_result, render_section
 from export.markdown_exporter import MarkdownExporter
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
-os.environ.setdefault("PERPLEXITY_API_KEY", "test")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 

--- a/tests/test_researcher_pipeline.py
+++ b/tests/test_researcher_pipeline.py
@@ -7,7 +7,6 @@ from agents.researcher_pipeline import CitationDraft, researcher_pipeline
 from core.state import State
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
-os.environ.setdefault("PERPLEXITY_API_KEY", "test")
 
 
 @pytest.mark.asyncio

--- a/tests/test_researcher_web_clients.py
+++ b/tests/test_researcher_web_clients.py
@@ -2,25 +2,7 @@ import json
 
 import httpx
 
-from agents.researcher_web import PerplexityClient, TavilyClient
-
-
-def test_perplexity_client_parses_response():
-    def handler(
-        request: httpx.Request,
-    ) -> httpx.Response:  # pragma: no cover - simple handler
-        assert request.url.path == "/search"
-        data = {
-            "search_results": [
-                {"url": "https://example.com", "snippet": "snippet", "title": "title"}
-            ]
-        }
-        return httpx.Response(200, json=data)
-
-    transport = httpx.MockTransport(handler)
-    client = PerplexityClient("key", http=httpx.Client(transport=transport))
-    results = client.search("query")
-    assert results[0].url == "https://example.com"
+from agents.researcher_web import TavilyClient
 
 
 def test_tavily_client_parses_response():


### PR DESCRIPTION
## Summary
- remove Perplexity-based search and configuration
- default researcher to Tavily client
- update docs and tests for Tavily-only search

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(failed: certificate verify failed)*
- `poetry run pytest` *(errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6899939c3f70832bb14c734efb5b5dd0