### PR TITLE
feat: switch theme toggle to Octicons

### DIFF
--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Moon, Sun, Monitor } from "lucide-react";
+import { SunIcon, MoonIcon, DeviceDesktopIcon } from "@primer/octicons-react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -59,9 +59,9 @@ const ThemeToggle: React.FC = () => {
           aria-pressed={resolved === "dark"}
         >
           {resolved === "dark" ? (
-            <Sun className="h-4 w-4" />
+            <SunIcon className="h-4 w-4" />
           ) : (
-            <Moon className="h-4 w-4" />
+            <MoonIcon className="h-4 w-4" />
           )}
           <span className="sr-only">Toggle theme</span>
         </Button>
@@ -77,19 +77,19 @@ const ThemeToggle: React.FC = () => {
             value="light"
             className="flex items-center gap-2"
           >
-            <Sun className="h-4 w-4" /> Light
+            <SunIcon className="h-4 w-4" /> Light
           </DropdownMenuRadioItem>
           <DropdownMenuRadioItem
             value="dark"
             className="flex items-center gap-2"
           >
-            <Moon className="h-4 w-4" /> Dark
+            <MoonIcon className="h-4 w-4" /> Dark
           </DropdownMenuRadioItem>
           <DropdownMenuRadioItem
             value="system"
             className="flex items-center gap-2"
           >
-            <Monitor className="h-4 w-4" /> System
+            <DeviceDesktopIcon className="h-4 w-4" /> System
           </DropdownMenuRadioItem>
         </DropdownMenuRadioGroup>
       </DropdownMenuContent>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "dependencies": {
         "@opentelemetry/instrumentation-fetch": "^0.203.0",
         "@primer/css": "^22.0.2",
+        "@primer/octicons-react": "^19.15.5",
         "@pydantic/logfire-browser": "^0.9.0",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-scroll-area": "^1.2.9",
@@ -1714,6 +1715,18 @@
       },
       "peerDependencies": {
         "@primer/primitives": "10.x || 11.x"
+      }
+    },
+    "node_modules/@primer/octicons-react": {
+      "version": "19.15.5",
+      "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-19.15.5.tgz",
+      "integrity": "sha512-JEoxBVkd6F8MaKEO1QKau0Nnk3IVroYn7uXGgMqZawcLQmLljfzua3S1fs2FQs295SYM9I6DlkESgz5ORq5yHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "react": ">=16.3"
       }
     },
     "node_modules/@primer/primitives": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@opentelemetry/instrumentation-fetch": "^0.203.0",
     "@primer/css": "^22.0.2",
+    "@primer/octicons-react": "^19.15.5",
     "@pydantic/logfire-browser": "^0.9.0",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-scroll-area": "^1.2.9",

--- a/src/web/routes/stream.py
+++ b/src/web/routes/stream.py
@@ -60,7 +60,7 @@ def verify_stream_token(request: Request) -> Dict[str, Any]:
 
 @router.get("/stream/token")
 async def issue_stream_token(
-    request: Request, payload: Dict[str, Any] = Depends(verify_jwt)
+    request: Request, payload: Dict[str, Any] = Depends(verify_jwt)  # noqa: B008
 ) -> Dict[str, str]:
     """Return a short-lived JWT for authenticating SSE connections."""
 


### PR DESCRIPTION
## Summary
- use Octicons for light, dark, and system theme icons
- add `@primer/octicons-react` dependency
- silence flake8 B008 warning in stream token route

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type src/web/routes/stream.py`
- `poetry run black --preview --enable-unstable-feature string_processing src/web/routes/stream.py`
- `poetry run ruff check src/web/routes/stream.py`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `npm run lint`
- `npm run lint:css`
- `npm test`
- `npm run typecheck`
- `poetry run pip-audit` *(fails: CERTIFICATE_VERIFY_FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_6899ded1de14832bbb59d41fa9716b8e