### PR TITLE
Disable bloom classification retries

### DIFF
--- a/src/agents/pedagogy_critic.py
+++ b/src/agents/pedagogy_critic.py
@@ -96,6 +96,7 @@ async def classify_bloom_level(text: str) -> str:
             model=model,
             output_type=BloomResult,  # return structured BloomResult from LLM
             instructions=instructions,
+            retries=0,  # attempt the model call once to avoid retry loops
         )
         result = await agent.run(text)
         level = result.output.level.strip().lower()


### PR DESCRIPTION
## Summary
- disable internal retries when classifying Bloom levels to prevent repeated OpenAI calls

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: certificate verify failed)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'jwt')*


------
https://chatgpt.com/codex/tasks/task_e_689d565fca58832b98b67573534b8ced