### PR TITLE
Ensure CLI runs with workspace database

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,19 @@ alembic revision --autogenerate -m "add new table"
 The command reads `alembic.ini` and writes migration scripts to
 `migrations/versions/`.
 
+### Command-line Lecture Generation
+
+Run the CLI to generate lecture material while persisting state to the
+workspace database. Each invocation creates a new workspace identified by a
+slug of the topic and timestamp:
+
+```bash
+poetry run python -m cli.generate_lecture "Intro to Quantum"
+```
+
+The resulting workspace data is stored in `DATA_DIR/workspace.db` and exports
+are written alongside the generated Markdown file.
+
 ---
 
 ## Configuration & Environment Variables


### PR DESCRIPTION
## Summary
- create workspace IDs for CLI runs and initialize the persistence database
- document command-line lecture generation and workspace persistence
- update tests for database-backed CLI workflow

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/ tests/`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: Missing Authority Key Identifier SSL error)*
- `poetry run pytest tests/test_generate_lecture.py`


------
https://chatgpt.com/codex/tasks/task_e_689d78258850832ba038b694a25219b4