### PR TITLE
chore: tidy npm dependencies and run style check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@primer/react": "^37.30.0",
         "@pydantic/logfire-browser": "^0.9.0",
         "@tanstack/react-virtual": "^3.13.12",
-        "clsx": "^2.1.1",
         "diff-match-patch": "^1.0.5",
         "github-markdown-css": "^5.8.1",
         "postcss": "^8.5.6",
@@ -25,6 +24,7 @@
         "sonner": "^2.0.7"
       },
       "devDependencies": {
+        "@eslint/js": "^9.33.0",
         "@testing-library/jest-dom": "^6.6.4",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "eslint \"frontend/src/**/*.{ts,tsx}\""
   },
   "devDependencies": {
+    "@eslint/js": "^9.33.0",
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
@@ -46,7 +47,6 @@
     "@primer/react": "^37.30.0",
     "@pydantic/logfire-browser": "^0.9.0",
     "@tanstack/react-virtual": "^3.13.12",
-    "clsx": "^2.1.1",
     "diff-match-patch": "^1.0.5",
     "github-markdown-css": "^5.8.1",
     "postcss": "^8.5.6",


### PR DESCRIPTION
## Summary
- remove unused clsx dependency
- add missing @eslint/js for lint config
- run stylelint to ensure css passes

## Testing
- `npx depcheck`
- `npm run lint`
- `npm run lint:css`
- `npm test`
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/` *(fails: Command not found)*
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLCertVerificationError)*
- `poetry run pytest` *(fails: 26 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689a51297d18832b956adb08c09704df