### PR TITLE
feat: bypass auth for localhost

### DIFF
--- a/src/web/auth.py
+++ b/src/web/auth.py
@@ -2,21 +2,23 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import jwt
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
-security = HTTPBearer()
+security = HTTPBearer(auto_error=False)
 security_dependency = Depends(security)
 
 
 def verify_jwt(
     request: Request,
-    credentials: HTTPAuthorizationCredentials = security_dependency,
+    credentials: Optional[HTTPAuthorizationCredentials] = security_dependency,
 ) -> Dict[str, Any]:
     """Validate the provided JWT and return its payload.
+
+    Requests from ``127.0.0.1`` bypass authentication checks.
 
     Args:
         request: Incoming HTTP request used to access application settings.
@@ -28,6 +30,14 @@ def verify_jwt(
     Raises:
         HTTPException: If the token is missing, invalid, or fails authorization.
     """
+    if request.client and request.client.host == "127.0.0.1":
+        return {"role": "user"}
+
+    if credentials is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing token"
+        )
+
     secret = request.app.state.settings.jwt_secret
     algorithm = request.app.state.settings.jwt_algorithm
     try:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import os
 
 import jwt
+from fastapi import Request
 from fastapi.testclient import TestClient
 
+from web.auth import verify_jwt
 from web.main import create_app
 
 
@@ -23,3 +25,18 @@ def test_invalid_role_returns_403() -> None:
     client = TestClient(create_app())
     resp = client.get("/api/entries", headers={"Authorization": f"Bearer {token}"})
     assert resp.status_code == 403
+
+
+def test_localhost_bypasses_authentication() -> None:
+    """Requests from 127.0.0.1 should bypass authentication."""
+    app = create_app()
+    scope = {
+        "type": "http",
+        "client": ("127.0.0.1", 12345),
+        "method": "GET",
+        "path": "/",
+        "headers": [],
+        "app": app,
+    }
+    request = Request(scope)
+    assert verify_jwt(request, None) == {"role": "user"}


### PR DESCRIPTION
## Summary
- allow unauthenticated requests from 127.0.0.1 by skipping JWT validation
- add regression test covering localhost bypass

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .` (Skipped 3 files)
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/` *(failed: Command not found)*
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll` *(failed: Command not found)*
- `poetry run pip-audit` *(failed: Command not found)*
- `poetry run pytest` *(errors during collection)*
- `npm test` *(1 failed)


------
https://chatgpt.com/codex/tasks/task_e_68999a74b1d0832b8a067c066715b1eb