### PR TITLE
fix: align theme plumbing with Primer

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,10 @@
 <!doctype html>
-<html lang="en">
+<html
+  lang="en"
+  data-color-mode="auto"
+  data-light-theme="light"
+  data-dark-theme="dark_dimmed"
+>
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -12,15 +17,6 @@
       href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Domine:wght@400;700&display=swap"
       rel="stylesheet"
     />
-    <script>
-      const t = localStorage.getItem("theme");
-      const d = t
-        ? t === "dark"
-        : window.matchMedia("(prefers-color-scheme: dark)").matches;
-      if (t !== "light" && t !== "dark" && !d)
-        document.documentElement.classList.remove("dark");
-      else document.documentElement.classList.toggle("dark", d || t === "dark");
-    </script>
   </head>
   <body class="bg-background text-foreground min-h-screen antialiased">
     <div id="root"></div>

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -29,27 +29,26 @@ const ThemeToggle: React.FC = () => {
     theme === "system" ? (mql.matches ? "dark" : "light") : theme;
 
   useEffect(() => {
-    const apply = (t: "light" | "dark") => {
-      document.documentElement.classList.toggle("dark", t === "dark");
-      localStorage.setItem("theme", theme);
-      document.dispatchEvent(new CustomEvent("theme-change", { detail: t }));
+    const apply = (mode: "light" | "dark" | "system") => {
+      const root = document.documentElement;
+      root.setAttribute("data-color-mode", mode === "system" ? "auto" : mode);
+      root.setAttribute("data-light-theme", "light");
+      root.setAttribute("data-dark-theme", "dark_dimmed");
+      localStorage.setItem("theme", mode);
+      const res = mode === "system" ? (mql.matches ? "dark" : "light") : mode;
+      document.dispatchEvent(new CustomEvent("theme-change", { detail: res }));
       // keep meta theme-color in sync (see next point)
       const meta = document.querySelector('meta[name="theme-color"]');
       if (meta)
-        meta.setAttribute("content", t === "dark" ? "#0d1117" : "#ffffff");
+        meta.setAttribute("content", res === "dark" ? "#0d1117" : "#ffffff");
     };
-    apply(resolved);
+    apply(theme);
     if (theme === "system") {
-      const handler = () =>
-        apply(
-          window.matchMedia("(prefers-color-scheme: dark)").matches
-            ? "dark"
-            : "light",
-        );
+      const handler = () => apply("system");
       mql.addEventListener("change", handler);
       return () => mql.removeEventListener("change", handler);
     }
-  }, [mql, resolved, theme]);
+  }, [mql, theme]);
 
   return (
     <DropdownMenu>

--- a/tests/themeToggle.test.tsx
+++ b/tests/themeToggle.test.tsx
@@ -18,7 +18,9 @@ describe("ThemeToggle", () => {
   });
   beforeEach(() => {
     localStorage.clear();
-    document.documentElement.classList.remove("dark");
+    document.documentElement.removeAttribute("data-color-mode");
+    document.documentElement.removeAttribute("data-light-theme");
+    document.documentElement.removeAttribute("data-dark-theme");
   });
 
   it("returns focus to trigger after selecting a theme", async () => {
@@ -27,6 +29,11 @@ describe("ThemeToggle", () => {
     await userEvent.click(trigger);
     await userEvent.click(screen.getByText("Dark"));
     await waitFor(() => expect(trigger).toHaveFocus());
-    await waitFor(() => expect(document.documentElement).toHaveClass("dark"));
+    await waitFor(() =>
+      expect(document.documentElement).toHaveAttribute(
+        "data-color-mode",
+        "dark",
+      ),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- set Primer data-color defaults on `<html>` and drop dark-class boot script
- update ThemeToggle to manage Primer data attributes and persist selection
- adjust ThemeToggle tests for new attribute-based logic

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/` (fails: B008 Do not perform function calls in argument defaults)
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` (fails: SSLCertVerificationError)
- `npm run lint`
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6899db6e3e98832bb7b8e9671bebcc28