### PR TITLE
Allow unknown environment vars in Settings

### DIFF
--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -19,8 +19,8 @@ class Settings(BaseSettings):
     """Configuration sourced from environment variables."""
 
     model_config = SettingsConfigDict(
-        env_file=".env", env_prefix="", case_sensitive=False
-    )
+        env_file=".env", env_prefix="", case_sensitive=False, extra="ignore"
+    )  # ignore unknown env vars for forward compatibility
 
     OPENAI_API_KEY: SecretStr = Field(..., description="API key for OpenAI access")
     DATA_DIR: Path = Field(


### PR DESCRIPTION
## Summary
- ignore undefined environment variables in Pydantic settings to support extra config without errors

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLError: CERTIFICATE_VERIFY_FAILED)*
- `poetry run pytest` *(fails: 26 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6899cfabc4e0832b9409619b735d682f