### PR TITLE
feat: make web search client asynchronous

### DIFF
--- a/src/agents/cache_backed_researcher.py
+++ b/src/agents/cache_backed_researcher.py
@@ -18,7 +18,20 @@ class CacheBackedResearcher:
     populate the cache beforehand.
     """
 
-    def search(self, query: str) -> List[RawSearchResult]:
+    async def __aenter__(self) -> "CacheBackedResearcher":
+        return self
+
+    async def __aexit__(
+        self, exc_type, exc, tb
+    ) -> None:  # noqa: D401 - Protocol method
+        return None
+
+    async def aclose(self) -> None:
+        """Conform to the :class:`SearchClient` interface."""
+
+        return None
+
+    async def search(self, query: str) -> List[RawSearchResult]:
         """Load cached results for ``query`` or raise ``FileNotFoundError``.
 
         Parameters

--- a/src/agents/researcher_pipeline.py
+++ b/src/agents/researcher_pipeline.py
@@ -34,7 +34,7 @@ async def researcher_pipeline(query: str, state: State) -> List[Citation]:
 
     state.prompt = query
     try:
-        drafts: List[CitationDraft] = run_web_search(state)
+        drafts: List[CitationDraft] = await run_web_search(state)
     except Exception:
         logging.exception("Web search failed")
         return []

--- a/src/agents/researcher_web_runner.py
+++ b/src/agents/researcher_web_runner.py
@@ -20,12 +20,16 @@ def _to_draft(result: RawSearchResult) -> CitationDraft:
     return CitationDraft(url=result.url, snippet=result.snippet, title=result.title)
 
 
-def run_web_search(state: State) -> List[CitationDraft]:
+async def run_web_search(state: State) -> List[CitationDraft]:
     """Run a web search using the configured provider."""
+
     settings = Settings()
     if settings.offline_mode:
         client: SearchClient = CacheBackedResearcher()
     else:
         client = TavilyClient(settings.tavily_api_key or "")
-    results = client.search(state.prompt)
+
+    async with client:
+        results = await client.search(state.prompt)
+
     return [_to_draft(r) for r in results]

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -57,6 +57,7 @@ def create_app() -> FastAPI:
         try:
             yield
         finally:
+            await app.state.research_client.aclose()
             await app.state.http.aclose()
 
     app = FastAPI(lifespan=lifespan)

--- a/tests/test_researcher_pipeline.py
+++ b/tests/test_researcher_pipeline.py
@@ -11,7 +11,7 @@ os.environ.setdefault("OPENAI_API_KEY", "test")
 
 @pytest.mark.asyncio
 async def test_pipeline_handles_web_search_error(monkeypatch):
-    def fail_search(_state):
+    async def fail_search(_state):
         raise httpx.HTTPError("search failure")
 
     monkeypatch.setattr("agents.researcher_pipeline.run_web_search", fail_search)
@@ -27,7 +27,7 @@ async def test_pipeline_continues_on_license_and_db_errors(monkeypatch):
         CitationDraft(url="https://example.edu/b", snippet="", title="B"),
     ]
 
-    def good_search(_state):
+    async def good_search(_state):
         return drafts
 
     async def flaky_lookup(url: str) -> str:

--- a/tests/test_researcher_web_clients.py
+++ b/tests/test_researcher_web_clients.py
@@ -1,11 +1,13 @@
 import json
 
 import httpx
+import pytest
 
 from agents.researcher_web import TavilyClient
 
 
-def test_tavily_client_parses_response():
+@pytest.mark.asyncio
+async def test_tavily_client_parses_response():
     def handler(
         request: httpx.Request,
     ) -> httpx.Response:  # pragma: no cover - simple handler
@@ -19,6 +21,8 @@ def test_tavily_client_parses_response():
         return httpx.Response(200, json=data)
 
     transport = httpx.MockTransport(handler)
-    client = TavilyClient("key", http=httpx.Client(transport=transport))
-    results = client.search("query")
+    async with TavilyClient(
+        "key", http=httpx.AsyncClient(transport=transport)
+    ) as client:
+        results = await client.search("query")
     assert results[0].title == "Tavily"


### PR DESCRIPTION
## Summary
- refactor Tavily search client to use httpx.AsyncClient with async context management
- make web search runner and pipeline fully asynchronous
- adapt tests and offline cache researcher to async interface

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLCertVerificationError)*
- `pytest tests/test_researcher_web_clients.py tests/test_researcher_pipeline.py` *(fails: ModuleNotFoundError: pydantic_settings)*

------
https://chatgpt.com/codex/tasks/task_e_6899bb82273c832bbf9ab22ed88dc09d