### PR TITLE
feat: use css utility for skeleton

### DIFF
--- a/frontend/src/components/ui/skeleton.tsx
+++ b/frontend/src/components/ui/skeleton.tsx
@@ -4,12 +4,7 @@ function Skeleton({
   className,
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) {
-  return (
-    <div
-      className={cn("bg-muted animate-pulse rounded-md", className)}
-      {...props}
-    />
-  );
+  return <div className={cn("skeleton", className)} {...props} />;
 }
 
 export { Skeleton };

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -23,3 +23,20 @@ body {
   border-radius: 12px;
   padding: 1.5rem;
 }
+
+.skeleton {
+  background: var(--color-neutral-muted);
+  border-radius: 6px;
+  animation: pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 0.6;
+  }
+
+  50% {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Summary
- replace Tailwind-only skeleton styles with a reusable CSS utility
- apply `skeleton` class in Skeleton component

## Testing
- `npx prettier --write frontend/src/index.css frontend/src/components/ui/skeleton.tsx`
- `npm run lint`
- `npm run lint:css`
- `npm test`
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/` *(fails: Command not found: flake8)*
- `poetry install --with dev` *(fails: All attempts to connect to pypi.org failed)*
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll` *(fails: Command not found: bandit)*
- `poetry run pip-audit` *(fails: Command not found: pip-audit)*
- `poetry run pytest` *(fails: 26 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6899de75e13c832b9236405afb1c5a97