### PR TITLE
Make cached_search asynchronous and add sync wrapper

### DIFF
--- a/src/agents/researcher_web.py
+++ b/src/agents/researcher_web.py
@@ -134,12 +134,30 @@ async def _cached_search_async(
     return results
 
 
-def cached_search(
+async def cached_search(
     query: str, client: SearchClient, dense: Optional[DenseRetriever] = None
 ) -> List[RawSearchResult]:
-    """Synchronous wrapper around :func:`_cached_search_async`."""
+    """Return cached search results for ``query`` using ``client``."""
 
-    return asyncio.run(_cached_search_async(query, client, dense))
+    return await _cached_search_async(query, client, dense)
+
+
+def cached_search_sync(
+    query: str, client: SearchClient, dense: Optional[DenseRetriever] = None
+) -> List[RawSearchResult]:
+    """Synchronous wrapper around :func:`cached_search`.
+
+    Raises ``RuntimeError`` if called when an event loop is already running.
+    """
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(cached_search(query, client, dense))
+    raise RuntimeError(
+        "cached_search_sync cannot be used when an event loop is running; use 'await"
+        " cached_search'"
+    )
 
 
 def score_domain_authority(domain: str) -> float:


### PR DESCRIPTION
## Summary
- convert `cached_search` to an async function awaiting `_cached_search_async`
- add `cached_search_sync` wrapper that safely runs the async search from synchronous contexts

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type src/agents/researcher_web.py`
- `poetry run black --preview --enable-unstable-feature string_processing src/agents/researcher_web.py`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(failed: certificate verify failed)*
- `poetry run pytest` *(failed: 25 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6899be07dd3c832ba157ee4864351c32