### PR TITLE
Use Primer buttons instead of custom styles

### DIFF
--- a/frontend/src/components/ControlsPanel.tsx
+++ b/frontend/src/components/ControlsPanel.tsx
@@ -39,7 +39,7 @@ const ControlsPanel: React.FC<Props> = ({ workspaceId }) => {
     <div className="d-flex flex-wrap flex-items-center">
       <button
         onClick={onRunClick}
-        className="btn mr-3"
+        className="btn btn-primary mr-3"
         aria-busy={status === "running"}
         disabled={runDisabled}
       >

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -17,30 +17,3 @@
   border-radius: 12px;
   padding: 1.5rem;
 }
-
-.btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 1rem;
-  border: var(--borderWidth-thin) solid var(--borderColor-muted);
-  border-radius: 8px;
-  font-size: 0.875rem;
-  font-weight: 500;
-  background-color: var(--color-canvas-default);
-  transition: background-color 0.2s, color 0.2s, border-color 0.2s;
-}
-
-.btn:hover {
-  background-color: var(--color-neutral-muted);
-}
-
-.btn:focus-visible {
-  outline: 2px solid var(--color-accent-emphasis);
-  outline-offset: 2px;
-}
-
-.btn:disabled {
-  cursor: not-allowed;
-  opacity: 0.5;
-}


### PR DESCRIPTION
## Summary
- remove custom `.btn` styles from frontend to avoid overriding Primer
- use Primer `btn btn-primary` and `btn` classes in controls panel buttons

## Testing
- `npm run lint:css`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: certificate verify failed)*

------
https://chatgpt.com/codex/tasks/task_e_6899db92de1c832bb41232f1a218a7e8