### PR TITLE
Handle missing WeasyPrint gracefully in PDF exporter

### DIFF
--- a/src/export/pdf_exporter.py
+++ b/src/export/pdf_exporter.py
@@ -7,8 +7,6 @@ from html import escape
 from pathlib import Path
 from typing import Optional
 
-from weasyprint import HTML  # type: ignore
-
 from .markdown_exporter import MarkdownExporter
 
 os.environ.setdefault("WEASYPRINT_HEADLESS", "1")
@@ -99,5 +97,12 @@ class PdfExporter:
         Returns:
             The binary PDF data.
         """
+
+        try:
+            from weasyprint import HTML  # type: ignore
+        except Exception as exc:  # pragma: no cover - fallback path
+            raise RuntimeError(
+                "PDF export requires WeasyPrint and its system libraries (e.g., Pango)."
+            ) from exc
 
         return HTML(string=html).write_pdf()

--- a/tests/test_pdf_exporter.py
+++ b/tests/test_pdf_exporter.py
@@ -1,0 +1,19 @@
+"""Tests for PDF export utilities."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from export.pdf_exporter import PdfExporter
+
+
+def test_render_pdf_requires_weasyprint(monkeypatch: pytest.MonkeyPatch) -> None:
+    """It raises a helpful error when WeasyPrint is unavailable."""
+
+    monkeypatch.delitem(sys.modules, "weasyprint", raising=False)
+    exporter = PdfExporter(":memory:")
+    with pytest.raises(RuntimeError) as excinfo:
+        exporter.render_pdf("<html><head></head><body></body></html>")
+    assert "WeasyPrint" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- avoid import-time crashes by importing WeasyPrint lazily
- test PDF export failure when WeasyPrint is missing

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLError: certificate verify failed)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'jwt', and 23 more)*

------
https://chatgpt.com/codex/tasks/task_e_6899ad35b288832b9a77f2c483c7678d