### PR TITLE
Align loguru and logfire configuration

### DIFF
--- a/src/observability.py
+++ b/src/observability.py
@@ -57,13 +57,21 @@ def init_observability() -> None:
 
     install_auto_tracing()
     logfire.configure(token=token, service_name=project)
-    logging.getLogger().addHandler(logfire.LogfireLoggingHandler())
+
+    # Ensure loguru and the standard logging module send records to Logfire.
+    # Clearing existing handlers prevents duplicate log entries.
+    root_logger = logging.getLogger()
+    root_logger.handlers.clear()
+    root_logger.addHandler(logfire.LogfireLoggingHandler())
+
+    loguru_logger.remove()
+    loguru_logger.add(logfire.loguru_handler())
+
     logfire.instrument_pydantic()
     logfire.instrument_httpx()
     logfire.instrument_sqlalchemy()
     logfire.instrument_sqlite3()
     logfire.instrument_system_metrics()
-    loguru_logger.add(logfire.loguru_handler())
 
 
 def instrument_app(app: "FastAPI") -> None:

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import logging
+import types
+
 import logfire
 from loguru import logger as loguru_logger
 
@@ -47,3 +50,51 @@ def test_init_observability_enabled(monkeypatch):
     monkeypatch.setattr(loguru_logger, "add", lambda *a, **k: None)
     init_observability()
     assert called is True
+
+
+def test_loguru_and_logfire_handlers_aligned(monkeypatch):
+    """Loguru sinks and standard logging handlers are replaced by Logfire."""
+
+    monkeypatch.setenv("ENABLE_TRACING", "1")
+    monkeypatch.setattr("observability.install_auto_tracing", lambda: None)
+    for name in [
+        "instrument_pydantic",
+        "instrument_httpx",
+        "instrument_sqlalchemy",
+        "instrument_sqlite3",
+        "instrument_system_metrics",
+    ]:
+        monkeypatch.setattr(logfire, name, lambda *a, **k: None)
+    monkeypatch.setattr(logfire, "configure", lambda *a, **k: None)
+    monkeypatch.setattr(logfire, "loguru_handler", lambda: None)
+
+    removed = []
+    added = []
+
+    def fake_remove(*_a, **_k):
+        removed.append(True)
+
+    def fake_add(*_a, **_k):
+        added.append(True)
+
+    monkeypatch.setattr(loguru_logger, "remove", fake_remove)
+    monkeypatch.setattr(loguru_logger, "add", fake_add)
+
+    class HandlerList(list):
+        def clear(self):  # type: ignore[override]
+            cleared.append(True)
+            super().clear()
+
+    cleared: list[bool] = []
+
+    def add_handler(_):
+        handlers_added.append(True)
+
+    handlers_added: list[bool] = []
+    root_logger = types.SimpleNamespace(handlers=HandlerList(), addHandler=add_handler)
+    monkeypatch.setattr(logging, "getLogger", lambda: root_logger)
+
+    init_observability()
+
+    assert removed and added
+    assert cleared and handlers_added


### PR DESCRIPTION
## Summary
- route standard logging and Loguru through Logfire
- expand observability tests to verify handler alignment

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(failed: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /pypi/bandit/1.8.6/json (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)')))*
- `poetry run pytest` *(failed: 25 errors - ModuleNotFoundError: No module named 'jwt', 'aiosqlite', 'fastapi', 'pydantic', ...)*

------
https://chatgpt.com/codex/tasks/task_e_6899c12cbec4832b94c87a84fb7eea5d