### PR TITLE
Log stream messages for CLI visibility

### DIFF
--- a/src/agents/streaming.py
+++ b/src/agents/streaming.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections import defaultdict
 from collections.abc import AsyncIterator
 from typing import Any, Callable, DefaultDict, List
@@ -63,15 +64,27 @@ async def subscribe(channel: str, *, max_queue: int = 100) -> AsyncIterator[Any]
 
 
 def stream_messages(token: str) -> None:
-    """Forward ``token`` over the ``messages`` channel."""
+    """Forward ``token`` over the ``messages`` channel and log it."""
 
-    stream("messages", token)
+    stream("messages", token, fallback=_log_message)
 
 
 def stream_debug(message: str) -> None:
-    """Forward ``message`` over the ``debug`` channel."""
+    """Forward ``message`` over the ``debug`` channel and log it."""
 
-    stream("debug", message)
+    stream("debug", message, fallback=_log_debug)
+
+
+def _log_message(_channel: str, payload: Any) -> None:
+    """Emit ``payload`` to the logger as a ``messages`` event."""
+
+    logging.getLogger(__name__).info("[messages] %s", payload)
+
+
+def _log_debug(_channel: str, payload: Any) -> None:
+    """Emit ``payload`` to the logger as a ``debug`` event."""
+
+    logging.getLogger(__name__).debug("[debug] %s", payload)
 
 
 __all__ = ["stream", "subscribe", "stream_messages", "stream_debug"]

--- a/src/core/orchestrator.py
+++ b/src/core/orchestrator.py
@@ -26,10 +26,7 @@ from agents.planner import run_planner
 from agents.researcher_web_node import run_researcher_web
 from agents.streaming import stream as publish
 from core.logging import get_logger
-from core.policies import (
-    policy_retry_on_critic_failure,
-    policy_retry_on_low_confidence,
-)
+from core.policies import policy_retry_on_low_confidence
 from core.state import State
 from metrics.collector import MetricsCollector
 from metrics.repository import MetricsRepository

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -23,6 +23,15 @@ def test_stream_uses_fallback(caplog):
     assert "[messages] hi" in caplog.text
 
 
+def test_stream_messages_logs(caplog):
+    """``stream_messages`` should log tokens for CLI visibility."""
+
+    with caplog.at_level(logging.INFO, logger="agents.streaming"):
+        streaming.stream_messages("hello")
+
+    assert "[messages] hello" in caplog.text
+
+
 @pytest.mark.asyncio
 async def test_stream_broadcasts_to_subscribers() -> None:
     async def reader():


### PR DESCRIPTION
## Summary
- log `stream_messages` and `stream_debug` events to provide CLI feedback
- test that `stream_messages` writes to logger
- remove unused policy import from orchestrator

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: CERTIFICATE_VERIFY_FAILED)*
- `poetry run pytest` *(fails: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689d62d44e60832ba2c67124d5a83a70