### PR TITLE
fix: ensure frontend mounts without app state

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -949,8 +949,8 @@ def from_schema(weave: WeaveResult) -> str:
   - Initialize the custom orchestrator and checkpointing module.
   - Store orchestrator instance on `app.state.orchestrator` for endpoint handlers.
 
-- **`mount_frontend(app)`**
-  - Serve the React build directory (`/frontend/dist`) at the root path.
+- **`mount_frontend(app, settings)`**
+  - Serve the React build directory (`/frontend/dist`) at the root path using the provided settings instance.
 
 - **`register_routes(app)`**
   - Include routers from:

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -77,7 +77,7 @@ def create_app() -> FastAPI:
     )
 
     register_routes(app)
-    mount_frontend(app)
+    mount_frontend(app, app_settings.settings)
     return app
 
 
@@ -101,10 +101,19 @@ def setup_graph(app: FastAPI) -> None:
     app.state.graph = graph_orchestrator
 
 
-def mount_frontend(app: FastAPI) -> None:
-    """Serve built frontend assets and provide history-fallback routing."""
+def mount_frontend(app: FastAPI, settings: Settings | None = None) -> None:
+    """Serve built frontend assets and provide history-fallback routing.
 
-    settings: Settings = app.state.settings
+    Parameters
+    ----------
+    app:
+        FastAPI application instance to mount the frontend on.
+    settings:
+        Optional settings instance. When ``None``, the function attempts to
+        retrieve settings from ``app.state`` and falls back to global settings.
+    """
+
+    settings = settings or getattr(app.state, "settings", app_settings.settings)
     dist = Path(settings.frontend_dist)
     if not dist.exists():
 


### PR DESCRIPTION
## Summary
- allow mounting frontend before lifecycle sets `app.state.settings`
- document `mount_frontend` parameter requirement

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLError: HTTPSConnectionPool(host='pypi.org', port=443) ...)*
- `poetry run pytest tests/test_spa_fallback.py::test_history_fallback_serves_index -q` *(fails: ModuleNotFoundError: No module named 'opentelemetry.exporter')*

------
https://chatgpt.com/codex/tasks/task_e_6899e79b7eb0832b9def2adf331161da