### PR TITLE
Add GitHub-style theming and component tidy-ups

### DIFF
--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,10 +1,9 @@
 import React, { useEffect, useState } from "react";
-import { Moon, Sun } from "lucide-react";
+import { Moon, Sun, Monitor } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
@@ -18,7 +17,12 @@ import {
  */
 const ThemeToggle: React.FC = () => {
   const [theme, setTheme] = useState<"light" | "dark" | "system">(() => {
-    const saved = localStorage.getItem("theme") || "system";
+    const saved = localStorage.getItem("theme") as
+      | "light"
+      | "dark"
+      | "system"
+      | null;
+    return saved || "system";
   });
   const mql = window.matchMedia("(prefers-color-scheme: dark)");
   const resolved =
@@ -32,7 +36,7 @@ const ThemeToggle: React.FC = () => {
       // keep meta theme-color in sync (see next point)
       const meta = document.querySelector('meta[name="theme-color"]');
       if (meta)
-        meta.setAttribute("content", t === "dark" ? "#0b0b0c" : "#ffffff");
+        meta.setAttribute("content", t === "dark" ? "#0d1117" : "#ffffff");
     };
     apply(resolved);
     if (theme === "system") {
@@ -50,8 +54,12 @@ const ThemeToggle: React.FC = () => {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="icon" aria-pressed={theme === "dark"}>
-          {theme === "dark" ? (
+        <Button
+          variant="outline"
+          size="icon"
+          aria-pressed={resolved === "dark"}
+        >
+          {resolved === "dark" ? (
             <Sun className="h-4 w-4" />
           ) : (
             <Moon className="h-4 w-4" />
@@ -60,10 +68,30 @@ const ThemeToggle: React.FC = () => {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        <DropdownMenuRadioGroup value={theme} onValueChange={setTheme}>
-          <DropdownMenuRadioItem value="light">Light</DropdownMenuRadioItem>
-          <DropdownMenuRadioItem value="dark">Dark</DropdownMenuRadioItem>
-          <DropdownMenuRadioItem value="system">System</DropdownMenuRadioItem>
+        <DropdownMenuRadioGroup
+          value={theme}
+          onValueChange={(value) =>
+            setTheme(value as "light" | "dark" | "system")
+          }
+        >
+          <DropdownMenuRadioItem
+            value="light"
+            className="flex items-center gap-2"
+          >
+            <Sun className="h-4 w-4" /> Light
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem
+            value="dark"
+            className="flex items-center gap-2"
+          >
+            <Moon className="h-4 w-4" /> Dark
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem
+            value="system"
+            className="flex items-center gap-2"
+          >
+            <Monitor className="h-4 w-4" /> System
+          </DropdownMenuRadioItem>
         </DropdownMenuRadioGroup>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -1,21 +1,17 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+/* eslint-disable react/prop-types */
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => (
     <textarea
       ref={ref}
       className={cn(
-        // layout & shape
-        "flex min-h-[80px] w-full rounded-md px-3 py-2 text-sm",
-        // theme-aware colours
-        "border border-input bg-background text-foreground placeholder:text-muted-foreground",
-        // focus ring uses your tokens
-        "ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-        // disabled states (optional)
+        "border-input bg-background text-foreground flex min-h-[80px] w-full rounded-md border px-3 py-2 text-sm",
+        "placeholder:text-muted-foreground",
+        "focus-visible:ring-ring ring-offset-background focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none",
         "disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -22,49 +22,49 @@
     color-scheme: light;
 
     --background: 0 0% 100%;
-    --foreground: 240 10% 3.9%;
+    --foreground: 213 13% 16%;
     --card: 0 0% 100%;
-    --card-foreground: 240 10% 3.9%;
+    --card-foreground: 213 13% 16%;
     --popover: 0 0% 100%;
-    --popover-foreground: 240 10% 3.9%;
-    --primary: 240 5.9% 10%;
-    --primary-foreground: 0 0% 98%;
-    --secondary: 240 4.8% 95.9%;
-    --secondary-foreground: 240 5.9% 10%;
-    --muted: 240 4.8% 95.9%;
-    --muted-foreground: 240 3.8% 46.1%;
-    --accent: 240 4.8% 95.9%;
-    --accent-foreground: 240 5.9% 10%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 240 5.9% 90%;
-    --input: 240 5.9% 90%;
-    --ring: 240 5.9% 10%;
+    --popover-foreground: 213 13% 16%;
+    --primary: 212 92% 45%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 210 29% 97%;
+    --secondary-foreground: 213 13% 16%;
+    --muted: 210 29% 97%;
+    --muted-foreground: 212 10% 38%;
+    --accent: 212 92% 45%;
+    --accent-foreground: 0 0% 100%;
+    --destructive: 356 72% 47%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 210 18% 84%;
+    --input: 210 18% 84%;
+    --ring: 212 92% 45%;
     --radius: 0.5rem;
   }
 
   .dark {
     color-scheme: dark;
 
-    --background: 240 10% 3.9%;
-    --foreground: 0 0% 98%;
-    --card: 240 10% 3.9%;
-    --card-foreground: 0 0% 98%;
-    --popover: 240 10% 3.9%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
-    --primary-foreground: 240 5.9% 10%;
-    --secondary: 240 3.7% 15.9%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 240 3.7% 15.9%;
-    --muted-foreground: 240 5% 64.9%;
-    --accent: 240 3.7% 15.9%;
-    --accent-foreground: 240 5.9% 10%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 240 3.7% 15.9%;
-    --input: 240 3.7% 15.9%;
-    --ring: 240 4.9% 83.9%;
+    --background: 216 28% 7%;
+    --foreground: 210 17% 82%;
+    --card: 216 28% 7%;
+    --card-foreground: 210 17% 82%;
+    --popover: 216 28% 7%;
+    --popover-foreground: 210 17% 82%;
+    --primary: 212 100% 67%;
+    --primary-foreground: 216 28% 7%;
+    --secondary: 215 21% 11%;
+    --secondary-foreground: 210 17% 82%;
+    --muted: 215 21% 11%;
+    --muted-foreground: 212 9% 58%;
+    --accent: 212 100% 67%;
+    --accent-foreground: 216 28% 7%;
+    --destructive: 3 93% 63%;
+    --destructive-foreground: 216 28% 7%;
+    --border: 212 12% 21%;
+    --input: 215 15% 15%;
+    --ring: 212 100% 67%;
   }
 
   h1,

--- a/tests/themeToggle.test.tsx
+++ b/tests/themeToggle.test.tsx
@@ -1,9 +1,21 @@
 import "@testing-library/jest-dom";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
 import ThemeToggle from "@/components/ThemeToggle";
 
 describe("ThemeToggle", () => {
+  beforeAll(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    });
+  });
   beforeEach(() => {
     localStorage.clear();
     document.documentElement.classList.remove("dark");


### PR DESCRIPTION
## Summary
- align light and dark palettes with GitHub hues
- default theme dropdown to system and show icons for each option
- simplify textarea styling and ensure ThemeToggle tests stub `matchMedia`

## Testing
- `npm run lint`
- `npm run lint:css`
- `npm test`
- `npm run typecheck`
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSL: CERTIFICATE_VERIFY_FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_689999eace04832b9d5dc0e6027c91a9