### PR TITLE
Use env-configured database URL for Alembic and smoke test migrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           cache: "poetry"
           cache-dependency-path: poetry.lock
       - run: poetry install --with dev --extras test --no-interaction --no-ansi
-      - name: Verify migrations
+      - name: Smoke test migrations
         env:
           DATABASE_URL: sqlite:///${{ github.workspace }}/workspace/migration.db
           OPENAI_API_KEY: test

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
+import os
 from logging.config import fileConfig
 
 from alembic import context
-from sqlalchemy import engine_from_config, pool
-
-from config import Settings
+from sqlalchemy import create_engine, pool
 
 # Alembic Config object, provides access to .ini values.
 config = context.config
@@ -20,13 +19,9 @@ target_metadata = None
 
 
 def get_url() -> str:
-    """Return the database URL from environment settings."""
+    """Return the database URL from configuration."""
 
-    settings = Settings()
-    if settings.database_url:
-        return settings.database_url
-    db_path = settings.data_dir / "workspace.db"
-    return f"sqlite:///{db_path}"
+    return os.path.expandvars(config.get_main_option("sqlalchemy.url"))
 
 
 def run_migrations_offline() -> None:
@@ -45,9 +40,8 @@ def run_migrations_offline() -> None:
 
 def run_migrations_online() -> None:
     """Run migrations in 'online' mode."""
-    connectable = engine_from_config(
-        {"url": get_url()}, prefix="", poolclass=pool.NullPool
-    )
+    url = get_url()
+    connectable = create_engine(url, poolclass=pool.NullPool)
 
     with connectable.connect() as connection:
         context.configure(connection=connection, target_metadata=target_metadata)


### PR DESCRIPTION
## Summary
- resolve Alembic database URL from `sqlalchemy.url` config
- run Alembic migration as smoke test in CI

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type migrations/env.py .github/workflows/ci.yml`
- `poetry run black --preview --enable-unstable-feature string_processing migrations/env.py`
- `poetry run ruff check migrations/env.py`
- `poetry run flake8 migrations/env.py`
- `poetry run mypy migrations/env.py`
- `poetry run bandit -r migrations -ll`
- `poetry run pip-audit` *(fails: certificate verify failed)*
- `DATABASE_URL=sqlite:///workspace/test.db OPENAI_API_KEY=test PERPLEXITY_API_KEY=test JWT_SECRET=test poetry run alembic upgrade head`
- `DATABASE_URL=sqlite:///workspace/test.db OPENAI_API_KEY=test PERPLEXITY_API_KEY=test JWT_SECRET=test poetry run pytest --maxfail=1 --disable-warnings -q` *(fails: ModuleNotFoundError: No module named 'jwt')*


------
https://chatgpt.com/codex/tasks/task_e_6899b3f8a2c4832bb1ff813ecaea2aa9