### PR TITLE
feat: add pithy progress logging with topic

### DIFF
--- a/src/core/orchestrator.py
+++ b/src/core/orchestrator.py
@@ -135,6 +135,18 @@ class Node:
     condition: Optional[Callable[[Any, State], Optional[str]]] = None
 
 
+# Human-friendly progress strings keyed by node name
+PROGRESS_MESSAGES: Dict[str, str] = {
+    "Planner": "Sketching the roadmap for {topic}",
+    "Researcher-Web": "Scouting resources on {topic}",
+    "Content-Weaver": "Weaving content from different sources for {topic}",
+    "Pedagogy-Critic": "Assessing learning outcomes for {topic}",
+    "Fact-Checker": "Verifying facts about {topic}",
+    "Human-In-Loop": "Inviting human insight on {topic}",
+    "Exporter": "Packaging the final lecture on {topic}",
+}
+
+
 def build_main_flow() -> List[Node]:
     """Return the ordered list of nodes forming the primary pipeline."""
 
@@ -224,7 +236,13 @@ class GraphOrchestrator:
 
         current = self.flow[0]
         workspace = getattr(state, "workspace_id", "default")
+        topic = getattr(state, "prompt", "")
         while current:
+            message_tpl = PROGRESS_MESSAGES.get(current.name)
+            if message_tpl:
+                text = message_tpl.format(topic=topic)
+                logger.info(text)
+                publish(f"{workspace}:messages", text)
             publish(f"{workspace}:action", current.name)
             yield {"type": "action", "payload": current.name}
             try:

--- a/tests/test_progress_logging.py
+++ b/tests/test_progress_logging.py
@@ -1,0 +1,24 @@
+import logging
+
+import pytest
+
+from core.orchestrator import GraphOrchestrator, Node
+from core.state import State
+
+
+@pytest.mark.asyncio
+async def test_stream_logs_pithy_messages(caplog):
+    async def noop(_state: State) -> None:
+        return None
+
+    flow = [
+        Node("Content-Weaver", noop, "Pedagogy-Critic"),
+        Node("Pedagogy-Critic", noop, None),
+    ]
+    orch = GraphOrchestrator(flow)
+    state = State(prompt="Photosynthesis")
+    with caplog.at_level(logging.INFO):
+        async for _ in orch.stream(state):
+            pass
+    assert "Weaving content from different sources for Photosynthesis" in caplog.text
+    assert "Assessing learning outcomes for Photosynthesis" in caplog.text


### PR DESCRIPTION
## Summary
- log engaging progress messages with the topic for each orchestrator node
- cover progress logging with a focused unit test

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLError: certificate verify failed)*
- `poetry run pytest` *(fails: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689d5cdb34d8832ba072f1bd7f75bb01