### PR TITLE
feat: support portfolio loops in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ been replaced by Logfire's settings.
 - **Performance tests**: `k6` scripts in `performance/`
 - **Benchmarks**: `scripts/benchmark_pipeline.py` compares the current
   pipeline against the previous implementation to surface regressions.
-- **CLI run output**: `./scripts/cli.sh "<topic>"` writes the generated lecture in Markdown to `run_output.md`.
+- **CLI run output**: `./scripts/cli.sh "<topic>" [--portfolio <portfolio> ...]` writes the generated lecture in Markdown to `run_output_<portfolio>.md` for each portfolio.
 - **Accessibility**: Lighthouse and axe-core audits configured in CI pipeline.
 
 ---

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -17,12 +17,12 @@ Command-line shortcuts for running the application, executing tests, and handlin
 - **Generate lecture material**
 
   ```bash
-  ./scripts/cli.sh [--verbose] "<topic>"
+  ./scripts/cli.sh [--verbose] "<topic>" [--portfolio <portfolio> ...]
   ```
 
-  Produces a structured lecture in Markdown for the topic and saves it to `run_output.md`.
-  `--verbose` shows progress logs. Use `--output` to specify a different
-  Markdown file.
+  Produces a structured lecture for the topic across one or more portfolios and
+  saves each to `run_output_<portfolio>.md`. `--verbose` shows progress logs.
+  Use `--output` to specify a different base Markdown file.
 
 ## Testing
 

--- a/scripts/cli.sh
+++ b/scripts/cli.sh
@@ -2,12 +2,12 @@
 # Starts the CLI application locally without Docker.
 #
 # Usage:
-#   ./scripts/cli.sh [--verbose] <topic>
+#   ./scripts/cli.sh [--verbose] <topic> [--portfolio <portfolio> ...]
 #
 # The script will:
 #   1. Source environment variables from .env
 #   2. Apply database migrations via Alembic
-#   3. Launch the CLI instance (forwarding any flags like --verbose)
+#   3. Launch the CLI instance (forwarding any flags like --verbose and --portfolio)
 
 set -euo pipefail
 

--- a/src/cli/generate_lecture.py
+++ b/src/cli/generate_lecture.py
@@ -15,6 +15,20 @@ from agents.models import Activity, Citation, WeaveResult
 from agents.streaming import stream_messages
 from export.markdown import from_weave_result
 
+PORTFOLIOS_ALL = [
+    "Research & Innovation",
+    "Education",
+    "STEM",
+    "Design & Social Context",
+    "Business & Law",
+    "Vocational Education",
+]
+
+
+def slugify(text: str) -> str:
+    """Create a filesystem-friendly slug from ``text``."""
+    return text.lower().replace("&", "and").replace("/", " ").replace(" ", "_")
+
 
 def parse_args() -> argparse.Namespace:
     """Parse command-line arguments."""
@@ -34,7 +48,16 @@ def parse_args() -> argparse.Namespace:
         default=Path("run_output.md"),
         help="Path to the output markdown file",
     )
-    return parser.parse_args()
+    parser.add_argument(
+        "--portfolio",
+        dest="portfolios",
+        action="append",
+        help="Portfolio to target. May be used multiple times.",
+    )
+    args = parser.parse_args()
+    if not args.portfolios:
+        args.portfolios = PORTFOLIOS_ALL
+    return args
 
 
 async def _generate(topic: str) -> Dict[str, Any]:
@@ -87,15 +110,20 @@ def main() -> None:
     init_observability()
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
-        stream_messages("LLM response stream start")
-    try:
-        payload = asyncio.run(_generate(args.topic))
-    except Exception as exc:  # pragma: no cover - defensive
-        raise SystemExit(f"Error generating lecture: {exc}") from exc
-    if args.verbose:
-        stream_messages("LLM response stream complete: %s" % json.dumps(payload))
-    print(json.dumps(payload, indent=2))
-    save_markdown(args.output, args.topic, payload)
+    for portfolio in args.portfolios:
+        topic = f"{args.topic} for {portfolio}"
+        if args.verbose:
+            stream_messages("LLM response stream start")
+        try:
+            payload = asyncio.run(_generate(topic))
+        except Exception as exc:  # pragma: no cover - defensive
+            raise SystemExit(f"Error generating lecture: {exc}") from exc
+        if args.verbose:
+            stream_messages("LLM response stream complete: %s" % json.dumps(payload))
+        print(json.dumps(payload, indent=2))
+        output_name = f"{args.output.stem}_{slugify(portfolio)}{args.output.suffix}"
+        output_path = args.output.parent / output_name
+        save_markdown(output_path, topic, payload)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_logging.py
+++ b/tests/test_cli_logging.py
@@ -22,7 +22,12 @@ def test_main_logs_stream_boundaries(monkeypatch, caplog, tmp_path):
         return {"result": "ok"}
 
     def fake_parse_args():
-        return SimpleNamespace(topic="demo", verbose=True, output=tmp_path / "out.md")
+        return SimpleNamespace(
+            topic="demo",
+            verbose=True,
+            output=tmp_path / "out.md",
+            portfolios=["Education"],
+        )
 
     monkeypatch.setattr(generate_lecture, "_generate", fake_generate)
     monkeypatch.setattr(generate_lecture, "parse_args", fake_parse_args)

--- a/tests/test_generate_lecture.py
+++ b/tests/test_generate_lecture.py
@@ -34,11 +34,24 @@ def test_parse_args_verbose(monkeypatch):
 
     from cli.generate_lecture import parse_args
 
-    monkeypatch.setattr(sys, "argv", ["prog", "topic", "--verbose"])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "prog",
+            "topic",
+            "--verbose",
+            "--portfolio",
+            "STEM",
+            "--portfolio",
+            "Education",
+        ],
+    )
     args = parse_args()
     assert args.verbose is True
     assert args.topic == "topic"
     assert args.output.name == "run_output.md"
+    assert args.portfolios == ["STEM", "Education"]
 
 
 def test_main_writes_output(monkeypatch, tmp_path):
@@ -57,7 +70,10 @@ def test_main_writes_output(monkeypatch, tmp_path):
 
     def fake_parse_args() -> types.SimpleNamespace:
         return types.SimpleNamespace(
-            topic="demo", verbose=False, output=tmp_path / "out.md"
+            topic="demo",
+            verbose=False,
+            output=tmp_path / "out.md",
+            portfolios=["Research & Innovation"],
         )
 
     from cli import generate_lecture
@@ -65,8 +81,11 @@ def test_main_writes_output(monkeypatch, tmp_path):
     monkeypatch.setattr(generate_lecture, "_generate", fake_generate)
     monkeypatch.setattr(generate_lecture, "parse_args", fake_parse_args)
 
+    from cli.generate_lecture import slugify
+
     generate_lecture.main()
-    content = (tmp_path / "out.md").read_text()
+    out_file = tmp_path / f"out_{slugify('Research & Innovation')}.md"
+    content = out_file.read_text()
     assert "demo" in content
 
 


### PR DESCRIPTION
## Summary
- allow specifying multiple portfolios when generating lecture material
- iterate over portfolios to create output files per portfolio
- document portfolio usage in CLI docs and scripts

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSL certificate verify failed)*
- `poetry run pytest tests/test_generate_lecture.py tests/test_cli_logging.py` *(fails: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_689d59010e58832ba6c57ceae1983fbe