### PR TITLE
fix: correct uvicorn entrypoint for dev server

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -22,4 +22,4 @@ fi
 poetry run alembic upgrade head
 
 # Forward all arguments (e.g., --offline) to uvicorn
-poetry run uvicorn web.main:create_app --reload "$@"
+poetry run uvicorn web.main:app --reload "$@"


### PR DESCRIPTION
## Summary
- update dev server script to run `web.main:app` instead of factory function

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLError: certificate verify failed)*
- `poetry run pytest` *(fails: 23 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6899acff806c832ba3ed3cd15f55f338