### PR TITLE
feat: introduce spacing scale and stack layout

### DIFF
--- a/frontend/src/components/DocumentPanel.tsx
+++ b/frontend/src/components/DocumentPanel.tsx
@@ -42,7 +42,7 @@ const DocumentPanel: React.FC<Props> = ({ text, onAcceptDiff }) => {
     return (
       <div
         data-testid="document-skeleton"
-        className="max-w-none animate-pulse space-y-2"
+        className="max-w-none animate-pulse stack"
       >
         <div className="h-4 rounded bg-gray-300" />
         <div className="h-4 rounded bg-gray-300" />

--- a/frontend/src/components/LogPanel.tsx
+++ b/frontend/src/components/LogPanel.tsx
@@ -20,7 +20,7 @@ const LogPanel: React.FC<Props> = ({ logs }) => {
 
   if (!logs.length)
     return (
-      <div data-testid="logs-skeleton" className="space-y-2">
+      <div data-testid="logs-skeleton" className="stack">
         <Skeleton className="h-4 w-3/4" />
         <Skeleton className="h-4 w-2/3" />
         <Skeleton className="h-4 w-1/2" />

--- a/frontend/src/components/SourcesPanel.tsx
+++ b/frontend/src/components/SourcesPanel.tsx
@@ -14,13 +14,13 @@ interface Props {
 const SourcesPanel: React.FC<Props> = ({ sources }) => {
   if (!sources.length)
     return (
-      <div data-testid="sources-skeleton" className="space-y-2">
+      <div data-testid="sources-skeleton" className="stack">
         <Skeleton className="h-4 w-2/3" />
         <Skeleton className="h-4 w-1/3" />
       </div>
     );
   return (
-    <ul className="space-y-2">
+    <ul className="stack">
       {sources.map((s, idx) => {
         const url = typeof s === "string" ? s : s.url;
         const title = typeof s === "string" ? s : (s.title ?? s.url);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,21 @@
 @import "@primer/css/dist/primer.css";
 
+:root {
+  --space-1: var(--base-size-4); /* 4px */
+  --space-2: var(--base-size-8); /* 8px */
+  --space-3: var(--base-size-12); /* 12px */
+  --space-4: var(--base-size-16); /* 16px */
+}
+
+.stack > * + * {
+  margin-top: var(--space-3);
+}
+
+.grid {
+  display: grid;
+  gap: var(--space-4);
+}
+
 body {
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif,


### PR DESCRIPTION
## Summary
- add small spacing scale and layout utilities to `index.css`
- replace Tailwind `space-y-2` with semantic `.stack`

## Testing
- `npx prettier frontend/src/index.css frontend/src/components/DocumentPanel.tsx frontend/src/components/SourcesPanel.tsx frontend/src/components/LogPanel.tsx --write`
- `npm run lint`
- `npm run lint:css`
- `npm test`
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/ && echo "flake8 passed"`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLCertVerificationError)*
- `poetry run pytest` *(fails: ModuleNotFoundError: jwt, fastapi, pydantic, etc.)`
- `poetry install` *(fails: unable to connect to pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_6899dea54088832bb286017273174b4f