### PR TITLE
feat: enforce source context and timing in content weaver

### DIFF
--- a/src/agents/content_weaver.py
+++ b/src/agents/content_weaver.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import AsyncGenerator
+from typing import AsyncGenerator, Sequence
 
 from pydantic import ValidationError
 
-from core.state import Module, State
+from core.state import Citation, Module, State
 from prompts import get_prompt
 
 from .models import WeaveResult
@@ -19,8 +19,15 @@ class RetryableError(RuntimeError):
     """Signal that the operation can be retried."""
 
 
-async def call_openai_function(prompt: str) -> AsyncGenerator[str, None]:
-    """Invoke an LLM via Pydantic AI and yield streamed tokens."""
+async def call_openai_function(
+    prompt: str, sources: Sequence[Citation] | None = None
+) -> AsyncGenerator[str, None]:
+    """Invoke an LLM via Pydantic AI and yield streamed tokens.
+
+    Args:
+        prompt: Prompt passed to the agent.
+        sources: Optional citation metadata to provide additional context.
+    """
 
     try:
         from pydantic_ai import Agent
@@ -45,10 +52,29 @@ async def call_openai_function(prompt: str) -> AsyncGenerator[str, None]:
         return empty()
 
     schema = json.dumps(WeaveResult.model_json_schema(), indent=2)
-    instructions = [
-        get_prompt("content_weaver_system"),
-        f"Output must conform to this JSON schema:\n{schema}",
-    ]
+    instructions: list[str] = []
+    if sources:
+        lines = []
+        for src in sources:
+            if src.title and src.licence and src.retrieved_at:
+                lines.append(
+                    f"- {src.title} ({src.url}) – {src.licence} retrieved"
+                    f" {src.retrieved_at}"
+                )
+        if lines:
+            context = "\n".join(lines)
+            instructions.append(
+                "Use only the following sources. If a claim is not supported here, "
+                "write it cautiously and avoid definitive language.\n"
+                + context
+            )
+    instructions.extend(
+        [
+            get_prompt("content_weaver_system"),
+            "Ensure the total duration equals the sum of activity durations.",
+            f"Output must conform to this JSON schema:\n{schema}",
+        ]
+    )
     agent = Agent(model=model, instructions=instructions)
 
     async def generator() -> AsyncGenerator[str, None]:
@@ -70,24 +96,36 @@ async def content_weaver(state: State, section_id: int | None = None) -> WeaveRe
             is used.
     """
 
-    tokens: list[str] = []
-
     prompt = state.prompt
     if section_id is not None and state.outline:
         if section_id < 0 or section_id >= len(state.outline.steps):
             raise IndexError("section_id out of range")
         prompt = state.outline.steps[section_id]
 
-    stream = await call_openai_function(prompt)
-    async for token in stream:
-        tokens.append(token)
-        stream_messages(token)
-    raw = "".join(tokens)
-    try:
-        return WeaveResult.model_validate_json(raw)
-    except ValidationError as exc:  # pragma: no cover - defensive
-        stream_debug(str(exc))
-        raise RetryableError("model returned invalid schema") from exc
+    base_prompt = prompt
+    for attempt in range(2):
+        tokens: list[str] = []
+        stream = await call_openai_function(prompt, state.sources)
+        async for token in stream:
+            tokens.append(token)
+            stream_messages(token)
+        raw = "".join(tokens)
+        try:
+            weave = WeaveResult.model_validate_json(raw)
+        except ValidationError as exc:  # pragma: no cover - defensive
+            stream_debug(str(exc))
+            raise RetryableError("model returned invalid schema") from exc
+
+        total = sum(act.duration_min for act in weave.activities)
+        if total == weave.duration_min:
+            return weave
+        prompt = (
+            f"{base_prompt}\n"
+            "Durations of activities must sum to the overall duration. "
+            f"Activities total {total} but duration_min is {weave.duration_min}."
+        )
+
+    raise RetryableError("duration mismatch after retry")
 
 
 async def run_content_weaver(state: State, section_id: int | None = None) -> Module:

--- a/src/core/state.py
+++ b/src/core/state.py
@@ -18,9 +18,15 @@ class Citation(BaseModel):
 
     Attributes:
         url: Location of the referenced material.
+        title: Human readable name for the source.
+        licence: Usage licence for the material.
+        retrieved_at: ISO8601 timestamp when the source was accessed.
     """
 
     url: HttpUrl
+    title: str | None = None
+    licence: str | None = None
+    retrieved_at: str | None = None
 
 
 class Module(BaseModel):


### PR DESCRIPTION
## Summary
- extend state citations with title, licence, and retrieved_at metadata
- feed citation context into content weaver and instruct model to respect it
- validate activity durations against total time with retry loop

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /pypi/bandit/1.8.6/json (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)')))*)
- `pytest` *(fails: ModuleNotFoundError: No module named 'jwt'; ModuleNotFoundError: No module named 'aiosqlite'; ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_689aaaebf660832b9a9ddd9d645bc6ab