### PR TITLE
chore: suppress logfire missing config warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,3 +73,6 @@ pythonpath = ["src"]
 [tool.mypy]
 python_version = "3.11"
 ignore_missing_imports = true
+
+[tool.logfire]
+ignore_no_config = true


### PR DESCRIPTION
## Summary
- suppress Logfire configuration warnings by opting out via pyproject

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/` *(fails: Command not found)*
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll` *(fails: Command not found)*
- `poetry run pip-audit` *(fails: Command not found)*
- `poetry run pytest` *(fails: errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6899bf1e1124832b88e570a72888b10d