### PR TITLE
Use system font and drop Google Fonts

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,12 +6,6 @@
     <meta name="color-scheme" content="light dark" />
     <meta name="theme-color" content="#0b0b0c" />
     <title>Lecture Builder</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Domine:wght@400;700&display=swap"
-      rel="stylesheet"
-    />
     <script>
       const t = localStorage.getItem("theme");
       const d = t

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,11 @@
 @import "@primer/css/dist/primer.css";
 
+body {
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji";
+}
+
 @media (prefers-reduced-motion: no-preference) {
   html,
   body,
@@ -28,7 +34,10 @@
   font-size: 0.875rem;
   font-weight: 500;
   background-color: var(--color-canvas-default);
-  transition: background-color 0.2s, color 0.2s, border-color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s,
+    border-color 0.2s;
 }
 
 .btn:hover {


### PR DESCRIPTION
## Summary
- remove Google Fonts loading from `index.html`
- default body font to Primer's system font stack

## Testing
- `npm run lint:css`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(failed: SSLError certificate verify failed)*

------
https://chatgpt.com/codex/tasks/task_e_6899db82a3a8832ba52fa9307cca2693