### PR TITLE
Fix logfire loguru handler integration

### DIFF
--- a/src/observability.py
+++ b/src/observability.py
@@ -65,7 +65,7 @@ def init_observability() -> None:
     root_logger.addHandler(logfire.LogfireLoggingHandler())
 
     loguru_logger.remove()
-    loguru_logger.add(logfire.loguru_handler())
+    loguru_logger.add(**logfire.loguru_handler())
 
     logfire.instrument_pydantic()
     logfire.instrument_httpx()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,7 +95,13 @@ class LogfireLoggingHandler:  # pragma: no cover - simple placeholder
 
 
 logfire_stub.LogfireLoggingHandler = LogfireLoggingHandler  # type: ignore[attr-defined]
-logfire_stub.loguru_handler = LogfireLoggingHandler  # type: ignore[attr-defined]
+
+
+def _loguru_handler():  # pragma: no cover - simple placeholder
+    return {"sink": LogfireLoggingHandler()}
+
+
+logfire_stub.loguru_handler = _loguru_handler  # type: ignore[attr-defined]
 sys.modules.setdefault("logfire", logfire_stub)
 
 # Minimal loguru replacement

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -46,7 +46,7 @@ def test_init_observability_enabled(monkeypatch):
         "instrument_system_metrics",
     ]:
         monkeypatch.setattr(logfire, name, lambda *a, **k: None)
-    monkeypatch.setattr(logfire, "loguru_handler", lambda: None)
+    monkeypatch.setattr(logfire, "loguru_handler", lambda: {"sink": None})
     monkeypatch.setattr(loguru_logger, "add", lambda *a, **k: None)
     init_observability()
     assert called is True
@@ -66,7 +66,7 @@ def test_loguru_and_logfire_handlers_aligned(monkeypatch):
     ]:
         monkeypatch.setattr(logfire, name, lambda *a, **k: None)
     monkeypatch.setattr(logfire, "configure", lambda *a, **k: None)
-    monkeypatch.setattr(logfire, "loguru_handler", lambda: None)
+    monkeypatch.setattr(logfire, "loguru_handler", lambda: {"sink": None})
 
     removed = []
     added = []


### PR DESCRIPTION
## Summary
- fix loguru logging by expanding `logfire.loguru_handler()` args
- align tests with new logfire loguru handler API

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: [SSL: CERTIFICATE_VERIFY_FAILED])* 
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'jwt', 'pydantic', 'fastapi', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689ac7bcd340832ba651d9821ed9e307