### PR TITLE
Use existing topics for run

### DIFF
--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -6,6 +6,7 @@ import { useWorkspaceStore } from "../store/useWorkspaceStore";
 interface Command {
   name: string;
   action: () => Promise<void> | void;
+  disabled?: boolean;
 }
 
 /**
@@ -15,6 +16,7 @@ interface Command {
 const CommandPalette: React.FC = () => {
   const workspaceId = useWorkspaceStore((s) => s.workspaceId);
   const setStatus = useWorkspaceStore((s) => s.setStatus);
+  const topics = useWorkspaceStore((s) => s.topics);
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
@@ -31,9 +33,10 @@ const CommandPalette: React.FC = () => {
   const commands: Command[] = [
     {
       name: "Run",
+      disabled: topics.length === 0,
       action: async () => {
         if (!workspaceId) return;
-        const topic = window.prompt("Enter topic");
+        const topic = topics[0];
         if (!topic) return;
         await controlClient.run(workspaceId, topic);
         setStatus("running");
@@ -76,8 +79,9 @@ const CommandPalette: React.FC = () => {
           {commands.map((cmd) => (
             <li key={cmd.name}>
               <button
-                className="w-full rounded p-2 text-left hover:bg-gray-100"
-                onClick={() => cmd.action()}
+                className="w-full rounded p-2 text-left hover:bg-gray-100 disabled:opacity-50"
+                onClick={() => !cmd.disabled && cmd.action()}
+                disabled={cmd.disabled}
               >
                 {cmd.name}
               </button>

--- a/frontend/src/components/ControlsPanel.tsx
+++ b/frontend/src/components/ControlsPanel.tsx
@@ -9,10 +9,10 @@ interface Props {
 
 // Renders basic graph controls.
 const ControlsPanel: React.FC<Props> = ({ workspaceId }) => {
-  const { status, setStatus } = useWorkspaceStore();
+  const { status, setStatus, topics } = useWorkspaceStore();
 
   const onRunClick = async () => {
-    const topic = window.prompt("Enter topic");
+    const topic = topics[0];
     if (!topic) return;
     console.info(`Running workspace ${workspaceId} with topic "${topic}"`);
     try {
@@ -33,12 +33,15 @@ const ControlsPanel: React.FC<Props> = ({ workspaceId }) => {
     }
   };
 
+  const runDisabled = status === "running" || topics.length === 0;
+
   return (
     <div className="flex flex-wrap items-center gap-3">
       <button
         onClick={onRunClick}
-        className="btn"
+        className="btn disabled:opacity-50"
         aria-busy={status === "running"}
+        disabled={runDisabled}
       >
         {status === "running" ? "Running…" : "Run"}
       </button>

--- a/frontend/src/components/DataEntryForm.tsx
+++ b/frontend/src/components/DataEntryForm.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { apiFetch } from "../api/http";
 import { Textarea } from "@/components/ui/textarea";
+import { useWorkspaceStore } from "../store/useWorkspaceStore";
 
 interface Entry {
   id: number;
@@ -14,6 +15,8 @@ const DataEntryForm: React.FC = () => {
   const [topic, setTopic] = useState("");
   const [entries, setEntries] = useState<Entry[]>([]);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const setTopics = useWorkspaceStore((s) => s.setTopics);
+  const addTopic = useWorkspaceStore((s) => s.addTopic);
 
   useEffect(() => {
     (async () => {
@@ -22,6 +25,7 @@ const DataEntryForm: React.FC = () => {
         if (res.ok) {
           const data: Entry[] = await res.json();
           setEntries(data);
+          setTopics(data.map((e) => e.topic));
         }
       } catch {
         // ignore network errors
@@ -40,6 +44,7 @@ const DataEntryForm: React.FC = () => {
       if (res.ok) {
         const entry: Entry = await res.json();
         setEntries((prev) => [...prev, entry]);
+        addTopic(entry.topic);
         setTopic("");
         const el = textareaRef.current;
         if (el) {

--- a/frontend/src/store/useWorkspaceStore.ts
+++ b/frontend/src/store/useWorkspaceStore.ts
@@ -21,10 +21,13 @@ interface WorkspaceStore {
   sources: (string | SourceItem)[];
   exportStatus: string;
   status: "idle" | "running";
+  topics: string[];
   connect: (workspaceId: string) => void;
   setWorkspaceId: (workspaceId: string | null) => void;
   updateState: (event: SseEvent) => void;
   setStatus: (status: "idle" | "running") => void;
+  setTopics: (topics: string[]) => void;
+  addTopic: (topic: string) => void;
 }
 
 // Global workspace state accessed throughout the UI.
@@ -35,6 +38,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
   sources: [],
   exportStatus: "idle",
   status: "idle",
+  topics: [],
   connect: (workspaceId: string) => {
     set({ workspaceId });
     (async () => {
@@ -56,6 +60,8 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
     })();
   },
   setWorkspaceId: (workspaceId) => set({ workspaceId }),
+  setTopics: (topics) => set({ topics }),
+  addTopic: (topic) => set((state) => ({ topics: [...state.topics, topic] })),
   updateState: (event: SseEvent) => {
     switch (event.type) {
       case "document":

--- a/tests/commandPalette.test.tsx
+++ b/tests/commandPalette.test.tsx
@@ -14,11 +14,19 @@ vi.mock("../frontend/src/api/exportClient", () => ({
 
 describe("CommandPalette", () => {
   beforeEach(() => {
-    useWorkspaceStore.setState({ workspaceId: "abc", status: "idle" });
+    useWorkspaceStore.setState({
+      workspaceId: "abc",
+      status: "idle",
+      topics: [],
+    });
   });
 
   it("opens with Cmd+K and triggers run", async () => {
-    vi.spyOn(window, "prompt").mockReturnValue("topic");
+    useWorkspaceStore.setState({
+      topics: ["topic"],
+      workspaceId: "abc",
+      status: "idle",
+    });
     render(<CommandPalette />);
     await act(async () => {
       fireEvent.keyDown(window, { key: "k", metaKey: true });

--- a/tests/controlsPanel.test.tsx
+++ b/tests/controlsPanel.test.tsx
@@ -15,9 +15,10 @@ vi.mock("@/api/controlClient", () => ({
 import ControlsPanel from "@/components/ControlsPanel";
 import controlClient from "@/api/controlClient";
 import { toast } from "sonner";
+import { useWorkspaceStore } from "../frontend/src/store/useWorkspaceStore";
 
 it("shows error toast on run failure", async () => {
-  vi.spyOn(window, "prompt").mockReturnValue("topic");
+  useWorkspaceStore.setState({ topics: ["topic"], status: "idle" });
   const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
   const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   const client = controlClient as unknown as {
@@ -37,4 +38,10 @@ it("shows error toast on run failure", async () => {
   await waitFor(() =>
     expect(vi.mocked(toast.error)).toHaveBeenCalledWith("Run failed"),
   );
+});
+
+it("disables run button with no topics", () => {
+  useWorkspaceStore.setState({ topics: [], status: "idle" });
+  render(<ControlsPanel workspaceId="1" />);
+  expect(screen.getByText("Run")).toBeDisabled();
 });


### PR DESCRIPTION
## Summary
- store submitted topics globally and share them across components
- disable Run actions when no topics are available
- update tests for topic-based runs

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLCertVerificationError)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899a01b4b08832b9bf2a454eb94b703