### PR TITLE
Fix async Bloom classification to avoid event loop errors

### DIFF
--- a/tests/test_pedagogy_critic.py
+++ b/tests/test_pedagogy_critic.py
@@ -23,9 +23,10 @@ async def test_run_pedagogy_critic_uses_module_activities(
 ) -> None:
     """Pedagogy critic aggregates activities from state modules."""
 
-    monkeypatch.setattr(
-        "agents.pedagogy_critic.classify_bloom_level", lambda _text: "remember"
-    )
+    async def _fake_classify(_text: str) -> str:
+        return "remember"
+
+    monkeypatch.setattr("agents.pedagogy_critic.classify_bloom_level", _fake_classify)
 
     state = State(prompt="topic")
     state.learning_objectives = ["List facts"]


### PR DESCRIPTION
## Summary
- avoid event loop collision by awaiting Pydantic AI agent when classifying Bloom levels
- propagate async Bloom classification through coverage analysis and pedagogy critic
- adjust pedagogy critic test to use async classifier stub

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(failed: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /pypi/bandit/1.8.6/json (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)'))))*
- `poetry run pytest` *(errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6899bfb045ec832b938467b700ed6524