### PR TITLE
Allow localhost access without authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,9 @@ been replaced by Logfire's settings.
 
 ## Roadmap & Next Steps
 
-Basic JWT authentication is in place; role-based authorization is planned for v2.
+Basic JWT authentication is in place for remote deployments; requests sent to
+`http://localhost` or `http://127.0.0.1` bypass authentication entirely. Role-
+based authorization is planned for v2.
 
 Refer to [ROADMAP.md](./docs/ROADMAP.md) for sprint plans and milestones.
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -7,8 +7,8 @@ This document provides a **detailed**, **explicit** reference for all backend HT
 ## 1. Authentication and Base Path
 
 - **Base URL**: `https://<your-domain>/api`
-- **Authentication**: All endpoints (except `/healthz` and `/metrics`) require a valid JSON Web Token (JWT).
-  - Send in HTTP header:
+- **Authentication**: All endpoints (except `/healthz` and `/metrics`) require a valid JSON Web Token (JWT) when accessed remotely. Requests sent to `http://localhost` or `http://127.0.0.1` bypass authentication.
+  - Send in HTTP header when required:
 
     ```http
     Authorization: Bearer <JWT_TOKEN>
@@ -101,15 +101,17 @@ This document provides a **detailed**, **explicit** reference for all backend HT
 Clients subscribe to four SSE endpoints to receive real-time updates. Each
 stream sends newline-delimited JSON messages where the `event` field indicates
 the channel and the payload conforms to the `SseEvent` schema (`type`,
-`payload`, `timestamp`). A short-lived JWT is required on the query string and
-can be obtained from `GET /stream/token`.
+`payload`, `timestamp`). For remote access, a short-lived JWT is required on the
+query string and can be obtained from `GET /stream/token`. Localhost requests do
+not require this token.
 
 ### 4.1 Token Messages
 
 #### GET `/stream/messages`
 
 - **Purpose**: Stream token-level diff messages from LLMs.
-- **Authentication**: Required (`viewer`, `editor`, or `admin`).
+- **Authentication**: Required (`viewer`, `editor`, or `admin`) for remote clients.
+  Localhost requests require none.
 - **Event Format**: `event: messages` followed by a serialized `SseEvent`.
 
 ### 4.2 Updates
@@ -117,7 +119,8 @@ can be obtained from `GET /stream/token`.
 #### GET `/stream/updates`
 
 - **Purpose**: Stream citation additions and workflow progress updates.
-- **Authentication**: Required (`viewer`, `editor`, or `admin`).
+- **Authentication**: Required (`viewer`, `editor`, or `admin`) for remote clients.
+  Localhost requests require none.
 - **Event Format**: `event: updates` with an `SseEvent` payload.
 
 ### 4.3 Values
@@ -125,7 +128,8 @@ can be obtained from `GET /stream/token`.
 #### GET `/stream/values`
 
 - **Purpose**: Stream structured state values as they change.
-- **Authentication**: Required (`viewer`, `editor`, or `admin`).
+- **Authentication**: Required (`viewer`, `editor`, or `admin`) for remote clients.
+  Localhost requests require none.
 - **Event Format**: `event: values` followed by an `SseEvent`.
 
 ### 4.4 Debug
@@ -133,7 +137,8 @@ can be obtained from `GET /stream/token`.
 #### GET `/stream/debug`
 
 - **Purpose**: Stream diagnostic or debug messages.
-- **Authentication**: Required (`viewer`, `editor`, or `admin`).
+- **Authentication**: Required (`viewer`, `editor`, or `admin`) for remote clients.
+  Localhost requests require none.
 - **Event Format**: `event: debug` followed by an `SseEvent`.
 
 ### 4.5 Workspace-Scoped Streams
@@ -144,26 +149,30 @@ events to a single workspace.
 #### GET `/stream/{workspace_id}/messages`
 
 - **Purpose**: Stream token-level diff messages for a specific workspace.
-- **Authentication**: Required (`viewer`, `editor`, or `admin`).
+- **Authentication**: Required (`viewer`, `editor`, or `admin`) for remote clients.
+  Localhost requests require none.
 - **Event Format**: `event: messages` with an `SseEvent` payload.
 
 #### GET `/stream/{workspace_id}/updates`
 
 - **Purpose**: Stream citation additions and workflow progress updates for a
   workspace.
-- **Authentication**: Required (`viewer`, `editor`, or `admin`).
+- **Authentication**: Required (`viewer`, `editor`, or `admin`) for remote clients.
+  Localhost requests require none.
 - **Event Format**: `event: updates` with an `SseEvent` payload.
 
 #### GET `/stream/{workspace_id}/values`
 
 - **Purpose**: Stream structured state values for a workspace.
-- **Authentication**: Required (`viewer`, `editor`, or `admin`).
+- **Authentication**: Required (`viewer`, `editor`, or `admin`) for remote clients.
+  Localhost requests require none.
 - **Event Format**: `event: values` followed by an `SseEvent`.
 
 #### GET `/stream/{workspace_id}/debug`
 
 - **Purpose**: Stream diagnostic messages for a workspace.
-- **Authentication**: Required (`viewer`, `editor`, or `admin`).
+- **Authentication**: Required (`viewer`, `editor`, or `admin`) for remote clients.
+  Localhost requests require none.
 - **Event Format**: `event: debug` followed by an `SseEvent`.
 
 ---

--- a/src/web/auth.py
+++ b/src/web/auth.py
@@ -18,7 +18,7 @@ def verify_jwt(
 ) -> Dict[str, Any]:
     """Validate the provided JWT and return its payload.
 
-    Requests from ``127.0.0.1`` bypass authentication checks.
+    Requests targeting ``localhost`` bypass authentication checks.
 
     Args:
         request: Incoming HTTP request used to access application settings.
@@ -30,7 +30,12 @@ def verify_jwt(
     Raises:
         HTTPException: If the token is missing, invalid, or fails authorization.
     """
-    if request.client and request.client.host == "127.0.0.1":
+    host = request.url.hostname
+    client_host = request.client.host if request.client else None
+    if host in {"localhost", "127.0.0.1", "::1"} or client_host in {
+        "127.0.0.1",
+        "::1",
+    }:
         return {"role": "user"}
 
     if credentials is None:

--- a/src/web/routes/stream.py
+++ b/src/web/routes/stream.py
@@ -26,6 +26,13 @@ router = APIRouter()
 
 def verify_stream_token(request: Request) -> Dict[str, Any]:
     """Validate the short-lived JWT passed as a query parameter."""
+    host = request.url.hostname
+    client_host = request.client.host if request.client else None
+    if host in {"localhost", "127.0.0.1", "::1"} or client_host in {
+        "127.0.0.1",
+        "::1",
+    }:
+        return {"role": "user"}
 
     token = request.query_params.get("token")
     if not token:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -27,7 +27,7 @@ def test_invalid_role_returns_403() -> None:
     assert resp.status_code == 403
 
 
-def test_localhost_bypasses_authentication() -> None:
+def test_loopback_client_bypasses_authentication() -> None:
     """Requests from 127.0.0.1 should bypass authentication."""
     app = create_app()
     scope = {
@@ -36,6 +36,23 @@ def test_localhost_bypasses_authentication() -> None:
         "method": "GET",
         "path": "/",
         "headers": [],
+        "app": app,
+    }
+    request = Request(scope)
+    assert verify_jwt(request, None) == {"role": "user"}
+
+
+def test_localhost_hostname_bypasses_authentication() -> None:
+    """Requests with a Host header of localhost should bypass authentication."""
+    app = create_app()
+    scope = {
+        "type": "http",
+        "client": ("192.168.1.5", 12345),
+        "scheme": "http",
+        "server": ("localhost", 80),
+        "method": "GET",
+        "path": "/",
+        "headers": [(b"host", b"localhost")],
         "app": app,
     }
     request = Request(scope)

--- a/tests/test_stream_endpoints.py
+++ b/tests/test_stream_endpoints.py
@@ -38,6 +38,21 @@ async def test_stream_messages_endpoint() -> None:
 
 
 @pytest.mark.asyncio
+async def test_stream_messages_endpoint_no_auth_localhost() -> None:
+    """Localhost requests should bypass the stream token requirement."""
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://localhost") as client:
+        async with client.stream("GET", "/stream/messages") as response:
+            await asyncio.sleep(0)
+            stream_messages("hi")
+            async for line in response.aiter_lines():
+                if line.startswith("data:"):
+                    assert "hi" in line
+                    break
+
+
+@pytest.mark.asyncio
 async def test_stream_workspace_messages_endpoint() -> None:
     """Workspace messages endpoint forwards streamed tokens."""
 


### PR DESCRIPTION
## Summary
- bypass auth when requests target localhost or loopback
- skip stream token validation for localhost SSE connections
- document localhost auth bypass across API reference and README
- expand tests for localhost authentication behavior

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443)...)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'jwt', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6899a1c78bbc832b865bda6326f02423