### PR TITLE
Expose module-level FastAPI app

### DIFF
--- a/src/web/main.py
+++ b/src/web/main.py
@@ -140,5 +140,8 @@ def main() -> None:
     uvicorn.run(create_app())
 
 
+# Make the ASGI app importable by uvicorn and tests
+app = create_app()
+
 if __name__ == "__main__":  # pragma: no cover - manual execution
     main()


### PR DESCRIPTION
## Summary
- make FastAPI application importable as `web.main:app`

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing src/web/main.py`
- `poetry run ruff check .`
- `poetry run flake8 src/web/main.py`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLCertVerificationError)*
- `poetry run pytest` *(fails: missing dependencies such as pydantic and fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6899ace118b4832b9fabc2ba6fb4e93d