### PR TITLE
Add structured logging and request ID middleware

### DIFF
--- a/src/core/logging.py
+++ b/src/core/logging.py
@@ -1,35 +1,83 @@
-"""Centralized Loguru configuration for structured logging.
+"""Centralised configuration for JSON logging and request correlation.
 
-This module sets up Loguru to emit JSON-formatted logs and exposes a helper
-for binding job and user identifiers. Modules should import ``get_logger``
-and call it with any relevant IDs to obtain a context-aware logger instance.
+This module configures `loguru` to emit structured JSON logs and exposes
+helpers for binding contextual information. A FastAPI middleware is provided
+to attach a short request identifier to each incoming request so log entries
+can be correlated across services.
 """
 
 from __future__ import annotations
 
+import logging
 import sys
+import uuid
+from contextvars import ContextVar
 from typing import Optional
 
 from loguru import logger as _logger
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
 
-# Configure a single JSON sink for all application logs.
-_logger.remove()
-_logger.add(sys.stdout, serialize=True)
+# Context variable storing the request ID for the current execution context.
+_REQUEST_ID_CTX: ContextVar[str | None] = ContextVar("request_id", default=None)
+
+
+class InterceptHandler(logging.Handler):
+    """Redirect standard logging records to Loguru."""
+
+    def emit(
+        self, record: logging.LogRecord
+    ) -> None:  # pragma: no cover - thin wrapper
+        try:
+            level = _logger.level(record.levelname).name
+        except ValueError:
+            level = record.levelno
+        _logger.bind(request_id=_REQUEST_ID_CTX.get()).opt(
+            depth=2, exception=record.exc_info
+        ).log(level, record.getMessage())
+
+
+def configure_logging(level: str = "INFO") -> None:
+    """Configure Loguru to produce JSON structured logs.
+
+    Args:
+        level: Minimum log level to emit. Defaults to ``"INFO"``.
+    """
+
+    _logger.remove()
+    _logger.add(sys.stdout, level=level, serialize=True)
+    logging.basicConfig(handlers=[InterceptHandler()], level=0, force=True)
 
 
 def get_logger(job_id: Optional[str] = None, user_id: Optional[str] = None):
-    """Return a Loguru logger bound with job and user identifiers.
+    """Return a logger bound with job, user and request identifiers.
 
     Args:
         job_id: Identifier for the current job or workspace.
         user_id: Identifier for the acting user.
 
     Returns:
-        ``loguru.Logger`` instance with the provided identifiers bound so
-        they appear in every log record.
+        ``loguru.Logger`` instance bound with the provided IDs.
     """
 
-    return _logger.bind(job_id=job_id, user_id=user_id)
+    return _logger.bind(
+        job_id=job_id, user_id=user_id, request_id=_REQUEST_ID_CTX.get()
+    )
+
+
+class RequestIDMiddleware(BaseHTTPMiddleware):
+    """Attach a short request ID to every HTTP request."""
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        request_id = uuid.uuid4().hex[:8]
+        request.state.req_id = request_id
+        token = _REQUEST_ID_CTX.set(request_id)
+        try:
+            response = await call_next(request)
+        finally:
+            _REQUEST_ID_CTX.reset(token)
+        response.headers["X-Request-ID"] = request_id
+        return response
 
 
 # Export the base logger for modules that don't require additional context.

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -14,11 +14,13 @@ from fastapi.staticfiles import StaticFiles
 from agents.cache_backed_researcher import CacheBackedResearcher
 from agents.researcher_web import TavilyClient
 from config import Settings, load_settings
+from core.logging import RequestIDMiddleware, configure_logging
 from core.orchestrator import graph_orchestrator
 from observability import init_observability, instrument_app
 from persistence.database import get_db_session, init_db
 from web.telemetry import REQUEST_COUNTER
 
+configure_logging()
 init_observability()
 
 
@@ -28,6 +30,7 @@ def create_app() -> FastAPI:
     settings = load_settings()
     app = FastAPI()
     app.state.settings = settings
+    app.add_middleware(RequestIDMiddleware)
 
     if settings.enable_tracing:
         instrument_app(app)


### PR DESCRIPTION
## Summary
- configure loguru for JSON structured logs and bridge stdlib logging
- add RequestIDMiddleware to attach request identifiers to responses
- integrate logging setup and middleware into FastAPI application

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLCertVerificationError)*
- `poetry run pytest` *(fails: missing modules such as pydantic and fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6899b3dc5be4832bbf9df40408564ec2