### PR TITLE
fix: expose frontend build path in settings

### DIFF
--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -38,7 +38,7 @@ class Settings(BaseSettings):
     ENABLE_TRACING: bool = Field(
         True, description="Enable application performance tracing and metrics"
     )
-    FRONTEND_DIST: str = Field(
+    frontend_dist: str = Field(
         "frontend/dist", description="Path to the built frontend assets"
     )
 


### PR DESCRIPTION
## Summary
- expose `frontend_dist` in core settings so FastAPI can locate built frontend assets

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSL certificate verify failed)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'jwt', 'aiosqlite', 'fastapi', 'pydantic', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689aa65321bc832bb839fced71bf90c8