### PR TITLE
style: align downloads panel with GitHub design

### DIFF
--- a/frontend/src/components/DownloadsPanel.tsx
+++ b/frontend/src/components/DownloadsPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { toast } from "sonner";
 import exportClient, { ExportUrls } from "../api/exportClient";
-import {Box, Link} from '@primer/react'
+import { Box, Link, Spinner, Text } from "@primer/react";
 
 interface Props {
   workspaceId: string;
@@ -40,17 +40,23 @@ const DownloadsPanel: React.FC<Props> = ({ workspaceId }) => {
   }, [workspaceId]);
 
   if (!urls) {
-    return <div className="text-sm text-gray-500">Preparing export…</div>;
+    return (
+      <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
+        <Spinner size="small" />
+        <Text sx={{ color: "fg.muted", fontSize: 1 }}>Preparing export…</Text>
+      </Box>
+    );
   }
 
   return (
-    <>
-<Box sx={{display: 'flex', gap: 3}}>
-  <Link href={urls.pdf} download>PDF</Link>
-  <Link href={urls.md} download>Markdown</Link>
-</Box>
-
-    </>
+    <Box sx={{ display: "flex", gap: 3 }}>
+      <Link href={urls.pdf} download>
+        PDF
+      </Link>
+      <Link href={urls.md} download>
+        Markdown
+      </Link>
+    </Box>
   );
 };
 


### PR DESCRIPTION
## Summary
- use Primer Spinner and Text in downloads panel for loading state

## Testing
- `npm run lint`
- `npm test`
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/` *(fails: Command not found)*
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll` *(fails: Command not found)*
- `poetry run pip-audit` *(fails: Command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a012d4d70832b8e22c24c42f11668