### PR TITLE
Silence mypy error for Settings initialization

### DIFF
--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -49,7 +49,12 @@ class Settings(BaseSettings):
 
 
 # Eagerly validate configuration on import for early failure.
-settings = Settings()
+#
+# Pydantic's ``BaseSettings`` pulls required configuration from environment
+# variables at runtime. Mypy cannot determine that these values will be
+# provided, so we ignore the missing argument error when instantiating the
+# settings object.
+settings = Settings()  # type: ignore[call-arg]
 
 
 __all__ = ["Settings", "settings"]


### PR DESCRIPTION
## Summary
- ignore missing env var arguments when instantiating `Settings`

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(failed: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /pypi/bandit/1.8.6/json (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)'))))*
- `poetry run pytest` *(errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689b1f5a403c832bacbe2284e3e00f35