### PR TITLE
Handle invalid source URLs in SourcesPanel

### DIFF
--- a/frontend/src/components/SourcesPanel.tsx
+++ b/frontend/src/components/SourcesPanel.tsx
@@ -24,7 +24,13 @@ const SourcesPanel: React.FC<Props> = ({ sources }) => {
       {sources.map((s, idx) => {
         const url = typeof s === "string" ? s : s.url;
         const title = typeof s === "string" ? s : (s.title ?? s.url);
-        const host = url ? new URL(url).host : "";
+        // Parse the hostname safely in case an invalid URL is provided.
+        let host = "";
+        try {
+          host = url ? new URL(url).host : "";
+        } catch {
+          // ignore malformed URLs
+        }
         return (
           <li key={idx} className="text-sm">
             <a

--- a/tests/sourcesPanel.test.tsx
+++ b/tests/sourcesPanel.test.tsx
@@ -14,4 +14,11 @@ describe("SourcesPanel", () => {
     expect(screen.queryByTestId("sources-skeleton")).toBeNull();
     expect(screen.getByText("https://example.com")).toBeInTheDocument();
   });
+
+  it("ignores invalid source URLs", () => {
+    const sources = ["not a url"];
+    render(<SourcesPanel sources={sources} />);
+    expect(screen.getByText("not a url")).toBeInTheDocument();
+    expect(screen.queryByText(/—/)).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- parse SourcePanel links with try/catch to safely extract hostnames
- add regression test for invalid source URLs

## Testing
- `npx prettier frontend/src/components/SourcesPanel.tsx tests/sourcesPanel.test.tsx -w`
- `npm run lint`
- `npm test`
- `npm run typecheck`
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLCertVerificationError)*

------
https://chatgpt.com/codex/tasks/task_e_6899df0ce80c832b8d3fc7d82d367a15