### PR TITLE
Render GitHub-style Markdown

### DIFF
--- a/frontend/src/components/DocumentPanel.tsx
+++ b/frontend/src/components/DocumentPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
+import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import { computeDiff, type DiffPatch } from "../utils/diffUtils";
 
 interface Props {
@@ -50,12 +51,22 @@ const DocumentPanel: React.FC<Props> = ({ text, onAcceptDiff }) => {
     );
   }
 
+  const sanitizeSchema = {
+    ...defaultSchema,
+    tagNames: [...(defaultSchema.tagNames || []), "mark"],
+    attributes: {
+      ...defaultSchema.attributes,
+      mark: ["className"],
+    },
+  };
+
   return (
-    <div
-      className="prose max-w-none text-black dark:text-black"
-      aria-live="polite"
-    >
-      <ReactMarkdown rehypePlugins={[rehypeRaw]}>{rendered}</ReactMarkdown>
+    <div className="markdown-body" aria-live="polite">
+      <ReactMarkdown
+        rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema]]}
+      >
+        {rendered}
+      </ReactMarkdown>
     </div>
   );
 };

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
 import "./index.css";
+import "github-markdown-css";
 import { configure } from "@pydantic/logfire-browser";
 import { FetchInstrumentation } from "@opentelemetry/instrumentation-fetch";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,12 +19,14 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "diff-match-patch": "^1.0.5",
+        "github-markdown-css": "^5.8.1",
         "lucide-react": "^0.539.0",
         "postcss": "^8.5.6",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-markdown": "^10.1.0",
         "rehype-raw": "^7.0.0",
+        "rehype-sanitize": "^6.0.0",
         "sonner": "^2.0.0"
       },
       "devDependencies": {
@@ -5652,6 +5654,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/github-markdown-css": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/github-markdown-css/-/github-markdown-css-5.8.1.tgz",
+      "integrity": "sha512-8G+PFvqigBQSWLQjyzgpa2ThD9bo7+kDsriUIidGcRhXgmcaAWUIpCZf8DavJgc+xifjbCG+GvMyWr0XMXmc7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -5926,6 +5940,21 @@
         "vfile": "^6.0.0",
         "web-namespaces": "^2.0.0",
         "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -8756,6 +8785,20 @@
         "@types/hast": "^3.0.0",
         "hast-util-raw": "^9.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "@opentelemetry/instrumentation-fetch": "^0.203.0",
+    "@primer/css": "^22.0.2",
     "@pydantic/logfire-browser": "^0.9.0",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-scroll-area": "^1.2.9",
@@ -52,13 +53,14 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "diff-match-patch": "^1.0.5",
+    "github-markdown-css": "^5.8.1",
     "lucide-react": "^0.539.0",
     "postcss": "^8.5.6",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-markdown": "^10.1.0",
     "rehype-raw": "^7.0.0",
-    "sonner": "^2.0.0",
-    "@primer/css": "^22.0.2"
+    "rehype-sanitize": "^6.0.0",
+    "sonner": "^2.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- style: load GitHub Markdown CSS for consistent styling
- feat: sanitize and render Markdown content in DocumentPanel
- chore: install rehype-sanitize and github-markdown-css dependencies

## Testing
- `npm run lint`
- `npm run lint:css`
- `npm run typecheck`
- `npm test`
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /pypi/bandit/1.8.6/json (Caused by SSLError))*

------
https://chatgpt.com/codex/tasks/task_e_6899db51a7d8832b8b8b80af28536c2a