### PR TITLE
Fix logfire configuration and update Bloom classifier

### DIFF
--- a/src/agents/pedagogy_critic.py
+++ b/src/agents/pedagogy_critic.py
@@ -94,11 +94,11 @@ def classify_bloom_level(text: str) -> str:
         model = OpenAIModel(settings.model_name, provider=provider)
         agent = Agent(
             model=model,
-            result_type=BloomResult,
+            output_type=BloomResult,
             instructions=instructions,
-        )  # type: ignore[call-overload]
+        )
         result = agent.run_sync(text)
-        level = result.data.level.strip().lower()
+        level = result.output.level.strip().lower()
         if level in BLOOM_LEVELS:
             return level
     except ValidationError:

--- a/src/cli/generate_lecture.py
+++ b/src/cli/generate_lecture.py
@@ -9,10 +9,7 @@ import json
 import logging
 from typing import Any, Dict
 
-import logfire
-
 from agents.streaming import stream_messages
-from config import load_settings
 
 
 def parse_args() -> argparse.Namespace:
@@ -43,15 +40,10 @@ async def _generate(topic: str) -> Dict[str, Any]:
 def main() -> None:
     """Entry point for console scripts."""
     args = parse_args()
-    from observability import install_auto_tracing
+    from observability import init_observability, install_auto_tracing
 
     install_auto_tracing()
-    settings = load_settings()
-    if settings.enable_tracing:
-        logfire.configure(
-            token=settings.logfire_api_key,
-            service_name=settings.logfire_project,
-        )
+    init_observability()
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
         stream_messages("LLM response stream start")

--- a/src/observability.py
+++ b/src/observability.py
@@ -50,6 +50,7 @@ def init_observability() -> None:
     gated by the ``ENABLE_TRACING`` environment variable.
     """
     if os.getenv("ENABLE_TRACING", "").lower() not in {"1", "true", "yes", "on"}:
+        logfire.configure(ignore_no_config=True)
         return
 
     token = os.getenv("LOGFIRE_API_KEY")


### PR DESCRIPTION
## Summary
- default configure logfire when tracing is disabled
- invoke observability setup in lecture generation CLI
- adapt Bloom classification agent to new pydantic_ai API

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLCertVerificationError)*
- `poetry run pytest` *(fails: 23 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6899a07589e8832bbf4b3aaa7c9ac869