### PR TITLE
Serialize action log timestamps and add lectures table migration

### DIFF
--- a/migrations/versions/20250806_create_lectures_table.py
+++ b/migrations/versions/20250806_create_lectures_table.py
@@ -1,0 +1,27 @@
+"""Create lectures table."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa  # type: ignore[import]
+from alembic import op  # type: ignore[import]
+
+revision = "20250806_create_lectures_table"
+down_revision = "20250805_create_citations_action_logs_metrics_tables"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Apply the migration."""
+    op.create_table(
+        "lectures",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("workspace_id", sa.String, nullable=False),
+        sa.Column("lecture_json", sa.Text, nullable=False),
+        sa.Column("created_at", sa.DateTime, nullable=False),
+    )
+
+
+def downgrade() -> None:
+    """Revert the migration."""
+    op.drop_table("lectures")

--- a/src/core/state.py
+++ b/src/core/state.py
@@ -118,7 +118,7 @@ class State:
             "prompt": self.prompt,
             "sources": [source.model_dump() for source in self.sources],
             "outline": self.outline.model_dump(),
-            "log": [entry.model_dump() for entry in self.log],
+            "log": [entry.model_dump(mode="json") for entry in self.log],
             "retries": self.retries,
             "retry_counts": self.retry_counts,
             "learning_objectives": self.learning_objectives,

--- a/tests/test_state_serialization.py
+++ b/tests/test_state_serialization.py
@@ -1,0 +1,13 @@
+"""Tests for state serialization edge cases."""
+
+from __future__ import annotations
+
+from core.state import ActionLog, State
+
+
+def test_to_dict_serializes_datetimes() -> None:
+    """State.to_dict serializes datetimes to strings."""
+    state = State(prompt="topic")
+    state.log.append(ActionLog(message="done"))
+    data = state.to_dict()
+    assert isinstance(data["log"][0]["timestamp"], str)


### PR DESCRIPTION
## Summary
- Ensure `State.to_dict` JSON serializes action log timestamps
- Add Alembic migration to create `lectures` table
- Test serialization of `ActionLog` timestamps

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(failed: SSLCertVerificationError)*
- `poetry run pytest` *(errors during collection: 26 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6899cdcf7eb8832b8e30fc7aa5d98a54