### PR TITLE
style: apply GitHub-style tables

### DIFF
--- a/frontend/src/components/DataEntryForm.tsx
+++ b/frontend/src/components/DataEntryForm.tsx
@@ -85,16 +85,16 @@ const DataEntryForm: React.FC = () => {
         </button>
       </form>
       {entries.length > 0 && (
-        <table className="width-full border-collapse">
+        <table>
           <thead>
             <tr>
-              <th className="border color-bg-subtle p-2 text-left">Topic</th>
+              <th>Topic</th>
             </tr>
           </thead>
           <tbody>
             {entries.map((e) => (
               <tr key={e.id}>
-                <td className="border p-2">{e.topic}</td>
+                <td>{e.topic}</td>
               </tr>
             ))}
           </tbody>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -23,3 +23,19 @@ body {
   border-radius: 12px;
   padding: 1.5rem;
 }
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  padding: 8px 12px;
+  border-top: var(--borderWidth-thin) solid var(--borderColor-muted);
+}
+
+thead th {
+  background: var(--color-canvas-subtle);
+  text-align: left;
+}


### PR DESCRIPTION
## Summary
- style tables like GitHub with minimal CSS
- remove Tailwind table classes from DataEntryForm

## Testing
- `npm run lint`
- `npm run lint:css`
- `npm run typecheck`
- `npm test`
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/` (B008 error)
- `poetry run mypy src/ tests/` (missing named argument errors)
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` (SSL error)

------
https://chatgpt.com/codex/tasks/task_e_6899dec16210832ba1e41ac36e17061f